### PR TITLE
feat(build_cache): concurrent cache build via build_concurrency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,7 +1191,6 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-function-vep"
 version = "0.8.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=34f4355af1fe5954f156b588a691c305740c386b#34f4355af1fe5954f156b588a691c305740c386b"
 dependencies = [
  "ahash",
  "arrow-ipc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,10 @@ serde_json = "1"
 datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "34f4355af1fe5954f156b588a691c305740c386b", features = ["cache-builder"] }
 datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "9cfe804f405f421e41daa2a9cb6aedb7fd7504cf" }
 datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "9cfe804f405f421e41daa2a9cb6aedb7fd7504cf" }
+
+# Local-dev override: build against the in-tree datafusion-bio-functions checkout
+# (HEAD == pinned rev 34f4355) so cache-builder parallelization changes are picked
+# up without pushing. Its own ensembl-cache dep pins the same formats rev (9cfe804)
+# as above, so the dependency graph stays single-versioned. Revert before release.
+[patch."https://github.com/biodatageeks/datafusion-bio-functions.git"]
+datafusion-bio-function-vep = { path = "../datafusion-bio-functions/datafusion/bio-function-vep" }

--- a/benchmark-results/CACHE_BUILD_PARALLELIZATION_SUMMARY.md
+++ b/benchmark-results/CACHE_BUILD_PARALLELIZATION_SUMMARY.md
@@ -56,6 +56,32 @@ cores and RAM — that run belongs on the 64 GB / many-core target machine. On 1
 concurrent large-chromosome variation tiers approach the memory ceiling (chr1
 variation alone peaks ~8.7 GiB).
 
+## Tuning: LPT scheduling (#1) + weighted semaphore (#2)
+The nested per-entity concurrency was replaced by one flat work-unit scheduler:
+all (entity, chromosome) units are discovered, ordered longest-first (LPT), and
+run through one weighted semaphore. Two tunables on top of the chromosome axis:
+
+LPT (#1) — chr19-22, partitions=1, VEPYR_VAR_WEIGHT=1, vs the earlier scheduler
+without global ordering:
+| build_concurrency | no LPT | with LPT | gain |
+|---:|---:|---:|---:|
+| 2 | 649 s (1.61×) | 585 s (1.77×) | ~10% |
+| 4 | 491 s (2.13×) | 427 s (**2.43×**) | ~13% |
+| 8 | 421 s (2.49×) | 421 s (2.46×) | ~0% |
+LPT helps when permits < heavy units (mid concurrency): variation chromosomes
+start before light units instead of queueing behind them. At concurrency=8 there
+are enough permits that order is irrelevant. Output-neutral (32/32 files identical).
+
+Weighted semaphore (#2) — chr19-22, concurrency=8:
+| VEPYR_VAR_WEIGHT | seconds |
+|---:|---:|
+| 1 | 421 s |
+| 3 | 615 s |
+Weighting caps concurrent variation tiers; on data that fits RAM this is a
+slowdown (idle cores). It is a **memory-safety valve**, not a speedup: it lets a
+high build_concurrency be used without OOM where 4+ concurrent large-chromosome
+variation tiers would exceed RAM. Keep `VEPYR_VAR_WEIGHT=1` on the 64 GB target.
+
 ## Correctness
 Gate: at FIXED partitions, varying `build_concurrency` must not change output.
 - chr22, p=1, conc 1 vs 6 → 8/8 files logically identical.

--- a/benchmark-results/CACHE_BUILD_PARALLELIZATION_SUMMARY.md
+++ b/benchmark-results/CACHE_BUILD_PARALLELIZATION_SUMMARY.md
@@ -1,0 +1,85 @@
+# Cache-build parallelization — summary
+
+Goal: parallelize `vepyr.build_cache` on a single machine, preserving cache content
+(VEP parity), measured as a relative speedup on the same machine.
+
+Dev/measurement machine: MacBook Air M1, 16 GB RAM, 8 cores, low-power mode ON.
+(NOT the Ryzen 9 5950X / 64 GB from the presentation — absolute numbers are not
+comparable to it; only relative same-machine speedups are reported.)
+
+## What was built
+A single knob `build_concurrency` controls a global semaphore of concurrent
+(entity, chromosome) work-units. `build_concurrency=1` reproduces the original
+serial build path exactly (semaphore = 1), so baseline and parallel runs use the
+SAME binary — zero build/profile/machine variance.
+
+Two axes of concurrency:
+- **Entity axis** (Etap 1): the 6 cache entities (variation, transcript, exon,
+  translation, regulatory, motif) build concurrently (disjoint output dirs).
+- **Chromosome axis** (Etap 3): chromosomes within each entity build concurrently.
+  `build_variation` refactored into `build_variation_main_chrom` (per-chrom, own
+  context + temp dir) + `build_variation_other` (combined contigs, single unit);
+  `build_parquet_entity` / `build_translation` parallelize their chrom loops.
+  Runtime worker threads decoupled from DataFusion `partitions`.
+
+## Results (release build, partitions=1)
+
+Entity axis only — chr22 (1 chromosome):
+| build_concurrency | speedup |
+|---:|---:|
+| 1 | 1.00× |
+| 4 | 1.31× |
+Amdahl-limited: `variation` dominates and is a single unit, so only the 5 smaller
+entities overlap with it.
+
+Entity + chromosome axis — chr21+22 (2 chromosomes):
+| build_concurrency | speedup |
+|---:|---:|
+| 1 | 1.00× |
+| 2 | 1.77× |
+| 4 | 1.98× |
+| 8 | 1.97× |
+Plateaus at ~2× = number of chromosomes (2 heavy variation long-poles).
+
+Entity + chromosome axis — chr19+20+21+22 (4 chromosomes):
+| build_concurrency | seconds | speedup | peak RSS |
+|---:|---:|---:|---:|
+| 1 | 1047.3 | 1.00× | 10.6 GiB |
+| 2 | 649.1 | 1.61× | 8.9 GiB |
+| 4 | 491.1 | 2.13× | 10.6 GiB |
+| 8 | 421.0 | **2.49×** | 9.9 GiB |
+Still climbing at conc=8 (bounded by 8 cores + low-power + RAM).
+
+**Trend: speedup grows with chromosome count** (1 chrom ~1.3×, 2 chroms ~2.0×,
+4 chroms ~2.5×). The full genome (24 main chromosomes) scales further, bounded by
+cores and RAM — that run belongs on the 64 GB / many-core target machine. On 16 GB,
+concurrent large-chromosome variation tiers approach the memory ceiling (chr1
+variation alone peaks ~8.7 GiB).
+
+## Correctness
+Gate: at FIXED partitions, varying `build_concurrency` must not change output.
+- chr22, p=1, conc 1 vs 6 → 8/8 files logically identical.
+- chr21+22, p=1, conc 1 vs 4 → 16/16 files logically identical.
+Verified with `scripts/compare_cache.py` (order-independent multiset hash per parquet
+via polars `hash_rows`). Parallelization is output-neutral.
+
+## Pre-existing non-determinism (separate issue, NOT introduced here)
+At `partitions>1` the build is not reproducible run-to-run: two independent serial
+builds at partitions=4 differed in several files (same row counts, different content).
+Cause: multi-partition execution + unstable dedup tie-breaks (`ROW_NUMBER() ... ORDER
+BY stable_id NULLS LAST` for exon/transcript) and warm/cold split across partition
+boundaries. Predates this work; relevant if reproducible caches are required.
+
+## Tooling
+- `scripts/bench_cache_build.py` — sweep `build_concurrency`/`partitions`, fresh
+  subprocess per config, records runs.csv / runs.jsonl / summary.json / RESULTS.md.
+  Builds a chromosome-subset raw cache by copying per-chrom dirs (build_cache has no
+  chromosome filter).
+- `scripts/compare_cache.py` — logical-equality check between two built caches.
+
+## Build notes (M1 16 GB)
+- `vepyr/Cargo.toml` has a `[patch]` redirecting `datafusion-bio-function-vep` to the
+  in-tree checkout so changes build without pushing. Revert before release.
+- Release build needs `CARGO_BUILD_JOBS=2 CARGO_PROFILE_RELEASE_CODEGEN_UNITS=256
+  CARGO_INCREMENTAL=0` + `SDKROOT`/`CPATH` (else OOM during compile / snappy C++ error).
+- Build via maturin only; never copy the raw `target/release/*.dylib` (code-signing).

--- a/benchmark-results/cache-build-chr1-baseline-20260613/RESULTS.md
+++ b/benchmark-results/cache-build-chr1-baseline-20260613/RESULTS.md
@@ -1,0 +1,11 @@
+# Cache build benchmark — 1
+
+- created: 2026-06-13T22:59:03+0200
+- knob swept: `partitions`
+- platform: macOS-26.4.1-arm64-arm-64bit
+- git: test-annotation-target-partitions@b2bea8a8d3
+- raw cache: /tmp/bench_chr1_baseline/raw_subset
+
+| partitions | median s | min s | max s | speedup | RSS GiB | rows |
+|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 1234.93 | 1234.93 | 1234.93 | 1.0x | 8.70 | 88639209 |

--- a/benchmark-results/cache-build-chr1-baseline-20260613/runs.csv
+++ b/benchmark-results/cache-build-chr1-baseline-20260613/runs.csv
@@ -1,0 +1,2 @@
+knob,knob_value,repeat,elapsed_seconds,max_rss_bytes,num_files,total_rows,total_parquet_bytes
+partitions,1,1,1234.928665,9342271488,7,88639209,6453056620

--- a/benchmark-results/cache-build-chr1-baseline-20260613/runs.jsonl
+++ b/benchmark-results/cache-build-chr1-baseline-20260613/runs.jsonl
@@ -1,0 +1,1 @@
+{"elapsed_seconds": 1234.928665, "knob": "partitions", "knob_value": 1, "max_rss_bytes": 9342271488, "num_files": 7, "repeat": 1, "total_parquet_bytes": 6453056620, "total_rows": 88639209}

--- a/benchmark-results/cache-build-chr1-baseline-20260613/summary.json
+++ b/benchmark-results/cache-build-chr1-baseline-20260613/summary.json
@@ -1,0 +1,29 @@
+{
+  "created_at": "2026-06-13T22:59:03+0200",
+  "platform": "macOS-26.4.1-arm64-arm-64bit",
+  "python": "3.12.0 (v3.12.0:0fb18b02c8, Oct  2 2023, 09:45:56) [Clang 13.0.0 (clang-1300.0.29.30)]",
+  "git_commit": "b2bea8a8d3f0374b16b7fb6b252f5ca1186301f9",
+  "git_branch": "test-annotation-target-partitions",
+  "local_cache": "/tmp/bench_chr1_baseline/raw_subset",
+  "chromosomes": "1",
+  "knob": "partitions",
+  "values": [
+    1
+  ],
+  "repeats": 1,
+  "results": [
+    {
+      "knob_value": 1,
+      "runs": 1,
+      "median_seconds": 1234.928665,
+      "min_seconds": 1234.928665,
+      "max_seconds": 1234.928665,
+      "median_max_rss_bytes": 9342271488,
+      "total_rows": [
+        88639209
+      ],
+      "rows_consistent": true,
+      "speedup_vs_1": 1.0
+    }
+  ]
+}

--- a/benchmark-results/cache-build-chr19-22-etap3-scaling-20260614/RESULTS.md
+++ b/benchmark-results/cache-build-chr19-22-etap3-scaling-20260614/RESULTS.md
@@ -1,0 +1,14 @@
+# Cache build benchmark — 19,20,21,22
+
+- created: 2026-06-14T12:45:28+0200
+- knob swept: `build_concurrency`
+- platform: macOS-26.4.1-arm64-arm-64bit
+- git: test-annotation-target-partitions@b2bea8a8d3
+- raw cache: /tmp/bench_chr19_22/raw_subset
+
+| build_concurrency | median s | min s | max s | speedup | RSS GiB | rows |
+|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 1047.34 | 1047.34 | 1047.34 | 1.0x | 10.57 | 78305358 |
+| 2 | 649.06 | 649.06 | 649.06 | 1.614x | 8.88 | 78305358 |
+| 4 | 491.05 | 491.05 | 491.05 | 2.133x | 10.61 | 78305358 |
+| 8 | 420.99 | 420.99 | 420.99 | 2.488x | 9.87 | 78305358 |

--- a/benchmark-results/cache-build-chr19-22-etap3-scaling-20260614/runs.csv
+++ b/benchmark-results/cache-build-chr19-22-etap3-scaling-20260614/runs.csv
@@ -1,0 +1,5 @@
+knob,knob_value,repeat,elapsed_seconds,max_rss_bytes,num_files,total_rows,total_parquet_bytes
+build_concurrency,1,1,1047.337525,11353178112,28,78305358,6665459277
+build_concurrency,2,1,649.063241,9530949632,28,78305358,6665459277
+build_concurrency,4,1,491.049426,11397070848,28,78305358,6665459277
+build_concurrency,8,1,420.990329,10594287616,28,78305358,6665459277

--- a/benchmark-results/cache-build-chr19-22-etap3-scaling-20260614/summary.json
+++ b/benchmark-results/cache-build-chr19-22-etap3-scaling-20260614/summary.json
@@ -1,0 +1,72 @@
+{
+  "created_at": "2026-06-14T12:45:28+0200",
+  "platform": "macOS-26.4.1-arm64-arm-64bit",
+  "python": "3.12.0 (v3.12.0:0fb18b02c8, Oct  2 2023, 09:45:56) [Clang 13.0.0 (clang-1300.0.29.30)]",
+  "git_commit": "b2bea8a8d3f0374b16b7fb6b252f5ca1186301f9",
+  "git_branch": "test-annotation-target-partitions",
+  "local_cache": "/tmp/bench_chr19_22/raw_subset",
+  "chromosomes": "19,20,21,22",
+  "knob": "build_concurrency",
+  "values": [
+    1,
+    2,
+    4,
+    8
+  ],
+  "repeats": 1,
+  "fixed_partitions": 1,
+  "results": [
+    {
+      "knob_value": 1,
+      "runs": 1,
+      "median_seconds": 1047.337525,
+      "min_seconds": 1047.337525,
+      "max_seconds": 1047.337525,
+      "median_max_rss_bytes": 11353178112,
+      "total_rows": [
+        78305358
+      ],
+      "rows_consistent": true,
+      "speedup_vs_1": 1.0
+    },
+    {
+      "knob_value": 2,
+      "runs": 1,
+      "median_seconds": 649.063241,
+      "min_seconds": 649.063241,
+      "max_seconds": 649.063241,
+      "median_max_rss_bytes": 9530949632,
+      "total_rows": [
+        78305358
+      ],
+      "rows_consistent": true,
+      "speedup_vs_1": 1.614
+    },
+    {
+      "knob_value": 4,
+      "runs": 1,
+      "median_seconds": 491.049426,
+      "min_seconds": 491.049426,
+      "max_seconds": 491.049426,
+      "median_max_rss_bytes": 11397070848,
+      "total_rows": [
+        78305358
+      ],
+      "rows_consistent": true,
+      "speedup_vs_1": 2.133
+    },
+    {
+      "knob_value": 8,
+      "runs": 1,
+      "median_seconds": 420.990329,
+      "min_seconds": 420.990329,
+      "max_seconds": 420.990329,
+      "median_max_rss_bytes": 10594287616,
+      "total_rows": [
+        78305358
+      ],
+      "rows_consistent": true,
+      "speedup_vs_1": 2.488
+    }
+  ]
+}

--- a/benchmark-results/cache-build-chr19-22-lpt-weighted-20260614/RESULTS.md
+++ b/benchmark-results/cache-build-chr19-22-lpt-weighted-20260614/RESULTS.md
@@ -1,0 +1,39 @@
+# Unified scheduler: LPT (#1) + weighted semaphore (#2) — chr19-22
+
+Machine: MacBook Air M1, 16 GB, 8 cores, low-power mode ON (release, partitions=1).
+Dataset: chr19+20+21+22, 78,305,358 rows. Relative same-machine comparison.
+
+`build_all` was refactored into a single flat work-unit scheduler: every
+(entity, chromosome) unit is discovered, ordered longest-first (LPT, #1), and
+run through one weighted semaphore (#2, env `VEPYR_VAR_WEIGHT`).
+
+## #1 LPT (VEPYR_VAR_WEIGHT=1) vs previous nested scheduler (no global LPT)
+| build_concurrency | nested (no LPT) | flat + LPT | LPT gain |
+|---:|---:|---:|---:|
+| 1 | 1047 s (1.00×) | 1037 s (1.00×) | — |
+| 2 | 649 s (1.61×) | 585 s (1.77×) | ~10% |
+| 4 | 491 s (2.13×) | 427 s (**2.43×**) | ~13% |
+| 8 | 421 s (2.49×) | 421 s (2.46×) | ~0% |
+
+LPT helps at mid concurrency (permits < heavy units → ordering matters): the
+heavy variation chromosomes start first instead of queueing behind light units.
+At concurrency=8 there are enough permits that ordering is irrelevant.
+Correctness: conc=1 vs conc=4 → 32/32 parquet files logically identical.
+
+## #2 Weighted semaphore (concurrency=8)
+| VEPYR_VAR_WEIGHT | seconds |
+|---:|---:|
+| 1 (unweighted) | 421 s |
+| 3 | 615 s |
+
+On data that fits in RAM, weighting is a **slowdown**: it caps how many
+variation tiers run at once (at weight=3, floor(8/3)=2 instead of 4), leaving
+cores idle. Its purpose is **not** speed — it is a memory-safety valve that lets
+a high `build_concurrency` be used without OOM on memory-constrained machines
+(e.g. full genome on 16 GB, where 4+ concurrent large-chromosome variation tiers
+would exceed RAM). On the target 64 GB machine, keep `VEPYR_VAR_WEIGHT=1`.
+
+## Takeaways
+- Best demo config: flat scheduler, `VEPYR_VAR_WEIGHT=1`, concurrency 4-8 → ~2.46×.
+- #1 (LPT) is a free, output-neutral win at mid concurrency; grows with chromosome count / when permits are scarcer than heavy units.
+- #2 (weighting) trades speed for memory headroom; only enable when unweighted would OOM.

--- a/benchmark-results/cache-build-chr2122-etap3-20260614/RESULTS.md
+++ b/benchmark-results/cache-build-chr2122-etap3-20260614/RESULTS.md
@@ -1,0 +1,44 @@
+# Etap 3 — chromosome-axis concurrency — chr21 + chr22
+
+Machine: MacBook Air M1, 16 GB RAM, 8 cores, low-power mode ON (release build).
+Dataset: full chr21 + chr22 raw Ensembl VEP cache (release 115, GRCh38), 29,893,709 rows.
+Method: same binary, vary `build_concurrency` (1 = original serial path), partitions=1.
+Relative comparison on this machine (NOT the Ryzen/64GB from the presentation).
+Raw per-run numbers: summary.json (conc 1 vs 4 + correctness), summary_curve.json (full sweep).
+
+## What changed (vs Etap 1)
+Etap 1 only overlapped the 6 *entities*. Etap 3 also runs *chromosomes within each
+entity* concurrently, under one global semaphore (`build_concurrency` = max
+concurrent (entity,chrom) units). `build_variation` was refactored: per-main-chrom
+work extracted into `build_variation_main_chrom` (own context + temp dir), "other"
+contigs kept as a single unit (`build_variation_other`); main chroms run via JoinSet.
+`build_parquet_entity` and `build_translation` parallelize their chrom loops the same way.
+
+## Scaling (partitions=1)
+| build_concurrency | seconds | speedup |
+|---:|---:|---:|
+| 1 (baseline) | 351.92 | 1.00× |
+| 2 | 198.34 | 1.77× |
+| 4 | 177.78 | **1.98×** |
+| 8 | 178.48 | 1.97× |
+
+Peak RSS 6.4–7.3 GiB (fits 16 GB).
+
+### Why it plateaus at ~2×
+Only **2 chromosomes** here → 2 heavy `variation` long-poles. Once both build
+concurrently (build_concurrency ≥ 2) wall-clock is bounded by the slowest single
+chromosome's variation tier; extra concurrency (4, 8) has no more big units to fill.
+The speedup ceiling ≈ number of chromosomes, capped by cores / memory. On the full
+genome (24 main chromosomes) the ceiling is far higher — that run belongs on the
+64 GB target machine (on 16 GB, concurrent large-chromosome variation tiers would
+exceed RAM; chr1 variation alone peaks ~8.7 GiB).
+
+## Correctness
+At partitions=1 (deterministic), build_concurrency 1 vs 4 → **16/16 parquet files
+logically identical** (order-independent multiset hash). The variation refactor and
+chromosome-level concurrency are output-neutral.
+
+## Combined picture (this machine)
+- Entity axis alone (Etap 1, chr22): ~1.31×.
+- Entity + chromosome axis (Etap 3, chr21+22): ~1.98× (2 chroms).
+- Speedup grows with chromosome count → full-genome validation on 64 GB hardware.

--- a/benchmark-results/cache-build-chr2122-etap3-20260614/RESULTS_curve.md
+++ b/benchmark-results/cache-build-chr2122-etap3-20260614/RESULTS_curve.md
@@ -1,0 +1,14 @@
+# Cache build benchmark — 21,22
+
+- created: 2026-06-14T09:54:55+0200
+- knob swept: `build_concurrency`
+- platform: macOS-26.4.1-arm64-arm-64bit
+- git: test-annotation-target-partitions@b2bea8a8d3
+- raw cache: /tmp/bench_chr2122/raw_subset
+
+| build_concurrency | median s | min s | max s | speedup | RSS GiB | rows |
+|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 351.92 | 351.92 | 351.92 | 1.0x | 6.81 | 29893709 |
+| 2 | 198.34 | 198.34 | 198.34 | 1.774x | 7.30 | 29893709 |
+| 4 | 177.78 | 177.78 | 177.78 | 1.98x | 6.69 | 29893709 |
+| 8 | 178.48 | 178.48 | 178.48 | 1.972x | 6.43 | 29893709 |

--- a/benchmark-results/cache-build-chr2122-etap3-20260614/summary.json
+++ b/benchmark-results/cache-build-chr2122-etap3-20260614/summary.json
@@ -1,0 +1,44 @@
+{
+  "created_at": "2026-06-14T09:37:50+0200",
+  "platform": "macOS-26.4.1-arm64-arm-64bit",
+  "python": "3.12.0 (v3.12.0:0fb18b02c8, Oct  2 2023, 09:45:56) [Clang 13.0.0 (clang-1300.0.29.30)]",
+  "git_commit": "b2bea8a8d3f0374b16b7fb6b252f5ca1186301f9",
+  "git_branch": "test-annotation-target-partitions",
+  "local_cache": "/tmp/bench_chr2122/raw_subset",
+  "chromosomes": "21,22",
+  "knob": "build_concurrency",
+  "values": [
+    1,
+    4
+  ],
+  "repeats": 1,
+  "fixed_partitions": 1,
+  "results": [
+    {
+      "knob_value": 1,
+      "runs": 1,
+      "median_seconds": 383.95797,
+      "min_seconds": 383.95797,
+      "max_seconds": 383.95797,
+      "median_max_rss_bytes": 5107449856,
+      "total_rows": [
+        29893709
+      ],
+      "rows_consistent": true,
+      "speedup_vs_1": 1.0
+    },
+    {
+      "knob_value": 4,
+      "runs": 1,
+      "median_seconds": 182.980559,
+      "min_seconds": 182.980559,
+      "max_seconds": 182.980559,
+      "median_max_rss_bytes": 6252298240,
+      "total_rows": [
+        29893709
+      ],
+      "rows_consistent": true,
+      "speedup_vs_1": 2.098
+    }
+  ]
+}

--- a/benchmark-results/cache-build-chr2122-etap3-20260614/summary_curve.json
+++ b/benchmark-results/cache-build-chr2122-etap3-20260614/summary_curve.json
@@ -1,0 +1,72 @@
+{
+  "created_at": "2026-06-14T09:54:55+0200",
+  "platform": "macOS-26.4.1-arm64-arm-64bit",
+  "python": "3.12.0 (v3.12.0:0fb18b02c8, Oct  2 2023, 09:45:56) [Clang 13.0.0 (clang-1300.0.29.30)]",
+  "git_commit": "b2bea8a8d3f0374b16b7fb6b252f5ca1186301f9",
+  "git_branch": "test-annotation-target-partitions",
+  "local_cache": "/tmp/bench_chr2122/raw_subset",
+  "chromosomes": "21,22",
+  "knob": "build_concurrency",
+  "values": [
+    1,
+    2,
+    4,
+    8
+  ],
+  "repeats": 1,
+  "fixed_partitions": 1,
+  "results": [
+    {
+      "knob_value": 1,
+      "runs": 1,
+      "median_seconds": 351.920828,
+      "min_seconds": 351.920828,
+      "max_seconds": 351.920828,
+      "median_max_rss_bytes": 7315456000,
+      "total_rows": [
+        29893709
+      ],
+      "rows_consistent": true,
+      "speedup_vs_1": 1.0
+    },
+    {
+      "knob_value": 2,
+      "runs": 1,
+      "median_seconds": 198.335837,
+      "min_seconds": 198.335837,
+      "max_seconds": 198.335837,
+      "median_max_rss_bytes": 7843627008,
+      "total_rows": [
+        29893709
+      ],
+      "rows_consistent": true,
+      "speedup_vs_1": 1.774
+    },
+    {
+      "knob_value": 4,
+      "runs": 1,
+      "median_seconds": 177.779177,
+      "min_seconds": 177.779177,
+      "max_seconds": 177.779177,
+      "median_max_rss_bytes": 7185055744,
+      "total_rows": [
+        29893709
+      ],
+      "rows_consistent": true,
+      "speedup_vs_1": 1.98
+    },
+    {
+      "knob_value": 8,
+      "runs": 1,
+      "median_seconds": 178.480102,
+      "min_seconds": 178.480102,
+      "max_seconds": 178.480102,
+      "median_max_rss_bytes": 6906986496,
+      "total_rows": [
+        29893709
+      ],
+      "rows_consistent": true,
+      "speedup_vs_1": 1.972
+    }
+  ]
+}

--- a/benchmark-results/cache-build-chr22-etap1-20260614/RESULTS.md
+++ b/benchmark-results/cache-build-chr22-etap1-20260614/RESULTS.md
@@ -1,0 +1,47 @@
+# Etap 1 — entity concurrency (`build_concurrency`) — chr22
+
+Machine: MacBook Air M1, 16 GB RAM, 8 cores, low-power mode ON (release build).
+Dataset: full chr22 raw Ensembl VEP cache (release 115, GRCh38), 15,262,195 output rows.
+Method: same binary, vary `build_concurrency` (1 = original serial path via semaphore=1).
+Comparison is relative on this machine (NOT the Ryzen/64GB from the presentation).
+
+## Performance
+
+### partitions = 4 (variation gets some intra-query parallelism)
+| build_concurrency | seconds | speedup |
+|---:|---:|---:|
+| 1 (baseline) | 304.75 | 1.00× |
+| 2 | 256.01 | 1.19× |
+| 4 | 233.51 | **1.31×** |
+| 6 | 246.20 | 1.24× |
+
+### partitions = 1 (variation fully sequential)
+| build_concurrency | seconds | speedup |
+|---:|---:|---:|
+| 1 (baseline) | 208.33 | 1.00× |
+| 6 | 165.27 | **1.26×** |
+
+Peak RSS ~6–7 GiB across all configs (fits 16 GB).
+
+## Why only ~1.3×
+Entity concurrency overlaps the 5 smaller entities with `variation`, which dominates
+runtime and runs as a single unit. Amdahl: max speedup ≈ total / variation_time.
+Going past concurrency=4 hurts (8 cores, 4 of them efficiency cores, low-power mode,
+scheduling/memory contention). The larger win requires the **chromosome axis**
+(Etap 3) so variation's many chromosomes build concurrently — only visible on
+multi-chromosome / full-genome inputs.
+
+## Correctness
+Gate: at FIXED partitions, vary `build_concurrency` → output must be identical.
+- partitions=1, build_concurrency 1 vs 6 → **8/8 parquet files logically identical**
+  (order-independent multiset hash via polars `hash_rows`). PASS.
+- Conclusion: entity concurrency is **output-neutral**; it introduces no non-determinism.
+
+## Pre-existing non-determinism (NOT caused by this change)
+At partitions>1 the build is **not reproducible run-to-run**: two independent serial
+(build_concurrency=1) builds at partitions=4 differed in 5/8 files (same row counts,
+different content). Cause is multi-partition execution + unstable dedup tie-breaks
+(`ROW_NUMBER() ... ORDER BY stable_id NULLS LAST` for exon/transcript) and the
+warm/cold variation split across partition boundaries. This predates the
+parallelization work and is independent of `build_concurrency`. Worth a separate
+look if reproducible caches are required.

--- a/benchmark-results/cache-build-chr22-etap1-20260614/RESULTS_partitions1.md
+++ b/benchmark-results/cache-build-chr22-etap1-20260614/RESULTS_partitions1.md
@@ -1,0 +1,12 @@
+# Cache build benchmark — 22
+
+- created: 2026-06-14T02:08:01+0200
+- knob swept: `build_concurrency`
+- platform: macOS-26.4.1-arm64-arm-64bit
+- git: test-annotation-target-partitions@b2bea8a8d3
+- raw cache: /tmp/bench_chr22_p1/raw_subset
+
+| build_concurrency | median s | min s | max s | speedup | RSS GiB | rows |
+|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 208.33 | 208.33 | 208.33 | 1.0x | 6.77 | 15262195 |
+| 6 | 165.27 | 165.27 | 165.27 | 1.261x | 6.25 | 15262195 |

--- a/benchmark-results/cache-build-chr22-etap1-20260614/RESULTS_partitions4.md
+++ b/benchmark-results/cache-build-chr22-etap1-20260614/RESULTS_partitions4.md
@@ -1,0 +1,14 @@
+# Cache build benchmark — 22
+
+- created: 2026-06-14T01:53:40+0200
+- knob swept: `build_concurrency`
+- platform: macOS-26.4.1-arm64-arm-64bit
+- git: test-annotation-target-partitions@b2bea8a8d3
+- raw cache: /tmp/bench_chr22full/raw_subset
+
+| build_concurrency | median s | min s | max s | speedup | RSS GiB | rows |
+|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 304.75 | 304.75 | 304.75 | 1.0x | 6.26 | 15262195 |
+| 2 | 256.01 | 256.01 | 256.01 | 1.19x | 5.96 | 15262195 |
+| 4 | 233.51 | 233.51 | 233.51 | 1.305x | 6.42 | 15262195 |
+| 6 | 246.20 | 246.20 | 246.20 | 1.238x | 6.14 | 15262195 |

--- a/benchmark-results/cache-build-chr22-etap1-20260614/summary_partitions1.json
+++ b/benchmark-results/cache-build-chr22-etap1-20260614/summary_partitions1.json
@@ -1,0 +1,44 @@
+{
+  "created_at": "2026-06-14T02:08:01+0200",
+  "platform": "macOS-26.4.1-arm64-arm-64bit",
+  "python": "3.12.0 (v3.12.0:0fb18b02c8, Oct  2 2023, 09:45:56) [Clang 13.0.0 (clang-1300.0.29.30)]",
+  "git_commit": "b2bea8a8d3f0374b16b7fb6b252f5ca1186301f9",
+  "git_branch": "test-annotation-target-partitions",
+  "local_cache": "/tmp/bench_chr22_p1/raw_subset",
+  "chromosomes": "22",
+  "knob": "build_concurrency",
+  "values": [
+    1,
+    6
+  ],
+  "repeats": 1,
+  "fixed_partitions": 1,
+  "results": [
+    {
+      "knob_value": 1,
+      "runs": 1,
+      "median_seconds": 208.331603,
+      "min_seconds": 208.331603,
+      "max_seconds": 208.331603,
+      "median_max_rss_bytes": 7266844672,
+      "total_rows": [
+        15262195
+      ],
+      "rows_consistent": true,
+      "speedup_vs_1": 1.0
+    },
+    {
+      "knob_value": 6,
+      "runs": 1,
+      "median_seconds": 165.274549,
+      "min_seconds": 165.274549,
+      "max_seconds": 165.274549,
+      "median_max_rss_bytes": 6710673408,
+      "total_rows": [
+        15262195
+      ],
+      "rows_consistent": true,
+      "speedup_vs_1": 1.261
+    }
+  ]
+}

--- a/benchmark-results/cache-build-chr22-etap1-20260614/summary_partitions4.json
+++ b/benchmark-results/cache-build-chr22-etap1-20260614/summary_partitions4.json
@@ -1,0 +1,72 @@
+{
+  "created_at": "2026-06-14T01:53:40+0200",
+  "platform": "macOS-26.4.1-arm64-arm-64bit",
+  "python": "3.12.0 (v3.12.0:0fb18b02c8, Oct  2 2023, 09:45:56) [Clang 13.0.0 (clang-1300.0.29.30)]",
+  "git_commit": "b2bea8a8d3f0374b16b7fb6b252f5ca1186301f9",
+  "git_branch": "test-annotation-target-partitions",
+  "local_cache": "/tmp/bench_chr22full/raw_subset",
+  "chromosomes": "22",
+  "knob": "build_concurrency",
+  "values": [
+    1,
+    2,
+    4,
+    6
+  ],
+  "repeats": 1,
+  "fixed_partitions": 4,
+  "results": [
+    {
+      "knob_value": 1,
+      "runs": 1,
+      "median_seconds": 304.751315,
+      "min_seconds": 304.751315,
+      "max_seconds": 304.751315,
+      "median_max_rss_bytes": 6717652992,
+      "total_rows": [
+        15262195
+      ],
+      "rows_consistent": true,
+      "speedup_vs_1": 1.0
+    },
+    {
+      "knob_value": 2,
+      "runs": 1,
+      "median_seconds": 256.005004,
+      "min_seconds": 256.005004,
+      "max_seconds": 256.005004,
+      "median_max_rss_bytes": 6402392064,
+      "total_rows": [
+        15262195
+      ],
+      "rows_consistent": true,
+      "speedup_vs_1": 1.19
+    },
+    {
+      "knob_value": 4,
+      "runs": 1,
+      "median_seconds": 233.513397,
+      "min_seconds": 233.513397,
+      "max_seconds": 233.513397,
+      "median_max_rss_bytes": 6892732416,
+      "total_rows": [
+        15262195
+      ],
+      "rows_consistent": true,
+      "speedup_vs_1": 1.305
+    },
+    {
+      "knob_value": 6,
+      "runs": 1,
+      "median_seconds": 246.204877,
+      "min_seconds": 246.204877,
+      "max_seconds": 246.204877,
+      "median_max_rss_bytes": 6588121088,
+      "total_rows": [
+        15262195
+      ],
+      "rows_consistent": true,
+      "speedup_vs_1": 1.238
+    }
+  ]
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ fn parse_cache_source_type(value: &str) -> PyResult<CacheSourceType> {
 ///
 /// Returns a list of `(entity, [(parquet_path, rows)], Option<(variants, positions, bytes, secs)>)`.
 #[pyfunction]
-#[pyo3(signature = (cache_root, output_dir, partitions=8, cache_format="indexed_parquet", zstd_level=3, dict_size_kb=112, on_progress=None, cache_source_type="ensembl", overwrite=false, variation_af_threshold=0.01, variation_position_radius=1, variation_cold_row_group_rows=8_192, variation_cold_data_page_rows=1_024))]
+#[pyo3(signature = (cache_root, output_dir, partitions=8, cache_format="indexed_parquet", zstd_level=3, dict_size_kb=112, on_progress=None, cache_source_type="ensembl", overwrite=false, variation_af_threshold=0.01, variation_position_radius=1, variation_cold_row_group_rows=8_192, variation_cold_data_page_rows=1_024, build_concurrency=0))]
 #[allow(clippy::type_complexity, clippy::too_many_arguments)]
 fn build_cache(
     py: Python<'_>,
@@ -33,11 +33,28 @@ fn build_cache(
     variation_position_radius: i64,
     variation_cold_row_group_rows: usize,
     variation_cold_data_page_rows: usize,
+    build_concurrency: usize,
 ) -> PyResult<Vec<(String, Vec<(String, usize)>, Option<(u64, u64, u64, f64)>)>> {
     let cache_source_type = parse_cache_source_type(cache_source_type)?;
     let cache_format = CacheFormat::parse(cache_format).map_err(|err| {
         pyo3::exceptions::PyValueError::new_err(format!("Invalid cache_format: {err}"))
     })?;
+
+    // build_concurrency = max entity build tasks running at once. 0 = auto:
+    // min(available_parallelism, number of entities = 6).
+    let resolved_concurrency = if build_concurrency == 0 {
+        std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1)
+            .min(6)
+    } else {
+        build_concurrency
+    }
+    .max(1);
+    // The runtime needs enough worker threads to actually parallelize the
+    // concurrent entity tasks (each may also drive its own intra-query
+    // partitions), so decouple it from `partitions`.
+    let worker_threads = partitions.max(resolved_concurrency).max(1);
 
     let cb: Option<OnProgress> = on_progress.map(|py_cb| {
         Box::new(
@@ -62,14 +79,16 @@ fn build_cache(
         .with_indexed_variation_cold_layout_options(
             variation_cold_row_group_rows,
             variation_cold_data_page_rows,
-        );
+        )
+        .with_build_concurrency(resolved_concurrency);
 
     if let Some(progress) = cb {
         builder = builder.with_on_progress(progress);
     }
+    let builder = std::sync::Arc::new(builder);
 
     let rt = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(partitions)
+        .worker_threads(worker_threads)
         .enable_all()
         .build()
         .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))?;

--- a/src/vepyr/__init__.py
+++ b/src/vepyr/__init__.py
@@ -256,6 +256,7 @@ def build_cache(
     variation_position_radius: int = 1,
     variation_cold_row_group_rows: int = 8_192,
     variation_cold_data_page_rows: int = 1_024,
+    build_concurrency: int = 0,
 ) -> list[tuple[str, int]]:
     """Download an Ensembl VEP cache and convert it to an optimized cache.
 
@@ -309,6 +310,12 @@ def build_cache(
     variation_cold_data_page_rows : int
         Target cold variation parquet data page row count used for page-level
         pruning metadata.
+    build_concurrency : int
+        Maximum number of cache entities built concurrently. ``0`` (default)
+        auto-selects ``min(cpu_count, 6)``. ``1`` reproduces the original
+        serial build. Entities write to disjoint output directories, so this
+        only changes scheduling, never output content. The tokio runtime worker
+        thread count is set to ``max(partitions, build_concurrency)``.
 
     Returns
     -------
@@ -346,6 +353,8 @@ def build_cache(
     }.items():
         if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
             raise ValueError(f"{name} must be a positive integer")
+    if isinstance(build_concurrency, bool) or not isinstance(build_concurrency, int) or build_concurrency < 0:
+        raise ValueError("build_concurrency must be a non-negative integer (0 = auto)")
 
     # Version directory name: e.g. "115_GRCh38_ensembl"
     version_dir = f"{release}_{assembly}_{cache_type}"
@@ -446,6 +455,7 @@ def build_cache(
             int(variation_position_radius),
             int(variation_cold_row_group_rows),
             int(variation_cold_data_page_rows),
+            int(build_concurrency),
         )
     finally:
         if _bars is not None:

--- a/src/vepyr/_core.pyi
+++ b/src/vepyr/_core.pyi
@@ -16,6 +16,7 @@ def build_cache(
     variation_position_radius: int = 1,
     variation_cold_row_group_rows: int = 8_192,
     variation_cold_data_page_rows: int = 1_024,
+    build_concurrency: int = 0,
 ) -> list[tuple[str, list[tuple[str, int]], tuple[int, int, int, float] | None]]:
     """Build all cache entities from an Ensembl VEP cache to Parquet."""
     ...


### PR DESCRIPTION
## What
Expose and wire a `build_concurrency` knob for parallel cache building (paired with biodatageeks/datafusion-bio-functions#179).

- **C2** `feat(build_cache)`: add `build_concurrency` param (PyO3 + Python + `.pyi`). `0` = auto `min(cpu, 6)`, `1` = serial baseline. Decouple tokio worker threads from `partitions` (now `max(partitions, build_concurrency)`).
- **C3** `build`: `[patch]` redirect `datafusion-bio-function-vep` to the in-tree checkout so changes build without pushing upstream first. **Dev-only — revert before release** (re-pin `rev=` to the merged commit instead).
- **C4** `docs(bench)`: benchmark results + `CACHE_BUILD_PARALLELIZATION_SUMMARY.md`.

## Correctness
Output-neutral at fixed partitions (see #179): logically identical to serial across `build_concurrency` levels.

## Performance (MacBook Air M1, 16 GB, release, partitions=1, relative same-machine)
chr19-22 scaling: 1.00× / 1.61× / 2.13× / 2.49× at build_concurrency 1 / 2 / 4 / 8. Speedup grows with chromosome count.

## Notes
- Depends on #179 (the parallel cache builder). The `[patch]` (C3) must be replaced with a normal `rev=` bump once #179 merges.
- Targets `test-annotation-target-partitions` (not master): the current indexed-parquet `build_cache` lives there, not on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)