### PR TITLE
feat: plugin-factory toolkit — build_plugin_cache pin, vepyr.parity, the region mini-cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,7 +1193,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-function-vep"
 version = "0.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?tag=v0.14.0#86bd907fc31917351b263681fe103250a5a773ee"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=f7b9e66#f7b9e66b74d2ffd5e4b076fe3866f14234cc938f"
 dependencies = [
  "ahash",
  "async-trait",
@@ -1201,6 +1201,7 @@ dependencies = [
  "chrono",
  "coitrees",
  "datafusion",
+ "datafusion-bio-format-core",
  "datafusion-bio-format-ensembl-cache",
  "datafusion-bio-format-vcf",
  "flate2",
@@ -5351,7 +5352,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vepyr"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "arrow",
  "datafusion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,6 @@ env_logger = { version = "0.11", default-features = false }
 serde_json = "1"
 
 # Upstream biodatageeks crates
-datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", tag = "v0.14.0", features = ["cache-builder"] }
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "f7b9e66", features = ["cache-builder", "parquet-cache"] }
 datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.8" }
 datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.8.8" }

--- a/docs/superpowers/plans/2026-07-14-plugin-factory-toolkit.md
+++ b/docs/superpowers/plans/2026-07-14-plugin-factory-toolkit.md
@@ -12,17 +12,39 @@
 
 ---
 
-## Two discoveries that change the spec, found while preparing this plan
+## Status — two of the five tasks were already done upstream. Read this before starting.
 
-**1. The mini-cache must be BUILT, not sliced.** The spec (§5) says: slice every table of `_cache_v115` to a region. That cannot work. The local variation cache has **no `tier` column** — verified directly, its 76 columns are `chrom, start, end, variation_name, allele_string, …` and `tier` is not among them — while `plugin_cache::join` does:
+This plan was first drafted against a **stale local checkout of `vepyr`**. After fetching, two tasks
+turned out to exist already, and one premise was simply wrong. Corrected:
+
+- **Task 1 (engine pin): DONE** (`f760f68`). The pin was never `v0.13.1` — it was already `v0.14.0`
+  (moved by `bd12ed3`, "feat: Plugin cache (#27)"). It is now rev-pinned at `f7b9e66`, the Plan A
+  merge. The feared PR-#181 migration was a **non-event**: #181 is already an ancestor of `v0.14.0`,
+  the real delta is two commits, and **zero call sites had to change**.
+- **Task 2 (`build_plugin_cache` binding): ALREADY EXISTS**, and is better than this plan's draft.
+  `src/lib.rs:111`, registered, stubbed, and tested (`tests/test_build_plugin_cache.py`). Its real
+  signature is `build_plugin_cache(manifest_path, source_path, variation_cache_dir,
+  plugin_cache_root, chroms=None, overwrite=False) -> list[(chrom, rows, warm, cold)]`, and it
+  already fail-fasts on multi-source manifests and guards against an accidental full rebuild.
+  **Do not rewrite it.** Tasks 3–5 build on it as-is.
+
+**The one discovery that still stands, and it is the load-bearing one:**
+
+**The mini-cache must be BUILT, not sliced.** The spec (§5) says: slice every table of `_cache_v115`
+to a region. That cannot work. The local variation cache has **no `tier` column** — verified
+directly; its 76 columns are `chrom, start, end, variation_name, allele_string, …` and `tier` is not
+among them — while `plugin_cache::join` does:
 
 ```sql
 SELECT chrom, start, allele_string, tier FROM <variation shard>
 ```
 
-So a plugin build against a slice of `_cache_v115` fails on a missing column. That cache predates the tiering work. The fix is not to weaken the engine (tiering is a real warm/cold code path the parity gate should exercise) but to **rebuild the region's variation shard with the current builder** — which already exists as `examples/build_parquet_variation_chrom` and reads the native Ensembl cache we have on disk.
+So a plugin build against a slice of `_cache_v115` fails on a missing column. That cache predates the
+tiering work. The fix is not to weaken the engine (tiering is a real warm/cold code path the parity
+gate should exercise) but to **rebuild the region's variation shard with the current builder** —
+`examples/build_parquet_variation_chrom`, which reads the native Ensembl cache we have on disk.
 
-**2. `vepyr` pins the engine to `v0.13.1`, which has no `plugin_cache` at all.** (`Cargo.toml:46`. `plugin_cache` landed in `v0.14.0`.) Nothing in this plan compiles until that pin moves. Task 1.
+**Remaining work: Task 3 (`vepyr.parity`), Task 4 (the mini-cache), Task 5 (the e2e proof).**
 
 ---
 

--- a/docs/superpowers/plans/2026-07-14-plugin-factory-toolkit.md
+++ b/docs/superpowers/plans/2026-07-14-plugin-factory-toolkit.md
@@ -1,0 +1,495 @@
+# Plugin Factory — Plan B: Toolkit (`vepyr` becomes the thing the catalogue depends on)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Give `vepyr-plugins` (Plan C) everything it needs to test a plugin manifest with nothing but `pip install vepyr` and a downloaded mini-cache — no Rust toolchain, no 34 GB cache, no Perl.
+
+**Architecture:** Three deliverables in the `vepyr` repo. (1) `vepyr.build_plugin_cache(...)` — a PyO3 binding over the engine's `PluginCacheBuilder`, which the prior handoff described as "already shipped" and which **does not exist**. (2) `vepyr.parity` — the CSQ comparator, lifted out of a 809-line benchmark script into an importable module so the plugin gate and the WGS e2e suite share one implementation. (3) A **built** (not sliced) region mini-cache, published as a release asset.
+
+**Tech Stack:** Rust + PyO3 0.28 (abi3-py310), Python, DataFusion.
+
+**Source spec:** `datafusion-bio-functions/docs/superpowers/specs/2026-07-13-vep-plugin-port-factory-design.md` (§4, §5, §6). Plan A (the engine half) is merged: PRs #194, #195 → `master-sitekwb`.
+
+---
+
+## Two discoveries that change the spec, found while preparing this plan
+
+**1. The mini-cache must be BUILT, not sliced.** The spec (§5) says: slice every table of `_cache_v115` to a region. That cannot work. The local variation cache has **no `tier` column** — verified directly, its 76 columns are `chrom, start, end, variation_name, allele_string, …` and `tier` is not among them — while `plugin_cache::join` does:
+
+```sql
+SELECT chrom, start, allele_string, tier FROM <variation shard>
+```
+
+So a plugin build against a slice of `_cache_v115` fails on a missing column. That cache predates the tiering work. The fix is not to weaken the engine (tiering is a real warm/cold code path the parity gate should exercise) but to **rebuild the region's variation shard with the current builder** — which already exists as `examples/build_parquet_variation_chrom` and reads the native Ensembl cache we have on disk.
+
+**2. `vepyr` pins the engine to `v0.13.1`, which has no `plugin_cache` at all.** (`Cargo.toml:46`. `plugin_cache` landed in `v0.14.0`.) Nothing in this plan compiles until that pin moves. Task 1.
+
+---
+
+## Branch policy
+
+Same convention as the engine repo: cut **`master-sitekwb`** from `vepyr`'s `master` and treat it as `main`. Feature branches off it, PRs into it. **Never commit to `master`/`main`.**
+
+```bash
+cd /Users/wojtek/Documents/vepyr/vepyr
+git fetch origin && git checkout -b master-sitekwb origin/master && git push -u origin master-sitekwb
+git worktree add ../vepyr-worktrees/toolkit -b feat/plugin-cache-toolkit master-sitekwb
+```
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `Cargo.toml` | Deps | Modify: bump `datafusion-bio-function-vep` past `plugin_cache`; add the `parquet-cache` feature |
+| `src/plugin_cache.rs` | **New.** The `build_plugin_cache` PyO3 binding | Create |
+| `src/lib.rs` | pymodule registration (`lib.rs:146-152`) | Modify: register the new function |
+| `src/vepyr/_core.pyi` | Type stubs | Modify: signature for `build_plugin_cache` |
+| `src/vepyr/parity.py` | **New.** The CSQ comparator, importable | Create (lifted from `e2e-testing/scripts/run_annotation_fast.py:384` `compare_vcfs`) |
+| `scripts/build_mini_cache.py` | **New.** Builds the region mini-cache fixture | Create |
+| `tests/test_plugin_cache.py` | Python-side tests | Create |
+| `tests/test_parity.py` | Comparator tests | Create |
+
+---
+
+### Task 1: Move the engine pin so `plugin_cache` exists at all
+
+**Files:** `Cargo.toml`
+
+- [ ] **Step 1: Confirm the gap**
+
+```bash
+cd /Users/wojtek/Documents/vepyr/vepyr
+grep -n "datafusion-bio-function-vep" Cargo.toml     # expect: tag = "v0.13.1"
+```
+`plugin_cache` is not in `v0.13.1` — it landed in `v0.14.0`, and the hardening (Plan A) is on `master-sitekwb` above that.
+
+- [ ] **Step 2: Repoint at the merged Plan A commit**
+
+In `Cargo.toml`, replace the `tag = "v0.13.1"` pin on `datafusion-bio-function-vep` with a **rev** pin at the Plan A merge commit, and add the feature that gates the plugin-cache builder:
+
+```toml
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "f7b9e66", features = ["cache-builder", "parquet-cache"] }
+```
+
+(Rev, not branch: a moving branch pin makes builds unreproducible. When the engine cuts a release containing Plan A, move to that tag.)
+
+- [ ] **Step 3: Build and run the existing suite — nothing may regress**
+
+```bash
+cargo build --release
+uv run pytest tests/ -x -q
+```
+Expected: builds; the existing tests pass unchanged. If the engine bump breaks an existing call site, that is a real incompatibility — **report it, do not paper over it.**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock
+git commit -m "build: pin the engine at the plugin_cache merge (v0.13.1 predates the subsystem)"
+```
+
+---
+
+### Task 2: `vepyr.build_plugin_cache` — the function the handoff claimed already existed
+
+The engine API is `PluginCacheBuilder::new(&manifest, manifest_file, variation_cache_dir, out)` → `.with_chrom_filter([..])` → `.with_overwrite(bool)` → `.build_all()`, and the manifest comes from `SourceManifest::load(path)` (which now also `validate()`s). Mirror that.
+
+**Files:** `src/plugin_cache.rs` (new), `src/lib.rs`, `src/vepyr/_core.pyi`, `tests/test_plugin_cache.py` (new)
+
+- [ ] **Step 1: Write the failing Python test**
+
+`tests/test_plugin_cache.py`:
+
+```python
+"""The plugin-cache builder binding: the surface vepyr-plugins' CI depends on."""
+
+from pathlib import Path
+
+import pytest
+
+import vepyr
+
+
+def test_build_plugin_cache_rejects_an_invalid_manifest(tmp_path: Path) -> None:
+    """A manifest that fails engine validation must raise, not build a broken cache."""
+    manifest = tmp_path / "bad.source.toml"
+    manifest.write_text(
+        '# no [[source]] and no [[value_columns]] -> structurally useless\n'
+        'plugin_name = "bad"\n'
+        'coordinate_system = "1-based"\n'
+        'ingest_sql = "SELECT 1"\n'
+    )
+    with pytest.raises(Exception) as exc:
+        vepyr.build_plugin_cache(
+            manifest=str(manifest),
+            variation_cache_dir=str(tmp_path),
+            out=str(tmp_path / "out"),
+        )
+    # The engine's validate() names the plugin and the missing block.
+    assert "bad" in str(exc.value)
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+uv run pytest tests/test_plugin_cache.py -x -q
+```
+Expected: `AttributeError: module 'vepyr' has no attribute 'build_plugin_cache'`.
+
+- [ ] **Step 3: Write the binding**
+
+`src/plugin_cache.rs`:
+
+```rust
+//! PyO3 binding over the engine's plugin-cache builder.
+//!
+//! `vepyr-plugins`' CI builds a plugin's cache from a TOML source manifest with
+//! nothing but `pip install vepyr` — no Rust toolchain. This is that entry point.
+
+use std::path::{Path, PathBuf};
+
+use datafusion_bio_function_vep::plugin_cache::builder::PluginCacheBuilder;
+use datafusion_bio_function_vep::plugin_cache::source_manifest::SourceManifest;
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+
+/// Build a plugin cache from a declarative source manifest.
+///
+/// `manifest`             path to `<plugin>.source.toml`
+/// `variation_cache_dir`  cache root containing `variation/<chrom>.parquet`
+/// `out`                  output root; writes `plugin/<name>/`
+/// `source_path`          override the manifest's source path (single-source manifests)
+/// `chroms`               restrict the build (empty/None = every chrom in the cache)
+/// `overwrite`            clean rebuild instead of an UPSERT into the prior manifest
+///
+/// Returns the built chromosomes as `[{chrom, rows, warm, cold}, ...]`.
+#[pyfunction]
+#[pyo3(signature = (manifest, variation_cache_dir, out, source_path=None, chroms=None, overwrite=false))]
+pub fn build_plugin_cache(
+    py: Python<'_>,
+    manifest: &str,
+    variation_cache_dir: &str,
+    out: &str,
+    source_path: Option<&str>,
+    chroms: Option<Vec<String>>,
+    overwrite: bool,
+) -> PyResult<Vec<PluginChrom>> {
+    let manifest_path = PathBuf::from(manifest);
+    // SourceManifest::load() also runs validate(), so a self-contradictory manifest
+    // (vcf source declaring 0-based, a [source.csv] block under provider = "vcf",
+    // no sources, no value columns, ...) raises here instead of building a cache
+    // that silently annotates nothing.
+    let mut src = SourceManifest::load(&manifest_path).map_err(to_py_err)?;
+
+    if let Some(p) = source_path {
+        if src.sources.len() != 1 {
+            return Err(PyRuntimeError::new_err(format!(
+                "source_path= is ambiguous: manifest '{}' declares {} sources",
+                src.plugin_name,
+                src.sources.len()
+            )));
+        }
+        src.sources[0].path = p.to_string();
+    }
+
+    let manifest_file = file_name_of(&manifest_path);
+    let chroms = chroms.unwrap_or_default();
+
+    // The builder is async; release the GIL while it runs.
+    py.detach(|| {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| PyRuntimeError::new_err(format!("tokio runtime: {e}")))?;
+        rt.block_on(async {
+            let mut b = PluginCacheBuilder::new(
+                &src,
+                &manifest_file,
+                Path::new(variation_cache_dir),
+                Path::new(out),
+            );
+            if !chroms.is_empty() {
+                b = b.with_chrom_filter(chroms.clone());
+            }
+            b = b.with_overwrite(overwrite);
+            let cache = b.build_all().await.map_err(to_py_err)?;
+            Ok(cache
+                .chroms
+                .iter()
+                .map(|c| PluginChrom {
+                    chrom: c.chrom.clone(),
+                    rows: c.rows,
+                    warm: c.warm,
+                    cold: c.cold,
+                })
+                .collect())
+        })
+    })
+}
+
+/// One built chromosome. `warm == 0` with `rows > 0` means NOT ONE row joined the
+/// variation cache — the manifest is almost certainly wrong (contig naming,
+/// coordinate system, or allele-string format). The engine also logs a warning.
+#[pyclass(get_all)]
+#[derive(Clone)]
+pub struct PluginChrom {
+    pub chrom: String,
+    pub rows: usize,
+    pub warm: usize,
+    pub cold: usize,
+}
+
+#[pymethods]
+impl PluginChrom {
+    fn __repr__(&self) -> String {
+        format!(
+            "PluginChrom(chrom='{}', rows={}, warm={}, cold={})",
+            self.chrom, self.rows, self.warm, self.cold
+        )
+    }
+}
+
+fn to_py_err(e: datafusion::common::DataFusionError) -> PyErr {
+    PyRuntimeError::new_err(e.to_string())
+}
+
+fn file_name_of(p: &Path) -> String {
+    p.file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| p.to_string_lossy().into_owned())
+}
+```
+
+> The exact types of `ChromEntry`'s count fields (`rows`/`warm`/`cold`) must be read from
+> `plugin_cache/cache_manifest.rs` — if they are `u64` rather than `usize`, use that. Do not guess;
+> a wrong integer type is a compile error, so the compiler will tell you.
+
+In `src/lib.rs`, add the module and register the function beside the existing three
+(`lib.rs:146-152`):
+
+```rust
+mod plugin_cache;
+// ... inside the #[pymodule] fn:
+    m.add_function(wrap_pyfunction!(plugin_cache::build_plugin_cache, m)?)?;
+    m.add_class::<plugin_cache::PluginChrom>()?;
+```
+
+- [ ] **Step 4: Add the type stub**
+
+In `src/vepyr/_core.pyi`, matching the style of the existing entries:
+
+```python
+class PluginChrom:
+    chrom: str
+    rows: int
+    warm: int
+    cold: int
+
+def build_plugin_cache(
+    manifest: str,
+    variation_cache_dir: str,
+    out: str,
+    source_path: str | None = None,
+    chroms: list[str] | None = None,
+    overwrite: bool = False,
+) -> list[PluginChrom]: ...
+```
+
+Re-export it from `src/vepyr/__init__.py` the way the existing functions are re-exported.
+
+- [ ] **Step 5: Build and run green**
+
+```bash
+RUSTFLAGS="-C target-cpu=native" uv sync --reinstall-package vepyr
+uv run pytest tests/test_plugin_cache.py -x -q
+```
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/plugin_cache.rs src/lib.rs src/vepyr/_core.pyi src/vepyr/__init__.py tests/test_plugin_cache.py
+git commit -m "feat: vepyr.build_plugin_cache — the binding the handoff assumed existed"
+```
+
+---
+
+### Task 3: `vepyr.parity` — one CSQ comparator, two consumers
+
+`e2e-testing/scripts/run_annotation_fast.py:384` defines `compare_vcfs`, an 809-line script's field-by-field CSQ comparator. It already handles the hard parts: merge-join on the variant key, CSQ entry-count and entry-**order** semantics (with an explicit rationale comment at `:374-380`), per-field mismatch counts with examples. Plan C needs exactly this, restricted to a plugin's fields. Copying it would fork it.
+
+**Files:** `src/vepyr/parity.py` (new), `tests/test_parity.py` (new), `e2e-testing/scripts/run_annotation_fast.py` (modify: import instead of define)
+
+- [ ] **Step 1: Read the original first**
+
+Read `e2e-testing/scripts/run_annotation_fast.py:384-620` in full before touching anything. The extraction must be **behaviour-preserving** — this function is the arbiter of a 4-million-variant WGS benchmark, and quietly changing its semantics would invalidate results nobody would re-check.
+
+- [ ] **Step 2: Write the failing test**
+
+`tests/test_parity.py` — cover what Plan C actually depends on:
+
+```python
+"""The CSQ comparator: the arbiter of every plugin's parity gate."""
+
+from vepyr.parity import compare_csq_fields
+
+
+def test_identical_files_agree() -> None:
+    ...
+
+def test_a_differing_plugin_field_is_reported_with_its_value() -> None:
+    """A mismatch must name the field, the key, and BOTH values — a bare count is useless."""
+    ...
+
+def test_over_emission_is_a_mismatch() -> None:
+    """vepyr populating a field VEP left empty is a failure, not a bonus.
+    (This is one of the two bugs the manual AlphaMissense e2e caught that unit tests missed.)"""
+    ...
+
+def test_fields_outside_the_requested_set_are_ignored() -> None:
+    """The plugin gate compares ONLY the plugin's CSQ fields; core-field drift is
+    a separate verdict (see the blame-attribution rule in the spec, §6.1)."""
+    ...
+```
+
+Write these as real tests over small in-memory/temp VCF pairs. Do not stub them.
+
+- [ ] **Step 3: Extract**
+
+Move `compare_vcfs` (and only the helpers it needs) into `src/vepyr/parity.py`, exposing:
+
+```python
+def compare_csq_fields(
+    truth_vcf: str | Path,
+    test_vcf: str | Path,
+    fields: Sequence[str] | None = None,   # None = every shared CSQ field
+) -> ComparisonResult: ...
+```
+
+`ComparisonResult` is a dataclass carrying at least: total keys compared, per-field mismatch counts, per-field examples (key + both values), entry-count mismatches, and over-emission counts. Keep the entry-order semantics **exactly** as the original, comment and all — that comment is the record of a real decision.
+
+Then have `e2e-testing/scripts/run_annotation_fast.py` **import** it rather than define it.
+
+- [ ] **Step 4: Prove the extraction is behaviour-preserving**
+
+This is the step that matters. Run the WGS e2e comparator before and after the extraction on the same inputs and diff the reports:
+
+```bash
+# whatever inputs the script's README specifies; a single chromosome is enough
+uv run python e2e-testing/scripts/run_annotation_fast.py --chrom chr22 ... > /tmp/after.txt
+git stash && uv run python e2e-testing/scripts/run_annotation_fast.py --chrom chr22 ... > /tmp/before.txt && git stash pop
+diff /tmp/before.txt /tmp/after.txt    # must be empty
+```
+If the inputs are unavailable locally, say so explicitly and fall back to a golden-file test over a committed VCF pair — but **do not skip the equivalence check silently.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/vepyr/parity.py tests/test_parity.py e2e-testing/scripts/run_annotation_fast.py
+git commit -m "refactor: extract the CSQ comparator into vepyr.parity (one implementation, two consumers)"
+```
+
+---
+
+### Task 4: The mini-cache — built, not sliced
+
+The parity gate needs a cache small enough for CI. The full one is 34 GB, and (see discoveries above) the local one has **no `tier` column**, so slicing it is not an option.
+
+Region: **`chr22:22,000,000–23,500,000`** — chosen because it contains `chr22:22,893,742 C>G`, the locus on which AlphaMissense parity was manually confirmed, so Plan C's regression test is meaningful.
+
+**Files:** `scripts/build_mini_cache.py` (new)
+
+- [ ] **Step 1: Rebuild chr22's variation shard with the CURRENT builder (this is what supplies `tier`)**
+
+The engine ships the tool already:
+
+```bash
+cargo run --release -p datafusion-bio-function-vep \
+  --features lance-cache,cache-builder \
+  --example build_parquet_variation_chrom -- \
+  --cache-root /Users/wojtek/Documents/vepyr/_cache_v115/homo_sapiens/<release>_GRCh38 \
+  --output-dir /tmp/mini_cache_full \
+  --chrom chr22 --cache-source-type <ensembl|merged|refseq> --partitions 8 --overwrite
+```
+
+Resolve `<release>` and the source type from what is actually on disk under `_cache_v115/homo_sapiens/` — read it, do not assume. **Verify the output has the column that started all this:**
+
+```bash
+python -c "import pyarrow.parquet as pq; n=pq.ParquetFile('/tmp/mini_cache_full/variation/chr22.parquet').schema_arrow.names; print('tier' in n, len(n))"
+```
+Expected: `True`. If it is `False`, STOP — the whole mini-cache design rests on this.
+
+- [ ] **Step 2: Build the other tables for chr22**
+
+`build_parquet_context_chrom` and `build_parquet_translation_sift_chrom` (same `examples/` dir) cover the remaining tables the annotator needs. Read each example's `--help`/header for its flags. Produce a chr22-only cache root.
+
+- [ ] **Step 3: Slice every table to the region, and cut the FASTA window**
+
+`scripts/build_mini_cache.py`: filter each parquet table to `22_000_000 <= start <= 23_500_000` (respect each table's own coordinate column — read the schema, do not assume they all use `start`), and cut the matching window out of `Homo_sapiens.GRCh38.dna.primary_assembly.fa`. Emit a cache root with the same layout as the full one, plus a `chrom_manifest.json` the runtime accepts.
+
+- [ ] **Step 4: The fixture's own test — the one the spec's §12 risk section demands**
+
+A mini-cache that silently drops a transcript would produce phantom "core drift" and poison the blame-attribution rule the whole gate depends on. So:
+
+```
+annotate the region's VCF with the FULL cache  -> output A
+annotate the same VCF with the MINI cache      -> output B
+require A == B (body-identical)
+```
+Anything less is trusting the slicer. Report the real diff.
+
+- [ ] **Step 5: Report size and publish**
+
+```bash
+du -sh /tmp/mini_cache_region
+```
+Target: tens of MB. Publish as a GitHub release asset on `vepyr` (**ask the user before publishing** — it is an outward-facing artifact), and record the URL + checksum in `scripts/build_mini_cache.py`'s header so Plan C's CI can fetch it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/build_mini_cache.py
+git commit -m "feat: build the region mini-cache fixture (built, not sliced — the old cache has no tier column)"
+```
+
+---
+
+### Task 5: The end-to-end proof — everything Plan C will do, done once by hand
+
+- [ ] **Step 1: Build the real AlphaMissense plugin cache against the mini-cache, through the Python API**
+
+```python
+import vepyr
+chroms = vepyr.build_plugin_cache(
+    manifest="/Users/wojtek/Documents/vepyr/vepyr-plugins/plugins/alphamissense/alphamissense.source.toml",
+    source_path="<a chr22-region slice of AlphaMissense_hg38.tsv.gz>",
+    variation_cache_dir="<mini-cache root>",
+    out="/tmp/plugin_cache",
+    chroms=["chr22"],
+)
+print(chroms)
+```
+
+- [ ] **Step 2: Read the numbers, and do not accept a healthy-looking lie**
+
+`warm == 0` with `rows > 0` means **not one row joined the variation cache** — the build "succeeded" and the plugin will annotate nothing. Plan A added a warning for exactly this. If you see it, the mini-cache or the source slice is wrong; fix it rather than proceeding.
+
+- [ ] **Step 3: Annotate with the plugin cache and confirm the CSQ fields appear**
+
+Use the existing `annotate_vcf` binding with `plugin_cache_root` pointed at the output, over the region's VCF, and confirm `am_class` / `am_pathogenicity` are populated on missense lines and empty elsewhere.
+
+- [ ] **Step 4: Commit nothing; report**
+
+This task produces no code — it produces the evidence that Plan C is buildable. Report the actual numbers.
+
+---
+
+## Definition of done
+
+`pip install vepyr` + the mini-cache release asset is enough to build a plugin cache from a manifest and diff two VCFs field-by-field — with no Rust toolchain, no 34 GB cache, and no Perl. That is precisely the surface Plan C's CI stands on.
+
+## Explicitly NOT in this plan
+
+The parity harness itself, `parity.toml`, the golden VEP outputs, the CI workflow, and the three clients (AlphaMissense / REVEL / a VCF plugin) — those are **Plan C**, in the `vepyr-plugins` repo. This plan only builds what Plan C imports.

--- a/e2e-testing/scripts/run_annotation_fast.py
+++ b/e2e-testing/scripts/run_annotation_fast.py
@@ -14,15 +14,18 @@ plain text and validate the compressed output.
 """
 
 import argparse
-import gzip
 import json
 import os
-import re
 import subprocess
 import sys
 import time
 
 import vepyr
+
+# The CSQ comparator lives in the library, not in this script: the plugin-parity
+# gate in vepyr-plugins runs the same comparison restricted to one plugin's
+# fields. One implementation, two consumers.
+from vepyr.parity import compare_vcfs, count_data_lines
 
 
 # ── Defaults ──────────────────────────────────────────────────────────────
@@ -233,13 +236,6 @@ def parse_args():
     return args
 
 
-def open_text(path):
-    """Open a VCF for text reading, transparently handling .gz (bgzf/gzip)."""
-    if path.endswith((".gz", ".bgz", ".bgzf")):
-        return gzip.open(path, "rt")
-    return open(path)
-
-
 def is_bgzf(path):
     """Return True if `path` is BGZF (block-gzip): gzip magic + 'BC' subfield."""
     with open(path, "rb") as f:
@@ -252,16 +248,6 @@ def is_bgzf(path):
         and head[3] & 0x04
         and head[12:14] == b"BC"
     )
-
-
-def count_data_lines(path):
-    """Count non-header lines in a VCF (plain or .gz)."""
-    n = 0
-    with open_text(path) as f:
-        for line in f:
-            if not line.startswith("#"):
-                n += 1
-    return n
 
 
 def ensure_tabix_index(vcf_gz):
@@ -368,308 +354,9 @@ def extract_chrom_from_vep(vep_vcf, chrom, out_dir, suffix="", force=False):
     return out_path
 
 
+# Profiles whose VEP reference emits already-selected CSQ entries in Perl hash
+# order; see vepyr.parity.VEP_HASH_ORDER_PICK_IGNORE_REASON.
 VEP_HASH_ORDER_PICK_CACHES = {"merged_per_gene", "merged_pick_allele_gene"}
-
-VEP_HASH_ORDER_PICK_IGNORE_REASON = (
-    "CSQ entry order is ignored for per_gene and pick_allele_gene because "
-    "Ensembl VEP selects the representative consequences, then emits those "
-    "winners by iterating Perl hashes (`keys %by_gene`; for pick_allele_gene "
-    "also `keys %by_allele`). The comma order of those already-selected CSQ "
-    "entries has no biological or interpretation meaning; it is not a severity, "
-    "transcript-priority, genomic, MANE, or canonical ranking. The meaningful "
-    "checks are the selected CSQ entries, entry counts, and field values."
-)
-
-
-def compare_vcfs(
-    vepyr_vcf,
-    vep_vcf,
-    label,
-    ignore_csq_order=False,
-):
-    """Field-by-field CSQ comparison between vepyr and VEP output."""
-    print()
-    print("=" * 60)
-    print(f"Comparing vepyr ({BACKEND}) vs VEP — {label}")
-    print("=" * 60)
-
-    n_vepyr = count_data_lines(vepyr_vcf)
-    n_vep = count_data_lines(vep_vcf)
-    print(f"  vepyr:  {n_vepyr:,} data lines")
-    print(f"  VEP:    {n_vep:,} data lines")
-
-    # Parse CSQ field names from headers
-    csq_re = re.compile(r"CSQ=([^;\t]+)")
-
-    def get_csq_fields(path):
-        with open_text(path) as f:
-            for line in f:
-                if line.startswith("##INFO=<ID=CSQ"):
-                    m = re.search(r"Format: ([^\"]+)", line)
-                    return m.group(1).split("|") if m else []
-        return []
-
-    vepyr_fields = get_csq_fields(vepyr_vcf)
-    vep_fields = get_csq_fields(vep_vcf)
-    shared_fields = [f for f in vepyr_fields if f in vep_fields]
-
-    fields_only_vepyr = sorted(set(vepyr_fields) - set(vep_fields))
-    fields_only_vep = sorted(set(vep_fields) - set(vepyr_fields))
-    if fields_only_vepyr:
-        print(f"  Fields only in vepyr: {fields_only_vepyr}")
-    if fields_only_vep:
-        print(f"  Fields only in VEP:   {fields_only_vep}")
-
-    # Build sorted key+CSQ for merge-join
-    def extract_keyed_csq(path):
-        rows = []
-        with open_text(path) as f:
-            for line in f:
-                if line.startswith("#"):
-                    continue
-                cols = line.split("\t", 9)
-                m = csq_re.search(cols[7])
-                csq = m.group(1) if m else ""
-                key = (cols[0], int(cols[1]), cols[3], cols[4])
-                rows.append((key, csq))
-        rows.sort()
-        return rows
-
-    print("  Building sorted key+CSQ lists ...")
-    vepyr_rows = extract_keyed_csq(vepyr_vcf)
-    vep_rows = extract_keyed_csq(vep_vcf)
-
-    # Merge-join
-    field_matches = {f: 0 for f in shared_fields}
-    field_mismatches = {f: 0 for f in shared_fields}
-    field_total = {f: 0 for f in shared_fields}
-    field_mismatch_examples = {f: [] for f in shared_fields}
-
-    n_compared = 0
-    n_missing_in_vep = 0
-    n_missing_in_vepyr = 0
-    n_csq_count_match = 0
-    n_csq_count_mismatch = 0
-    n_csq_order_mismatch = 0
-    n_csq_order_ignored = 0
-    csq_order_mismatch_examples = []
-    csq_order_ignored_examples = []
-    field_order_mismatches = {f: 0 for f in shared_fields}
-    field_order_mismatch_examples = {f: [] for f in shared_fields}
-
-    i, j = 0, 0
-    while i < len(vepyr_rows) and j < len(vep_rows):
-        vk, vepyr_csq = vepyr_rows[i]
-        gk, vep_csq = vep_rows[j]
-
-        if vk < gk:
-            n_missing_in_vep += 1
-            i += 1
-            continue
-        elif vk > gk:
-            n_missing_in_vepyr += 1
-            j += 1
-            continue
-
-        n_compared += 1
-        key_str = f"{vk[0]}\t{vk[1]}\t{vk[2]}\t{vk[3]}"
-
-        if vepyr_csq and vep_csq:
-
-            def parse_entries(raw, fields):
-                entries = []
-                for e in raw.split(","):
-                    vals = dict(zip(fields, e.split("|")))
-                    entries.append(vals)
-                return entries
-
-            def sort_key(d):
-                return (d.get("Feature", ""), d.get("Consequence", ""))
-
-            vepyr_parsed = parse_entries(vepyr_csq, vepyr_fields)
-            vep_parsed = parse_entries(vep_csq, vep_fields)
-
-            # Detect CSQ entry ordering mismatch before sorting for comparison
-            vepyr_order = [d.get("Feature", "") for d in vepyr_parsed]
-            vep_order = [d.get("Feature", "") for d in vep_parsed]
-            if vepyr_order != vep_order and sorted(vepyr_order) == sorted(vep_order):
-                example = {
-                    "variant": key_str,
-                    "vepyr_order": vepyr_order,
-                    "vep_order": vep_order,
-                }
-                # Ensembl VEP's --per_gene and --pick_allele_gene paths group
-                # transcript alleles in Perl hashes, choose representative
-                # consequences, then emit winners with `keys %by_gene` and, for
-                # pick_allele_gene, `keys %by_allele`. The comma order of those
-                # already-selected CSQ entries has no biological or
-                # interpretation meaning: it is not a severity,
-                # transcript-priority, genomic, MANE, or canonical ranking.
-                # Ignoring only this order therefore does not change
-                # interpretation; entry counts and every CSQ field value are
-                # still compared strictly.
-                if ignore_csq_order:
-                    n_csq_order_ignored += 1
-                    if len(csq_order_ignored_examples) < 10:
-                        csq_order_ignored_examples.append(example)
-                else:
-                    n_csq_order_mismatch += 1
-                    if len(csq_order_mismatch_examples) < 10:
-                        csq_order_mismatch_examples.append(example)
-
-            # Sort by Feature for stable pairing (so field comparison is meaningful)
-            vepyr_parsed.sort(key=sort_key)
-            vep_parsed.sort(key=sort_key)
-
-            if len(vepyr_parsed) == len(vep_parsed):
-                n_csq_count_match += 1
-            else:
-                n_csq_count_mismatch += 1
-
-            for ei in range(min(len(vepyr_parsed), len(vep_parsed))):
-                vepyr_vals = vepyr_parsed[ei]
-                vep_vals = vep_parsed[ei]
-
-                for f in shared_fields:
-                    field_total[f] += 1
-                    vv = vepyr_vals.get(f, "")
-                    gv = vep_vals.get(f, "")
-                    if vv == gv:
-                        field_matches[f] += 1
-                    else:
-                        # Check if it's just an &-ordering difference
-                        if "&" in vv or "&" in gv:
-                            vv_norm = "&".join(sorted(vv.split("&")))
-                            gv_norm = "&".join(sorted(gv.split("&")))
-                            if vv_norm == gv_norm:
-                                # Same values, different order
-                                field_matches[f] += 1
-                                field_order_mismatches[f] += 1
-                                if len(field_order_mismatch_examples[f]) < 10:
-                                    field_order_mismatch_examples[f].append(
-                                        {"variant": key_str, "vepyr": vv, "vep": gv}
-                                    )
-                                continue
-                        field_mismatches[f] += 1
-                        if len(field_mismatch_examples[f]) < 10:
-                            field_mismatch_examples[f].append(
-                                {"variant": key_str, "vepyr": vv, "vep": gv}
-                            )
-
-        i += 1
-        j += 1
-
-    while i < len(vepyr_rows):
-        n_missing_in_vep += 1
-        i += 1
-    while j < len(vep_rows):
-        n_missing_in_vepyr += 1
-        j += 1
-
-    # Print results
-    print("\n  Results:")
-    print(f"    Variants compared:        {n_compared:,}")
-    print(f"    Only in vepyr:            {n_missing_in_vep:,}")
-    print(f"    Only in VEP:              {n_missing_in_vepyr:,}")
-    print(f"    CSQ count match:          {n_csq_count_match:,}")
-    print(f"    CSQ count mismatch:       {n_csq_count_mismatch:,}")
-    print(
-        f"    CSQ order mismatch:       {n_csq_order_mismatch:,}  (same entries, wrong order — issue #83)"
-    )
-    if ignore_csq_order:
-        print(
-            f"    CSQ order ignored:        {n_csq_order_ignored:,}  "
-            "(VEP hash-order only)"
-        )
-
-    if csq_order_mismatch_examples:
-        print("\n  CSQ order mismatch examples:")
-        for ex in csq_order_mismatch_examples:
-            print(f"    {ex['variant']}")
-            print(f"      vepyr: {', '.join(ex['vepyr_order'])}")
-            print(f"      VEP:   {', '.join(ex['vep_order'])}")
-
-    print(f"\n  Per-field match rates ({n_compared:,} variants):")
-    print(
-        f"  {'Field':<30} {'Match%':>8} {'Matches':>10} {'Mismatches':>10} {'OrderOnly':>10} {'Total':>10}"
-    )
-    print(f"  {'-' * 30} {'-' * 8} {'-' * 10} {'-' * 10} {'-' * 10} {'-' * 10}")
-    for f in shared_fields:
-        total = field_total[f]
-        matches = field_matches[f]
-        mismatches = field_mismatches[f]
-        order_only = field_order_mismatches[f]
-        rate = (matches / total * 100) if total > 0 else 0
-        flag = ""
-        if mismatches > 0:
-            flag = " <--"
-        elif order_only > 0:
-            flag = " (order)"
-        print(
-            f"  {f:<30} {rate:>7.2f}% {matches:>10,} {mismatches:>10,} {order_only:>10,} {total:>10,}{flag}"
-        )
-
-    fields_with_order_issues = [
-        f for f in shared_fields if field_order_mismatches[f] > 0
-    ]
-    if fields_with_order_issues:
-        print("\n  &-order mismatch examples (same values, different order):")
-        for f in fields_with_order_issues:
-            print(f"\n    {f} ({field_order_mismatches[f]:,} &-order mismatches):")
-            for ex in field_order_mismatch_examples[f]:
-                print(f"      {ex['variant']}")
-                print(f"        vepyr: {ex['vepyr']!r}")
-                print(f"        VEP:   {ex['vep']!r}")
-
-    fields_with_mismatches = [f for f in shared_fields if field_mismatches[f] > 0]
-    if fields_with_mismatches:
-        print("\n  Mismatch examples:")
-        for f in fields_with_mismatches:
-            print(f"\n    {f} ({field_mismatches[f]:,} mismatches):")
-            for ex in field_mismatch_examples[f]:
-                print(f"      {ex['variant']}")
-                print(f"        vepyr: {ex['vepyr']!r}")
-                print(f"        VEP:   {ex['vep']!r}")
-    else:
-        print(f"\n  ALL {len(shared_fields)} shared CSQ fields match at 100%!")
-
-    return {
-        "variants_compared": n_compared,
-        "variants_only_in_vepyr": n_missing_in_vep,
-        "csq_order_mismatch": n_csq_order_mismatch,
-        "csq_order_mismatch_examples": csq_order_mismatch_examples,
-        "csq_order_ignored": n_csq_order_ignored,
-        "csq_order_ignored_examples": csq_order_ignored_examples,
-        "csq_order_ignore_reason": VEP_HASH_ORDER_PICK_IGNORE_REASON
-        if ignore_csq_order
-        else None,
-        "variants_only_in_vep": n_missing_in_vepyr,
-        "csq_entry_count_match": n_csq_count_match,
-        "csq_entry_count_mismatch": n_csq_count_mismatch,
-        "field_match_rates": {
-            f: round(field_matches[f] / field_total[f] * 100, 4)
-            for f in shared_fields
-            if field_total[f] > 0
-        },
-        "field_mismatch_counts": {
-            f: field_mismatches[f] for f in shared_fields if field_mismatches[f] > 0
-        },
-        "field_mismatch_examples": {
-            f: field_mismatch_examples[f]
-            for f in shared_fields
-            if field_mismatch_examples[f]
-        },
-        "field_order_mismatch_counts": {
-            f: field_order_mismatches[f]
-            for f in shared_fields
-            if field_order_mismatches[f] > 0
-        },
-        "field_order_mismatch_examples": {
-            f: field_order_mismatch_examples[f]
-            for f in shared_fields
-            if field_order_mismatch_examples[f]
-        },
-    }
 
 
 def main():
@@ -776,6 +463,7 @@ def main():
             vep_chrom_vcf,
             chrom,
             ignore_csq_order=args.profile in VEP_HASH_ORDER_PICK_CACHES,
+            backend=BACKEND,
         )
 
     # ── Report ────────────────────────────────────────────────────────────

--- a/scripts/build_mini_cache.py
+++ b/scripts/build_mini_cache.py
@@ -1,0 +1,581 @@
+#!/usr/bin/env python3
+"""Slice a chromosome-scoped vepyr Parquet cache down to a small region fixture.
+
+Why this exists
+---------------
+The parity gate (real VEP + Perl plugin vs. vepyr + built plugin cache) needs a
+cache in CI. The production cache is ~34 GB (``variation/chr22.parquet`` alone is
+541 MB; the primary-assembly FASTA is 2.9 GB), which is far too large to publish
+as a release asset. This script produces a *region mini-cache*: tens of MB,
+downloadable in CI, and — critically — annotation-identical to the full cache
+over the region it covers.
+
+Build, don't slice-from-the-old-cache
+-------------------------------------
+This script slices a cache produced by the CURRENT engine builders
+(``build_parquet_variation_chrom`` / ``build_parquet_context_chrom`` /
+``build_parquet_translation_sift_chrom``). It cannot slice the legacy
+``_cache_v115/parquet/115_GRCh38_vep`` tree, which predates the engine's tiering
+work: its ``variation`` shard has 76 columns and none of them is ``tier``, while
+``plugin_cache::join`` issues ``SELECT chrom, start, allele_string, tier FROM
+<variation shard>``. That legacy tree also ships no ``chrom_manifest.json``, so
+``PartitionedParquetCache::detect`` does not even recognise it. Feed this script
+a freshly built cache root.
+
+The two traps this script exists to avoid
+-----------------------------------------
+A mini-cache that silently drops a feature manufactures phantom "core drift" and
+poisons the parity gate, whose whole job is to separate core drift from plugin
+bugs. Two ways that happens, both handled explicitly below:
+
+1. **Not every table is coordinate-sliceable.** ``translation_core`` has *no*
+   coordinate columns at all — only ``transcript_id``. ``exon`` has ``start`` /
+   ``end``, but its rows belong to transcripts: coordinate-filtering exons would
+   amputate the exons of a kept transcript that happen to lie outside the region,
+   silently changing that transcript's structure. So the slicer filters those
+   tables by **transcript-id membership**, not coordinates. See ``TABLE_POLICIES``.
+
+2. **Interval tables must be filtered by overlap, not containment.** A transcript
+   spanning the region boundary must be KEPT. Dropping it would delete real
+   annotation; keeping it means the region's *feature closure* extends past the
+   requested window — which is why the FASTA window is widened to cover every
+   kept feature (see ``feature_closure_span``). Without that widening, sequence
+   and HGVS lookups for a boundary-overlapping transcript would silently read
+   ``N`` instead of reference bases.
+
+Publication
+-----------
+The cache root is meant to be published as a **GitHub release asset on the
+``vepyr`` repository**, named ``mini-cache-chr22-22000000-23500000.tar.gz``, and
+downloaded by the parity-gate CI job. Publishing is outward-facing and is NOT done
+by this script: it builds the fixture locally and prints its checksum, and a human
+decides whether to upload it.
+
+    tar czf mini-cache-chr22-22000000-23500000.tar.gz -C /tmp mini_cache_region
+
+For chr22:22,000,000-23,500,000 that yields ~63 MB extracted (49 MB of which is
+the coordinate-preserving FASTA, almost all ``N`` and thus nearly free to
+compress) → **~14 MB** as the release asset, against ~29 GB + a 2.9 GB FASTA for
+the production cache.
+
+Region
+------
+``chr22:22,000,000-23,500,000`` is not arbitrary: it contains
+``chr22:22,893,742 C>G``, the locus on which AlphaMissense parity was manually
+confirmed, so the regression test built on this fixture is meaningful.
+
+Usage
+-----
+Build a complete single-chromosome cache with the engine's builders first (this
+script slices, it does not build)::
+
+    build_parquet_variation_chrom       --chrom chr22 --cache-source-type ensembl ...
+    build_parquet_context_chrom --entity {transcript,exon,regulatory,motif,translation_core} ...
+    build_parquet_translation_sift_chrom --chrom chr22 ...
+
+then slice it::
+
+    python scripts/build_mini_cache.py \\
+        --source-cache /tmp/mini_cache_chr22 \\
+        --fasta /path/to/Homo_sapiens.GRCh38.dna.primary_assembly.fa \\
+        --output /tmp/mini_cache_region \\
+        --chrom chr22 --start 22000000 --end 23500000
+
+``tests/test_build_mini_cache.py`` proves the slice is faithful by annotating a
+region VCF against the full chromosome cache and against the mini cache and
+requiring byte-identical bodies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Final
+
+import pyarrow as pa
+import pyarrow.compute as pc
+import pyarrow.parquet as pq
+from datafusion import SessionContext
+
+CHROM_MANIFEST_FILE: Final = "chrom_manifest.json"
+"""Per-entity manifest filename the runtime reads (``cache::manifest``)."""
+
+FASTA_LINE_WIDTH: Final = 60
+"""Bases per line in the emitted FASTA. The ``.fai`` is generated to match."""
+
+MISSING_IN_SOURCE: Final = -1
+"""Row count reported for a table the source cache has no shard for.
+
+Distinct from ``0`` (a shard that exists but retained no rows in the region), so
+"the source never had this table" is never confused with "the slice emptied it".
+"""
+
+
+class FilterKind(Enum):
+    """How a cache table is reduced to the region."""
+
+    INTERVAL = "interval"
+    """Keep rows whose ``[start, end]`` OVERLAPS the region (not containment)."""
+
+    TRANSCRIPT_MEMBERSHIP = "transcript_membership"
+    """Keep rows whose ``transcript_id`` (an ENST stable id) belongs to a kept
+    transcript.
+
+    Used for tables whose rows are *parts of* a transcript. Coordinate-filtering
+    them would truncate transcripts that overlap the region boundary.
+    """
+
+    TRANSCRIPT_UID_KEY = "transcript_uid_key"
+    """Keep rows whose packed ``key`` belongs to a kept transcript.
+
+    ``translation_sift`` has no ``transcript_id`` and no coordinates: it is a
+    point-lookup table keyed by ``key = (transcript_uid << 32) | protein_position``
+    (``cache::build::compact_translation_sift_position_schema``). So membership is
+    tested on ``key >> 32`` against the kept transcripts' ``transcript_uid``.
+
+    The uids are deliberately NOT renumbered when the transcript table is sliced:
+    the runtime reads ``transcript_uid`` straight off the transcript row and
+    reconstructs this key for a point lookup, so a sparse surviving subset of the
+    original uids resolves correctly, while renumbering would break every key.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class TablePolicy:
+    """The declared slicing rule for one cache entity directory."""
+
+    name: str
+    kind: FilterKind
+    required_columns: tuple[str, ...]
+    defines_transcript_set: bool = False
+    """True for ``transcript``: its surviving ``stable_id`` values drive the
+    membership filter applied to ``exon`` / ``translation_core`` /
+    ``translation_sift``."""
+
+
+TABLE_POLICIES: Final[tuple[TablePolicy, ...]] = (
+    # Interval tables — overlap-filtered on their own coordinates.
+    TablePolicy("variation", FilterKind.INTERVAL, ("chrom", "start", "end", "tier")),
+    TablePolicy(
+        "transcript",
+        FilterKind.INTERVAL,
+        ("chrom", "start", "end", "stable_id", "transcript_uid"),
+        defines_transcript_set=True,
+    ),
+    TablePolicy("regulatory", FilterKind.INTERVAL, ("chrom", "start", "end")),
+    TablePolicy("motif", FilterKind.INTERVAL, ("chrom", "start", "end")),
+    # Transcript-owned tables. `exon` DOES carry start/end, but slicing it on
+    # coordinates would drop the out-of-region exons of a boundary-overlapping
+    # transcript and thus silently change its structure. `translation_core` has no
+    # coordinate columns at all, and `translation_sift` has neither coordinates nor
+    # a stable id — only the packed `key`.
+    TablePolicy("exon", FilterKind.TRANSCRIPT_MEMBERSHIP, ("transcript_id",)),
+    TablePolicy(
+        "translation_core", FilterKind.TRANSCRIPT_MEMBERSHIP, ("transcript_id",)
+    ),
+    TablePolicy("translation_sift", FilterKind.TRANSCRIPT_UID_KEY, ("key",)),
+)
+
+SIFT_UID_SHIFT: Final = 32
+"""``translation_sift.key`` packs ``(transcript_uid << 32) | protein_position``."""
+
+DEFAULT_FLANK: Final = 5_000
+"""Bases to pad the region by when selecting interval features.
+
+VEP reports ``upstream_gene_variant`` / ``downstream_gene_variant`` for
+transcripts within a flank of the variant — the engine's default is
+``(5000, 5000)`` (``annotate_provider::transcript_distance_config`` →
+``.unwrap_or((5000, 5000))``, settable with ``--distance``).
+
+So a transcript lying entirely OUTSIDE the region can still annotate a variant
+INSIDE it. Selecting features by bare region overlap drops those transcripts and
+silently deletes real CSQ entries: the full-vs-mini test caught exactly this,
+losing the ``upstream_gene_variant`` on ``ENST00000548391`` (4,723 bp before the
+region start) for the variants at the region's left edge. Pad by at least the
+flank you will annotate with.
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class Region:
+    """A closed 1-based genomic interval, plus the annotation flank around it.
+
+    ``start``/``end`` are the region the fixture is *for*; ``flank`` widens the
+    window used to SELECT interval features, because VEP annotates a variant
+    against transcripts up to ``flank`` bases away (upstream/downstream gene
+    variants). The two are deliberately distinct: the VCF covers the region, but
+    the cache must carry the features the region's variants can reach.
+    """
+
+    chrom: str
+    start: int
+    end: int
+    flank: int = DEFAULT_FLANK
+
+    def __post_init__(self) -> None:
+        if self.start < 1 or self.end < self.start:
+            raise ValueError(f"invalid region {self.chrom}:{self.start}-{self.end}")
+        if self.flank < 0:
+            raise ValueError(f"flank must be non-negative, got {self.flank}")
+
+    @property
+    def padded(self) -> tuple[int, int]:
+        """The region widened by ``flank`` on both sides, clamped at 1."""
+        return max(1, self.start - self.flank), self.end + self.flank
+
+    @property
+    def label(self) -> str:
+        """A filename-safe rendering, e.g. ``chr22_22000000_23500000``."""
+        return f"{self.chrom}_{self.start}_{self.end}"
+
+
+def normalize_chrom(value: str) -> str:
+    """Strip a ``chr`` prefix so ``chr22`` and ``22`` compare equal.
+
+    Cache shards have historically stored the bare label (``"22"``) while the
+    manifest and CLI use ``"chr22"``; comparing without normalising would filter
+    every row away and yield a silently empty — but structurally valid — cache.
+    """
+    return value.removeprefix("chr")
+
+
+def overlap_mask(table: pa.Table, region: Region) -> pa.ChunkedArray:
+    """Boolean mask selecting rows whose interval OVERLAPS the FLANKED region.
+
+    Two things this must get right, both of which silently delete real annotation
+    if got wrong:
+
+    * **Overlap, not containment**: a feature starting before ``region.start`` or
+      ending after ``region.end`` still annotates variants inside the region.
+    * **Flanked, not bare**: a feature lying wholly outside the region but within
+      ``region.flank`` of it still produces upstream/downstream consequences for
+      variants at the region's edges.
+    """
+    lo, hi = region.padded
+    chrom = table["chrom"]
+    stripped = pc.if_else(
+        pc.starts_with(chrom, pattern="chr"),
+        pc.utf8_slice_codeunits(chrom, start=3),
+        chrom,
+    )
+    same_chrom = pc.equal(stripped, normalize_chrom(region.chrom))
+    starts_before_end = pc.less_equal(table["start"], hi)
+    ends_after_start = pc.greater_equal(table["end"], lo)
+    return pc.and_(same_chrom, pc.and_(starts_before_end, ends_after_start))
+
+
+def write_manifest(entity_dir: Path, entries: Sequence[dict[str, object]]) -> None:
+    """Write an entity's ``chrom_manifest.json`` in the runtime's shape."""
+    entity_dir.mkdir(parents=True, exist_ok=True)
+    (entity_dir / CHROM_MANIFEST_FILE).write_text(
+        json.dumps(list(entries), indent=2) + "\n"
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class KeptTranscripts:
+    """The transcripts that survived the region slice, in both identifier spaces.
+
+    ``stable_ids`` (ENST…) key ``exon`` / ``translation_core``; ``uids`` (the
+    ``transcript_uid`` column) key ``translation_sift`` via its packed ``key``.
+    """
+
+    stable_ids: pa.Array
+    uids: pa.Array
+
+
+def slice_table(
+    source: Path,
+    policy: TablePolicy,
+    region: Region,
+    kept: KeptTranscripts | None,
+) -> pa.Table:
+    """Apply ``policy`` to one parquet shard and return the surviving rows."""
+    table = pq.read_table(source)
+    missing = [c for c in policy.required_columns if c not in table.schema.names]
+    if missing:
+        raise ValueError(
+            f"{source}: table '{policy.name}' is missing required column(s) {missing}; "
+            f"present columns: {table.schema.names}"
+        )
+
+    if policy.kind is not FilterKind.INTERVAL and kept is None:
+        raise RuntimeError(
+            f"table '{policy.name}' needs the kept-transcript set, but the "
+            "'transcript' table was not sliced first"
+        )
+
+    match policy.kind:
+        case FilterKind.INTERVAL:
+            return table.filter(overlap_mask(table, region))
+        case FilterKind.TRANSCRIPT_MEMBERSHIP:
+            assert kept is not None
+            return table.filter(
+                pc.is_in(table["transcript_id"], value_set=kept.stable_ids)
+            )
+        case FilterKind.TRANSCRIPT_UID_KEY:
+            assert kept is not None
+            # `key` is uint64 and `transcript_uid` uint32; `is_in` will not compare
+            # across widths, so lift the uid set to the key's type.
+            uid = pc.shift_right(table["key"], SIFT_UID_SHIFT)
+            uids = kept.uids.cast(uid.type)
+            return table.filter(pc.is_in(uid, value_set=uids))
+
+
+def feature_closure_span(kept: pa.Table, region: Region) -> tuple[int, int]:
+    """Widen ``region`` to cover every kept interval feature.
+
+    A transcript overlapping the region boundary extends past it, and its exon
+    sequences are fetched from the FASTA by absolute coordinate. If the FASTA
+    carried real bases only across ``region``, those lookups would read ``N`` and
+    manufacture annotation differences. So the FASTA window spans the union of
+    the region and every kept feature.
+    """
+    lo, hi = region.padded
+    if kept.num_rows:
+        lo = min(lo, pc.min(kept["start"]).as_py())
+        hi = max(hi, pc.max(kept["end"]).as_py())
+    return lo, hi
+
+
+def iter_fasta_record(
+    fasta: Path, fai: Path, contig: str
+) -> tuple[str, int, Iterator[bytes]]:
+    """Stream one contig's bases from an indexed FASTA.
+
+    Returns the contig's name **as spelled in the source** (the primary-assembly
+    FASTA uses bare ``22`` while the cache and VCF use ``chr22``; the mini FASTA
+    must keep the source spelling so the engine's contig resolution takes exactly
+    the same path against both FASTAs), its length, and an iterator over raw base
+    chunks with newlines stripped.
+    """
+    wanted = normalize_chrom(contig)
+    for line in fai.read_text().splitlines():
+        name, length, offset, line_bases, line_width = line.split("\t")
+        if normalize_chrom(name) != wanted:
+            continue
+        length, offset = int(length), int(offset)
+        line_bases, line_width = int(line_bases), int(line_width)
+
+        def _chunks() -> Iterator[bytes]:
+            with fasta.open("rb") as handle:
+                handle.seek(offset)
+                remaining = length
+                while remaining > 0:
+                    take = min(line_bases, remaining)
+                    row = handle.read(line_width)
+                    yield row[:take]
+                    remaining -= take
+
+        return name, length, _chunks()
+    raise KeyError(f"contig '{contig}' not found in {fai}")
+
+
+def write_fasta_window(
+    fasta: Path,
+    fai: Path,
+    region: Region,
+    span: tuple[int, int],
+    out_fasta: Path,
+) -> None:
+    """Emit a coordinate-preserving FASTA: real bases across ``span``, ``N`` elsewhere.
+
+    The contig keeps its full length and its original name so that every absolute
+    coordinate in the cache still resolves. Only ``span`` carries real sequence;
+    the rest is ``N`` and compresses to almost nothing in the release tarball.
+    A matching ``.fai`` is written alongside.
+    """
+    span_lo, span_hi = span
+    contig, length, chunks = iter_fasta_record(fasta, fai, region.chrom)
+    span_lo = max(1, span_lo)
+    span_hi = min(span_hi, length)
+
+    # Assemble the contig in memory: `N` everywhere, real bases across the span.
+    # Done with bulk slice assignment rather than per-base Python loops — the
+    # contig is ~50 Mb and a byte-at-a-time loop would take minutes.
+    sequence = bytearray(b"N" * length)
+    pos = 0  # 0-based count of bases consumed from the source so far
+    for chunk in chunks:
+        chunk_lo, chunk_hi = pos + 1, pos + len(chunk)  # 1-based, inclusive
+        lo, hi = max(chunk_lo, span_lo), min(chunk_hi, span_hi)
+        if lo <= hi:
+            sequence[lo - 1 : hi] = chunk[lo - chunk_lo : hi - chunk_lo + 1]
+        pos = chunk_hi
+        if pos >= span_hi:
+            break
+
+    if pos < min(span_hi, length):
+        raise RuntimeError(f"FASTA source ended early at {pos}, span needs {span_hi}")
+
+    out_fasta.parent.mkdir(parents=True, exist_ok=True)
+    header = f">{contig}\n".encode()  # source spelling, not `region.chrom`
+    offset = len(header)
+    with out_fasta.open("wb") as out:
+        out.write(header)
+        for i in range(0, length, FASTA_LINE_WIDTH):
+            out.write(sequence[i : i + FASTA_LINE_WIDTH])
+            out.write(b"\n")
+
+    fai_line = (
+        f"{contig}\t{length}\t{offset}\t{FASTA_LINE_WIDTH}\t{FASTA_LINE_WIDTH + 1}\n"
+    )
+    out_fasta.with_suffix(out_fasta.suffix + ".fai").write_text(fai_line)
+
+
+def write_shard(ctx: SessionContext, table: pa.Table, destination: Path) -> None:
+    """Write a sliced shard as Parquet the engine's point-lookup reader can use.
+
+    The reader (``parquet_cache::page_dir::PageDir``) resolves a position to a
+    data page through the footer's **ColumnIndex/OffsetIndex**, and errors with
+    ``parquet has no column index`` without them. pyarrow's page index is not
+    loaded by that reader, so shards must be written by parquet-rs — which is what
+    the DataFusion ``COPY … STORED AS PARQUET`` writer used here is. Same reason
+    ``tests/cache_metadata.py`` rewrites its fixtures through DataFusion.
+
+    ``skip_arrow_metadata=false`` keeps the Arrow schema metadata
+    (``bio.vep.cache_source_type``, ``bio.vep.sift_blob_version``) that the engine
+    reads off the shard.
+
+    Row ORDER is preserved by the caller's filter, which matters: ``PageDir``
+    derives its sorted runs from the page statistics rather than from the footer's
+    ``sorting_columns``, so the variation shard's warm-then-cold (each ascending by
+    ``start``) layout survives the slice untouched.
+    """
+    if destination.exists():
+        destination.unlink()
+
+    if table.num_rows == 0:
+        # DataFusion's writer cannot handle a zero-batch input, and an empty shard
+        # has no pages to index anyway.
+        pq.write_table(table, destination)
+        return
+
+    ctx.register_record_batches("shard", [table.combine_chunks().to_batches()])
+    try:
+        ctx.sql(
+            f"COPY shard TO '{destination}' STORED AS PARQUET OPTIONS "
+            "('statistics_enabled' 'page', 'skip_arrow_metadata' 'false')"
+        ).collect()
+    finally:
+        ctx.deregister_table("shard")
+
+
+def sha256(path: Path) -> str:
+    """Hex SHA-256 of a file, read incrementally."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def build_mini_cache(
+    source_cache: Path,
+    fasta: Path,
+    output: Path,
+    region: Region,
+) -> dict[str, int]:
+    """Slice ``source_cache`` to ``region`` and cut the matching FASTA window.
+
+    Returns a ``{table: surviving_rows}`` summary.
+    """
+    if output.exists():
+        shutil.rmtree(output)
+    output.mkdir(parents=True)
+
+    # `transcript` must be sliced first: it defines the kept-transcript set that
+    # the membership-filtered tables depend on.
+    ordered = sorted(TABLE_POLICIES, key=lambda p: not p.defines_transcript_set)
+    kept_transcripts: KeptTranscripts | None = None
+    summary: dict[str, int] = {}
+    span = region.padded
+    ctx = SessionContext()
+
+    for policy in ordered:
+        entity_dir = source_cache / policy.name
+        shard = entity_dir / f"{region.chrom}.parquet"
+        if not shard.exists():
+            # A table the source cache does not have for this chromosome. This is
+            # normal, not a defect: `build_parquet_context_chrom` writes no shard
+            # (and no manifest) for an entity with zero rows, and the Ensembl v115
+            # cache ships NO motif features on any chromosome. The runtime's
+            # `context_path` already returns `None` for an absent entity dir, so
+            # mirroring the source's table set exactly — rather than fabricating an
+            # empty shard — keeps the mini cache faithful. If `transcript` itself
+            # were missing we could not build anything, so that one still fails.
+            if policy.defines_transcript_set:
+                raise FileNotFoundError(
+                    f"missing {shard} — the source must be a per-chromosome cache "
+                    f"built by the current engine builders for {region.chrom}"
+                )
+            summary[policy.name] = MISSING_IN_SOURCE
+            continue
+
+        kept = slice_table(shard, policy, region, kept_transcripts)
+
+        if policy.defines_transcript_set:
+            kept_transcripts = KeptTranscripts(
+                stable_ids=kept["stable_id"].combine_chunks(),
+                uids=kept["transcript_uid"].combine_chunks(),
+            )
+            span = feature_closure_span(kept, region)
+
+        out_dir = output / policy.name
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_shard = out_dir / f"{region.chrom}.parquet"
+        write_shard(ctx, kept, out_shard)
+        write_manifest(
+            out_dir,
+            [{"chrom": region.chrom, "dataset": out_shard.name, "rows": kept.num_rows}],
+        )
+        summary[policy.name] = kept.num_rows
+
+    write_fasta_window(
+        fasta,
+        fasta.with_suffix(fasta.suffix + ".fai"),
+        region,
+        span,
+        output / fasta.name,
+    )
+    summary["_fasta_span_start"], summary["_fasta_span_end"] = span
+    return summary
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--source-cache", type=Path, required=True)
+    parser.add_argument("--fasta", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--chrom", default="chr22")
+    parser.add_argument("--start", type=int, default=22_000_000)
+    parser.add_argument("--end", type=int, default=23_500_000)
+    parser.add_argument(
+        "--flank",
+        type=int,
+        default=DEFAULT_FLANK,
+        help=(
+            "bases to pad the region by when selecting features, so transcripts "
+            "just outside it still produce upstream/downstream consequences. Must "
+            "be >= the --distance the cache will be annotated with (default 5000)."
+        ),
+    )
+    args = parser.parse_args()
+
+    region = Region(args.chrom, args.start, args.end, args.flank)
+    summary = build_mini_cache(args.source_cache, args.fasta, args.output, region)
+
+    for table, rows in summary.items():
+        print(f"{table:24s} {rows:>12,}")
+    print(f"\nmini-cache: {args.output}")
+    print(f"fasta sha256: {sha256(args.output / args.fasta.name)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,7 +248,16 @@ fn create_annotator(
 
 #[pymodule]
 fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    let _ = env_logger::try_init();
+    // Default to `warn`, not env_logger's own default of `error`.
+    //
+    // The engine emits its loudest correctness guards at warn level — notably
+    // plugin_cache's "rows > 0 but warm == 0: NOT ONE row joined the variation cache",
+    // which is the single signal that catches a wrong contig naming, a wrong
+    // coordinate_system, or a wrong allele_string format. Under `error` those were
+    // swallowed, so a Python caller with no RUST_LOG set got a green build and silence
+    // for a plugin cache that annotates nothing. RUST_LOG still overrides this.
+    let _ = env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn"))
+        .try_init();
     m.add_class::<annotate::StreamingAnnotator>()?;
     m.add_function(wrap_pyfunction!(build_cache, m)?)?;
     m.add_function(wrap_pyfunction!(build_plugin_cache, m)?)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,11 +133,11 @@ fn build_plugin_cache(
     if let Some(first) = manifest.sources.first_mut() {
         first.path = source_path.to_string();
     }
-    // The builder always rewrites each chrom shard (its `with_overwrite` is a
-    // no-op in v0.14.0), so guard here against an accidental FULL rebuild. A build
-    // is "full" when no chromosome filter narrows it — either `chroms=None` or an
-    // empty list, which `PluginCacheBuilder::with_chrom_filter` also treats as no
-    // filter (resolving/rebuilding every shard). Refuse that without `overwrite`.
+    // The builder always rewrites each chrom shard, so guard here against an
+    // accidental FULL rebuild. A build is "full" when no chromosome filter narrows
+    // it — either `chroms=None` or an empty list, which
+    // `PluginCacheBuilder::with_chrom_filter` also treats as no filter
+    // (resolving/rebuilding every shard). Refuse that without `overwrite`.
     // A non-empty `chroms=[...]` is an explicit, targeted request that upserts into
     // the existing manifest, so it's allowed (enables incremental builds).
     let is_full_build = chroms.as_ref().is_none_or(|c| c.is_empty());
@@ -146,14 +146,15 @@ fn build_plugin_cache(
         .join(&manifest.plugin_name);
     if is_full_build {
         if overwrite {
-            // A full overwrite must start from a clean slate. The builder's
-            // `with_overwrite` is a no-op (it rewrites each shard per chrom), and
-            // `build_all` SEEDS its manifest from any existing plugin manifest,
-            // preserving chroms that are not part of the new build set. So without
-            // wiping first, rebuilding a smaller/different chrom set into the same
-            // root leaves stale chrom entries and shards behind, and `annotate()`
-            // keeps emitting those stale plugin values. Remove the whole plugin
-            // directory (manifest + shards) so only freshly built chroms remain.
+            // A full overwrite must start from a clean slate. As of engine rev
+            // f7b9e66, `with_overwrite(true)` does make `build_all` start from an
+            // EMPTY chrom list instead of seeding from the existing plugin manifest,
+            // so stale *manifest entries* no longer survive a rebuild. But the
+            // builder only writes the shards it builds — it never deletes the shard
+            // FILES of chroms outside the new build set, so a smaller/different
+            // chrom set would still leave orphan `<chrom>.parquet` files in the
+            // plugin dir. Wipe the whole plugin directory (manifest + shards) so
+            // only freshly built chroms remain on disk as well as in the manifest.
             if plugin_dir.exists() {
                 std::fs::remove_dir_all(&plugin_dir).map_err(|e| {
                     pyo3::exceptions::PyValueError::new_err(format!(

--- a/src/vepyr/parity.py
+++ b/src/vepyr/parity.py
@@ -248,6 +248,64 @@ class ComparisonResult:
     field_mismatch_examples: dict[str, list[FieldMismatch]] = field(
         default_factory=dict
     )
+    mismatch_keys: dict[str, set[str]] = field(default_factory=dict)
+    """Per field: EVERY variant key that mismatched — uncapped, unlike the examples.
+
+    Keys are rendered exactly as :attr:`FieldMismatch.key`
+    (``CHROM\\tPOS\\tREF\\tALT``). A field compared without a single mismatch maps
+    to an empty set, never to a missing entry, so a consumer may index any
+    compared field. Membership tracks :attr:`field_mismatches` exactly: an
+    order-only ``a&b`` difference counts as a match, so its key is *not* here.
+
+    This exists for the plugin-parity gate's **blame-attribution rule**. A
+    plugin's CSQ fields are derived from core engine attributes — AlphaMissense
+    keys its lookup on ``{ref_aa}{Protein_position}{alt_aa}``, built from
+    ``Amino_acids`` and ``Protein_position`` — so when vepyr's *core* diverges
+    from VEP, the plugin is handed a wrong lookup key and its field comes out
+    wrong through no fault of its own. The gate therefore takes two verdicts
+    over the same pair of files and subtracts::
+
+        core = compare_csq_fields(vep, vepyr, fields=CORE_FIELDS)
+        plugin = compare_csq_fields(vep, vepyr, fields=plugin.csq_fields)
+        core_diverged = set().union(*core.mismatch_keys.values())
+        plugin_failed = set().union(*plugin.mismatch_keys.values())
+        genuine_plugin_failures = plugin_failed - core_diverged
+
+    For that subtraction to be sound the exclusion set must be *complete*. The
+    capped :attr:`field_mismatch_examples` cannot serve: an approximate
+    exclusion set is worse than none, because it silently attributes core bugs
+    to plugins on precisely the long tail it cannot see.
+
+    Note this is a set of *variants*, not of entry pairs: a variant whose three
+    overlapping transcripts all mismatch counts three times in
+    :attr:`field_mismatches` but appears once here — one variant to exclude.
+
+    Memory is bounded by the number of *mismatching variants*, not by the number
+    of comparisons, and the key strings are shared between the per-field sets
+    rather than copied into each. Measured cost is ~42 bytes per (field, key)
+    set slot, plus ~55 bytes per distinct key string, counted once.
+
+    * Steady state — the clean or near-clean run this gate exists to defend:
+      essentially free (empty sets).
+    * A realistic failing run — a few fields diverging on a few percent of
+      variants: tens of MB.
+    * Worst case — a catastrophically broken run in which all ~60 fields
+      mismatch on every variant. Note the WGS benchmark compares **one
+      chromosome per call** (``run_annotation_fast.py``), so a single result
+      spans ~350k variants at most, not 4M: ~21M slots, ~0.9 GB. Only a caller
+      that compared all ~4M variants in one call would reach ~240M slots,
+      ~10 GB.
+
+    That ceiling is accepted rather than capped, for two reasons. It is a
+    total-failure run whose report is worthless anyway — nobody attributes blame
+    on a run where every field is wrong. And it is not a *new* order of cost:
+    :func:`_keyed_csq` already materialises both entire VCFs in memory, CSQ
+    strings and all, before a single comparison happens — that is the dominant
+    term at any realistic mismatch rate. Should a pathological run ever need
+    comparing without this cost, the fix is to make population **opt-out via a
+    flag**, never to cap the set: a capped exclusion set silently corrupts the
+    verdict it feeds, whereas an absent one fails loudly.
+    """
     field_order_mismatches: dict[str, int] = field(default_factory=dict)
     """Per field: same multi-values (``a&b``) in a different order — counted as matches."""
     field_order_mismatch_examples: dict[str, list[FieldMismatch]] = field(
@@ -374,6 +432,11 @@ def compare_csq_fields(
             :data:`VEP_HASH_ORDER_PICK_IGNORE_REASON`. Entry counts and every
             field value are still compared strictly.
         max_examples: Worked examples retained per mismatch class per field.
+            This caps :attr:`~ComparisonResult.field_mismatch_examples` only; it
+            does **not** bound :attr:`~ComparisonResult.mismatch_keys`, which is
+            complete by construction because the plugin gate's blame rule
+            subtracts with it and a partial exclusion set would silently blame
+            plugins for core bugs.
 
     Returns:
         The :class:`ComparisonResult` verdict.
@@ -416,6 +479,7 @@ def compare_csq_fields(
         field_matches=dict.fromkeys(compared, 0),
         field_mismatches=dict.fromkeys(compared, 0),
         field_mismatch_examples={f: [] for f in compared},
+        mismatch_keys={f: set() for f in compared},
         field_order_mismatches=dict.fromkeys(compared, 0),
         field_order_mismatch_examples={f: [] for f in compared},
         over_emissions=dict.fromkeys(compared, 0),
@@ -522,6 +586,11 @@ def compare_csq_fields(
                     result.field_mismatches[f] += 1
                     if mismatch.is_over_emission:
                         result.over_emissions[f] += 1
+                    # The examples are a capped report; the key set is the
+                    # complete record the plugin gate's blame rule subtracts
+                    # with. `key_str` is one object per variant, shared by every
+                    # field's set rather than copied into each.
+                    result.mismatch_keys[f].add(key_str)
                     if len(result.field_mismatch_examples[f]) < max_examples:
                         result.field_mismatch_examples[f].append(mismatch)
 

--- a/src/vepyr/parity.py
+++ b/src/vepyr/parity.py
@@ -1,0 +1,621 @@
+"""Field-by-field CSQ parity comparison between an Ensembl VEP VCF and vepyr's.
+
+This is the single implementation of the comparison that decides whether vepyr
+agrees with Ensembl VEP. It has two consumers:
+
+* the WGS benchmark (``e2e-testing/scripts/run_annotation_fast.py``), which
+  compares every shared CSQ field over ~4M variants and prints/serialises a
+  report — see :func:`compare_vcfs`;
+* the plugin-parity gate (``vepyr-plugins``), which compares *only* a ported
+  plugin's own CSQ fields and demands 100% — see :func:`compare_csq_fields`.
+
+Terminology: **truth** is the Ensembl VEP output, **test** is the vepyr output.
+The comparison is deliberately asymmetric in its reading but symmetric in its
+arithmetic: a value vepyr emits where VEP emitted nothing (*over-emission*) is a
+mismatch, exactly like a value it failed to emit. A plugin that fires more often
+than upstream is not a bonus, it is a bug.
+
+Comparison semantics (unchanged from the original benchmark implementation):
+
+* Variants are merge-joined on ``(CHROM, POS, REF, ALT)``; unmatched keys on
+  either side are counted, never compared.
+* Within a variant, CSQ entries are paired by ``(Feature, Consequence)`` so that
+  field comparison is meaningful regardless of emission order; the number of
+  entries is compared strictly.
+* The *comma order* of CSQ entries is compared strictly by default and reported
+  separately (it is not a field mismatch). See :func:`compare_csq_fields` and
+  :data:`VEP_HASH_ORDER_PICK_IGNORE_REASON` for the one case where it is
+  deliberately ignored.
+* Within a multi-valued field (``a&b``), a pure ordering difference counts as a
+  match and is reported separately as an *order-only* difference.
+"""
+
+from __future__ import annotations
+
+import gzip
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import IO, Final
+
+__all__ = [
+    "VEP_HASH_ORDER_PICK_IGNORE_REASON",
+    "ComparisonResult",
+    "EntryOrderMismatch",
+    "FieldMismatch",
+    "compare_csq_fields",
+    "compare_vcfs",
+    "count_data_lines",
+    "csq_format_fields",
+    "open_text",
+]
+
+#: Number of worked examples retained per mismatch class (a report, not a dump).
+MAX_EXAMPLES: Final = 10
+
+_CSQ_VALUE_RE: Final = re.compile(r"CSQ=([^;\t]+)")
+_CSQ_FORMAT_RE: Final = re.compile(r"Format: ([^\"]+)")
+_CSQ_HEADER_PREFIX: Final = "##INFO=<ID=CSQ"
+
+#: The rationale for ``ignore_entry_order``. Recorded on the result (and in the
+#: benchmark's JSON report) so that a run which ignored CSQ comma order says so,
+#: and says why.
+VEP_HASH_ORDER_PICK_IGNORE_REASON: Final = (
+    "CSQ entry order is ignored for per_gene and pick_allele_gene because "
+    "Ensembl VEP selects the representative consequences, then emits those "
+    "winners by iterating Perl hashes (`keys %by_gene`; for pick_allele_gene "
+    "also `keys %by_allele`). The comma order of those already-selected CSQ "
+    "entries has no biological or interpretation meaning; it is not a severity, "
+    "transcript-priority, genomic, MANE, or canonical ranking. The meaningful "
+    "checks are the selected CSQ entries, entry counts, and field values."
+)
+
+#: A variant identity: ``(chrom, pos, ref, alt)``.
+VariantKey = tuple[str, int, str, str]
+
+
+def open_text(path: str | Path) -> IO[str]:
+    """Open a VCF for text reading, transparently handling ``.gz`` (bgzf/gzip)."""
+    path = str(path)
+    if path.endswith((".gz", ".bgz", ".bgzf")):
+        return gzip.open(path, "rt")
+    return open(path)
+
+
+def count_data_lines(path: str | Path) -> int:
+    """Count non-header lines in a VCF (plain or ``.gz``)."""
+    n = 0
+    with open_text(path) as f:
+        for line in f:
+            if not line.startswith("#"):
+                n += 1
+    return n
+
+
+def csq_format_fields(path: str | Path) -> list[str]:
+    """Return the CSQ field names declared by a VCF's ``##INFO=<ID=CSQ`` header.
+
+    Returns an empty list if the VCF carries no CSQ header (or no ``Format:``
+    spec within it), which in turn makes every field unshared and uncomparable.
+    """
+    with open_text(path) as f:
+        for line in f:
+            if line.startswith(_CSQ_HEADER_PREFIX):
+                m = _CSQ_FORMAT_RE.search(line)
+                return m.group(1).split("|") if m else []
+    return []
+
+
+def _keyed_csq(path: str | Path) -> list[tuple[VariantKey, str]]:
+    """Return ``(key, raw_csq)`` pairs sorted by key, ready for a merge-join."""
+    rows: list[tuple[VariantKey, str]] = []
+    with open_text(path) as f:
+        for line in f:
+            if line.startswith("#"):
+                continue
+            cols = line.split("\t", 9)
+            m = _CSQ_VALUE_RE.search(cols[7])
+            csq = m.group(1) if m else ""
+            key: VariantKey = (cols[0], int(cols[1]), cols[3], cols[4])
+            rows.append((key, csq))
+    rows.sort()
+    return rows
+
+
+def _parse_entries(raw: str, fields: Sequence[str]) -> list[dict[str, str]]:
+    """Split a raw CSQ value into per-entry ``field -> value`` mappings."""
+    return [dict(zip(fields, entry.split("|"))) for entry in raw.split(",")]
+
+
+def _pairing_key(entry: dict[str, str]) -> tuple[str, str]:
+    """Sort key used to pair a vepyr CSQ entry with its VEP counterpart."""
+    return (entry.get("Feature", ""), entry.get("Consequence", ""))
+
+
+@dataclass(frozen=True, slots=True)
+class FieldMismatch:
+    """One worked example of a field-level disagreement.
+
+    A bare count is useless for debugging, so every example carries the variant
+    key *and* both values.
+    """
+
+    key: str
+    """The variant, as ``CHROM\\tPOS\\tREF\\tALT``."""
+    truth: str
+    """The value Ensembl VEP emitted (``""`` if it emitted none)."""
+    test: str
+    """The value vepyr emitted (``""`` if it emitted none)."""
+
+    @property
+    def is_over_emission(self) -> bool:
+        """True if vepyr populated a field that VEP left empty."""
+        return self.truth == "" and self.test != ""
+
+    def as_report_dict(self) -> dict[str, str]:
+        """Render as the benchmark report's example shape."""
+        return {"variant": self.key, "vepyr": self.test, "vep": self.truth}
+
+
+@dataclass(frozen=True, slots=True)
+class EntryOrderMismatch:
+    """One worked example of a CSQ *comma order* disagreement.
+
+    The same entries are present on both sides; only their emission order
+    differs. This is tracked apart from field mismatches because it is a
+    different kind of defect (see :data:`VEP_HASH_ORDER_PICK_IGNORE_REASON`).
+    """
+
+    key: str
+    """The variant, as ``CHROM\\tPOS\\tREF\\tALT``."""
+    truth_features: tuple[str, ...]
+    """``Feature`` of each CSQ entry, in the order Ensembl VEP emitted them."""
+    test_features: tuple[str, ...]
+    """``Feature`` of each CSQ entry, in the order vepyr emitted them."""
+
+    def as_report_dict(self) -> dict[str, str | list[str]]:
+        """Render as the benchmark report's example shape."""
+        return {
+            "variant": self.key,
+            "vepyr_order": list(self.test_features),
+            "vep_order": list(self.truth_features),
+        }
+
+
+@dataclass(slots=True)
+class ComparisonResult:
+    """The verdict of a CSQ comparison between a VEP VCF and a vepyr VCF."""
+
+    fields_compared: tuple[str, ...]
+    """CSQ fields actually compared, in report order."""
+    fields_only_in_test: tuple[str, ...]
+    """CSQ fields declared by vepyr's header but not VEP's (never compared)."""
+    fields_only_in_truth: tuple[str, ...]
+    """CSQ fields declared by VEP's header but not vepyr's (never compared)."""
+    fields_missing_from_test: tuple[str, ...]
+    """Explicitly requested fields absent from vepyr's CSQ header."""
+    fields_missing_from_truth: tuple[str, ...]
+    """Explicitly requested fields absent from VEP's CSQ header."""
+
+    keys_compared: int
+    """Variants present, and therefore compared, on both sides."""
+    keys_only_in_test: int
+    """Variants vepyr emitted that VEP did not."""
+    keys_only_in_truth: int
+    """Variants VEP emitted that vepyr did not."""
+
+    entry_count_match: int
+    """Compared variants where both sides emitted the same number of CSQ entries."""
+    entry_count_mismatch: int
+    """Compared variants where the sides disagreed on the CSQ entry count."""
+    entry_order_mismatch: int
+    """Compared variants with the same CSQ entries in a different comma order."""
+    entry_order_ignored: int
+    """Entry-order differences waived by ``ignore_entry_order``."""
+    entry_order_mismatch_examples: list[EntryOrderMismatch]
+    entry_order_ignored_examples: list[EntryOrderMismatch]
+    entry_order_ignore_reason: str | None
+    """Why entry order was ignored, or ``None`` if it was compared strictly."""
+
+    field_totals: dict[str, int] = field(default_factory=dict)
+    """Per field: CSQ entry pairs compared."""
+    field_matches: dict[str, int] = field(default_factory=dict)
+    """Per field: equal values (incl. order-only ``a&b`` differences)."""
+    field_mismatches: dict[str, int] = field(default_factory=dict)
+    """Per field: genuinely different values."""
+    field_mismatch_examples: dict[str, list[FieldMismatch]] = field(
+        default_factory=dict
+    )
+    field_order_mismatches: dict[str, int] = field(default_factory=dict)
+    """Per field: same multi-values (``a&b``) in a different order — counted as matches."""
+    field_order_mismatch_examples: dict[str, list[FieldMismatch]] = field(
+        default_factory=dict
+    )
+    over_emissions: dict[str, int] = field(default_factory=dict)
+    """Per field: mismatches where vepyr emitted a value and VEP emitted none.
+
+    A strict subset of :attr:`field_mismatches`: over-emission is a failure, not
+    a bonus, and is only broken out to name the failure mode.
+    """
+
+    @property
+    def field_match_rates(self) -> dict[str, float]:
+        """Per field: percentage of compared entry pairs that matched."""
+        return {
+            f: round(self.field_matches[f] / self.field_totals[f] * 100, 4)
+            for f in self.fields_compared
+            if self.field_totals[f] > 0
+        }
+
+    @property
+    def mismatched_fields(self) -> tuple[str, ...]:
+        """Compared fields with at least one genuine value mismatch."""
+        return tuple(f for f in self.fields_compared if self.field_mismatches[f] > 0)
+
+    @property
+    def is_clean(self) -> bool:
+        """True if this is a pass: nothing to explain away.
+
+        Clean means every compared field agreed on every compared variant, both
+        sides emitted the same variants and the same number of CSQ entries per
+        variant in the same (or a deliberately-ignored) order, and every field
+        that was asked for actually existed on both sides.
+        """
+        return (
+            not self.mismatched_fields
+            and not self.fields_missing_from_test
+            and not self.fields_missing_from_truth
+            and self.entry_count_mismatch == 0
+            and self.entry_order_mismatch == 0
+            and self.keys_only_in_test == 0
+            and self.keys_only_in_truth == 0
+        )
+
+    def as_report_dict(self) -> dict[str, object]:
+        """Render the benchmark's JSON report payload.
+
+        The key names and the "only non-zero entries" filtering are load-bearing:
+        ``run_annotation_fast_all.py`` and every archived report read this shape.
+        """
+        return {
+            "variants_compared": self.keys_compared,
+            "variants_only_in_vepyr": self.keys_only_in_test,
+            "csq_order_mismatch": self.entry_order_mismatch,
+            "csq_order_mismatch_examples": [
+                ex.as_report_dict() for ex in self.entry_order_mismatch_examples
+            ],
+            "csq_order_ignored": self.entry_order_ignored,
+            "csq_order_ignored_examples": [
+                ex.as_report_dict() for ex in self.entry_order_ignored_examples
+            ],
+            "csq_order_ignore_reason": self.entry_order_ignore_reason,
+            "variants_only_in_vep": self.keys_only_in_truth,
+            "csq_entry_count_match": self.entry_count_match,
+            "csq_entry_count_mismatch": self.entry_count_mismatch,
+            "field_match_rates": self.field_match_rates,
+            "field_mismatch_counts": {
+                f: self.field_mismatches[f]
+                for f in self.fields_compared
+                if self.field_mismatches[f] > 0
+            },
+            "field_mismatch_examples": {
+                f: [ex.as_report_dict() for ex in self.field_mismatch_examples[f]]
+                for f in self.fields_compared
+                if self.field_mismatch_examples[f]
+            },
+            "field_order_mismatch_counts": {
+                f: self.field_order_mismatches[f]
+                for f in self.fields_compared
+                if self.field_order_mismatches[f] > 0
+            },
+            "field_order_mismatch_examples": {
+                f: [ex.as_report_dict() for ex in self.field_order_mismatch_examples[f]]
+                for f in self.fields_compared
+                if self.field_order_mismatch_examples[f]
+            },
+        }
+
+
+def compare_csq_fields(
+    truth_vcf: str | Path,
+    test_vcf: str | Path,
+    fields: Sequence[str] | None = None,
+    *,
+    ignore_entry_order: bool = False,
+    max_examples: int = MAX_EXAMPLES,
+) -> ComparisonResult:
+    """Compare the CSQ fields of a vepyr VCF against an Ensembl VEP VCF.
+
+    Variants are merge-joined on ``(CHROM, POS, REF, ALT)``. Within a matched
+    variant, CSQ entries are paired by ``(Feature, Consequence)`` and compared
+    field by field; entry counts are compared strictly.
+
+    Args:
+        truth_vcf: Ensembl VEP output (plain or gzipped).
+        test_vcf: vepyr output (plain or gzipped).
+        fields: CSQ fields to compare. ``None`` compares every field shared by
+            both headers (the WGS benchmark). A plugin gate passes just that
+            plugin's fields, so that drift in the core fields — a separate
+            verdict — does not contaminate this one. Requested fields that are
+            absent from either header are not compared; they are reported in
+            :attr:`ComparisonResult.fields_missing_from_test` /
+            :attr:`~ComparisonResult.fields_missing_from_truth` and make the
+            result unclean.
+        ignore_entry_order: Waive CSQ *comma order* differences (same entries,
+            different order). Set this only for VEP's ``--per_gene`` and
+            ``--pick_allele_gene`` outputs; see
+            :data:`VEP_HASH_ORDER_PICK_IGNORE_REASON`. Entry counts and every
+            field value are still compared strictly.
+        max_examples: Worked examples retained per mismatch class per field.
+
+    Returns:
+        The :class:`ComparisonResult` verdict.
+    """
+    truth_fields = csq_format_fields(truth_vcf)
+    test_fields = csq_format_fields(test_vcf)
+    shared = [f for f in test_fields if f in truth_fields]
+
+    if fields is None:
+        compared = list(shared)
+        missing_from_test: tuple[str, ...] = ()
+        missing_from_truth: tuple[str, ...] = ()
+    else:
+        shared_set = set(shared)
+        compared = [f for f in fields if f in shared_set]
+        missing_from_test = tuple(f for f in fields if f not in test_fields)
+        missing_from_truth = tuple(f for f in fields if f not in truth_fields)
+
+    result = ComparisonResult(
+        fields_compared=tuple(compared),
+        fields_only_in_test=tuple(sorted(set(test_fields) - set(truth_fields))),
+        fields_only_in_truth=tuple(sorted(set(truth_fields) - set(test_fields))),
+        fields_missing_from_test=missing_from_test,
+        fields_missing_from_truth=missing_from_truth,
+        keys_compared=0,
+        keys_only_in_test=0,
+        keys_only_in_truth=0,
+        entry_count_match=0,
+        entry_count_mismatch=0,
+        entry_order_mismatch=0,
+        entry_order_ignored=0,
+        entry_order_mismatch_examples=[],
+        entry_order_ignored_examples=[],
+        entry_order_ignore_reason=(
+            VEP_HASH_ORDER_PICK_IGNORE_REASON if ignore_entry_order else None
+        ),
+        field_totals=dict.fromkeys(compared, 0),
+        field_matches=dict.fromkeys(compared, 0),
+        field_mismatches=dict.fromkeys(compared, 0),
+        field_mismatch_examples={f: [] for f in compared},
+        field_order_mismatches=dict.fromkeys(compared, 0),
+        field_order_mismatch_examples={f: [] for f in compared},
+        over_emissions=dict.fromkeys(compared, 0),
+    )
+
+    test_rows = _keyed_csq(test_vcf)
+    truth_rows = _keyed_csq(truth_vcf)
+
+    i, j = 0, 0
+    while i < len(test_rows) and j < len(truth_rows):
+        test_key, test_csq = test_rows[i]
+        truth_key, truth_csq = truth_rows[j]
+
+        if test_key < truth_key:
+            result.keys_only_in_test += 1
+            i += 1
+            continue
+        elif test_key > truth_key:
+            result.keys_only_in_truth += 1
+            j += 1
+            continue
+
+        result.keys_compared += 1
+        key_str = f"{test_key[0]}\t{test_key[1]}\t{test_key[2]}\t{test_key[3]}"
+
+        if test_csq and truth_csq:
+            test_parsed = _parse_entries(test_csq, test_fields)
+            truth_parsed = _parse_entries(truth_csq, truth_fields)
+
+            # Detect CSQ entry ordering mismatch before sorting for comparison
+            test_order = [e.get("Feature", "") for e in test_parsed]
+            truth_order = [e.get("Feature", "") for e in truth_parsed]
+            if test_order != truth_order and sorted(test_order) == sorted(truth_order):
+                example = EntryOrderMismatch(
+                    key=key_str,
+                    truth_features=tuple(truth_order),
+                    test_features=tuple(test_order),
+                )
+                # Ensembl VEP's --per_gene and --pick_allele_gene paths group
+                # transcript alleles in Perl hashes, choose representative
+                # consequences, then emit winners with `keys %by_gene` and, for
+                # pick_allele_gene, `keys %by_allele`. The comma order of those
+                # already-selected CSQ entries has no biological or
+                # interpretation meaning: it is not a severity,
+                # transcript-priority, genomic, MANE, or canonical ranking.
+                # Ignoring only this order therefore does not change
+                # interpretation; entry counts and every CSQ field value are
+                # still compared strictly.
+                if ignore_entry_order:
+                    result.entry_order_ignored += 1
+                    if len(result.entry_order_ignored_examples) < max_examples:
+                        result.entry_order_ignored_examples.append(example)
+                else:
+                    result.entry_order_mismatch += 1
+                    if len(result.entry_order_mismatch_examples) < max_examples:
+                        result.entry_order_mismatch_examples.append(example)
+
+            # Sort by Feature for stable pairing (so field comparison is meaningful)
+            test_parsed.sort(key=_pairing_key)
+            truth_parsed.sort(key=_pairing_key)
+
+            if len(test_parsed) == len(truth_parsed):
+                result.entry_count_match += 1
+            else:
+                result.entry_count_mismatch += 1
+
+            for ei in range(min(len(test_parsed), len(truth_parsed))):
+                test_vals = test_parsed[ei]
+                truth_vals = truth_parsed[ei]
+
+                for f in compared:
+                    result.field_totals[f] += 1
+                    tv = test_vals.get(f, "")
+                    gv = truth_vals.get(f, "")
+                    if tv == gv:
+                        result.field_matches[f] += 1
+                        continue
+
+                    # Check if it's just an &-ordering difference
+                    if "&" in tv or "&" in gv:
+                        tv_norm = "&".join(sorted(tv.split("&")))
+                        gv_norm = "&".join(sorted(gv.split("&")))
+                        if tv_norm == gv_norm:
+                            # Same values, different order
+                            result.field_matches[f] += 1
+                            result.field_order_mismatches[f] += 1
+                            if (
+                                len(result.field_order_mismatch_examples[f])
+                                < max_examples
+                            ):
+                                result.field_order_mismatch_examples[f].append(
+                                    FieldMismatch(key=key_str, truth=gv, test=tv)
+                                )
+                            continue
+
+                    mismatch = FieldMismatch(key=key_str, truth=gv, test=tv)
+                    result.field_mismatches[f] += 1
+                    if mismatch.is_over_emission:
+                        result.over_emissions[f] += 1
+                    if len(result.field_mismatch_examples[f]) < max_examples:
+                        result.field_mismatch_examples[f].append(mismatch)
+
+        i += 1
+        j += 1
+
+    result.keys_only_in_test += len(test_rows) - i
+    result.keys_only_in_truth += len(truth_rows) - j
+    return result
+
+
+def compare_vcfs(
+    vepyr_vcf: str | Path,
+    vep_vcf: str | Path,
+    label: str,
+    ignore_csq_order: bool = False,
+    *,
+    backend: str = "parquet",
+) -> dict[str, object]:
+    """Field-by-field CSQ comparison between vepyr and VEP output.
+
+    The WGS benchmark's entry point: runs :func:`compare_csq_fields` over every
+    shared CSQ field, prints the human-readable report, and returns the JSON
+    report payload consumed by ``run_annotation_fast_all.py``.
+
+    Args:
+        vepyr_vcf: vepyr's annotated output (the *test* side).
+        vep_vcf: the Ensembl VEP reference (the *truth* side).
+        label: Report label, typically the chromosome.
+        ignore_csq_order: See ``ignore_entry_order`` in :func:`compare_csq_fields`.
+        backend: Cache backend name, for the report header only.
+
+    Returns:
+        The report payload — see :meth:`ComparisonResult.as_report_dict`.
+    """
+    print()
+    print("=" * 60)
+    print(f"Comparing vepyr ({backend}) vs VEP — {label}")
+    print("=" * 60)
+
+    n_vepyr = count_data_lines(vepyr_vcf)
+    n_vep = count_data_lines(vep_vcf)
+    print(f"  vepyr:  {n_vepyr:,} data lines")
+    print(f"  VEP:    {n_vep:,} data lines")
+
+    vepyr_fields = set(csq_format_fields(vepyr_vcf))
+    vep_fields = set(csq_format_fields(vep_vcf))
+    fields_only_vepyr = sorted(vepyr_fields - vep_fields)
+    fields_only_vep = sorted(vep_fields - vepyr_fields)
+    if fields_only_vepyr:
+        print(f"  Fields only in vepyr: {fields_only_vepyr}")
+    if fields_only_vep:
+        print(f"  Fields only in VEP:   {fields_only_vep}")
+
+    print("  Building sorted key+CSQ lists ...")
+    result = compare_csq_fields(
+        vep_vcf,
+        vepyr_vcf,
+        ignore_entry_order=ignore_csq_order,
+    )
+    shared_fields = result.fields_compared
+
+    # Print results
+    print("\n  Results:")
+    print(f"    Variants compared:        {result.keys_compared:,}")
+    print(f"    Only in vepyr:            {result.keys_only_in_test:,}")
+    print(f"    Only in VEP:              {result.keys_only_in_truth:,}")
+    print(f"    CSQ count match:          {result.entry_count_match:,}")
+    print(f"    CSQ count mismatch:       {result.entry_count_mismatch:,}")
+    print(
+        f"    CSQ order mismatch:       {result.entry_order_mismatch:,}  (same entries, wrong order — issue #83)"
+    )
+    if ignore_csq_order:
+        print(
+            f"    CSQ order ignored:        {result.entry_order_ignored:,}  "
+            "(VEP hash-order only)"
+        )
+
+    if result.entry_order_mismatch_examples:
+        print("\n  CSQ order mismatch examples:")
+        for order_ex in result.entry_order_mismatch_examples:
+            print(f"    {order_ex.key}")
+            print(f"      vepyr: {', '.join(order_ex.test_features)}")
+            print(f"      VEP:   {', '.join(order_ex.truth_features)}")
+
+    print(f"\n  Per-field match rates ({result.keys_compared:,} variants):")
+    print(
+        f"  {'Field':<30} {'Match%':>8} {'Matches':>10} {'Mismatches':>10} {'OrderOnly':>10} {'Total':>10}"
+    )
+    print(f"  {'-' * 30} {'-' * 8} {'-' * 10} {'-' * 10} {'-' * 10} {'-' * 10}")
+    for f in shared_fields:
+        total = result.field_totals[f]
+        matches = result.field_matches[f]
+        mismatches = result.field_mismatches[f]
+        order_only = result.field_order_mismatches[f]
+        rate = (matches / total * 100) if total > 0 else 0
+        flag = ""
+        if mismatches > 0:
+            flag = " <--"
+        elif order_only > 0:
+            flag = " (order)"
+        print(
+            f"  {f:<30} {rate:>7.2f}% {matches:>10,} {mismatches:>10,} {order_only:>10,} {total:>10,}{flag}"
+        )
+
+    fields_with_order_issues = [
+        f for f in shared_fields if result.field_order_mismatches[f] > 0
+    ]
+    if fields_with_order_issues:
+        print("\n  &-order mismatch examples (same values, different order):")
+        for f in fields_with_order_issues:
+            print(
+                f"\n    {f} ({result.field_order_mismatches[f]:,} &-order mismatches):"
+            )
+            for ex in result.field_order_mismatch_examples[f]:
+                print(f"      {ex.key}")
+                print(f"        vepyr: {ex.test!r}")
+                print(f"        VEP:   {ex.truth!r}")
+
+    fields_with_mismatches = result.mismatched_fields
+    if fields_with_mismatches:
+        print("\n  Mismatch examples:")
+        for f in fields_with_mismatches:
+            print(f"\n    {f} ({result.field_mismatches[f]:,} mismatches):")
+            for ex in result.field_mismatch_examples[f]:
+                print(f"      {ex.key}")
+                print(f"        vepyr: {ex.test!r}")
+                print(f"        VEP:   {ex.truth!r}")
+    else:
+        print(f"\n  ALL {len(shared_fields)} shared CSQ fields match at 100%!")
+
+    return result.as_report_dict()

--- a/src/vepyr/parity.py
+++ b/src/vepyr/parity.py
@@ -108,13 +108,23 @@ def csq_format_fields(path: str | Path) -> list[str]:
 
 
 def _keyed_csq(path: str | Path) -> list[tuple[VariantKey, str]]:
-    """Return ``(key, raw_csq)`` pairs sorted by key, ready for a merge-join."""
+    """Return ``(key, raw_csq)`` pairs sorted by key, ready for a merge-join.
+
+    The record terminator is stripped before the line is split into columns. It
+    is not part of any field — a VCF field cannot contain CR or LF, since those
+    *are* the record separator — so stripping it cannot eat a legitimate value.
+    It matters because in a sites-only (8-column) VCF, INFO is the final column,
+    so the terminator sits immediately after the last CSQ field; left in place it
+    would be captured as part of that field's value (``[^;\\t]`` matches ``\\n``).
+    That is precisely where plugin fields live: they are appended to the end of
+    VEP's CSQ ``Format`` string.
+    """
     rows: list[tuple[VariantKey, str]] = []
     with open_text(path) as f:
         for line in f:
             if line.startswith("#"):
                 continue
-            cols = line.split("\t", 9)
+            cols = line.rstrip("\r\n").split("\t", 9)
             m = _CSQ_VALUE_RE.search(cols[7])
             csq = m.group(1) if m else ""
             key: VariantKey = (cols[0], int(cols[1]), cols[3], cols[4])
@@ -205,6 +215,17 @@ class ComparisonResult:
     keys_only_in_truth: int
     """Variants VEP emitted that vepyr did not."""
 
+    csq_missing_in_test: int
+    """Compared variants that VEP annotated but vepyr left with no CSQ at all.
+
+    A total annotation dropout: with no CSQ to parse, such a variant contributes
+    no field totals and no entry counts, so it is invisible in every other
+    counter. A plugin cache that annotated *nothing* would otherwise show a
+    perfectly clean field table. It gets its own bucket for that reason.
+    """
+    csq_missing_in_truth: int
+    """Compared variants that vepyr annotated but VEP left with no CSQ at all."""
+
     entry_count_match: int
     """Compared variants where both sides emitted the same number of CSQ entries."""
     entry_count_mismatch: int
@@ -259,8 +280,9 @@ class ComparisonResult:
 
         Clean means every compared field agreed on every compared variant, both
         sides emitted the same variants and the same number of CSQ entries per
-        variant in the same (or a deliberately-ignored) order, and every field
-        that was asked for actually existed on both sides.
+        variant in the same (or a deliberately-ignored) order, neither side
+        dropped a variant's annotation entirely, and every field that was asked
+        for actually existed on both sides.
         """
         return (
             not self.mismatched_fields
@@ -270,6 +292,8 @@ class ComparisonResult:
             and self.entry_order_mismatch == 0
             and self.keys_only_in_test == 0
             and self.keys_only_in_truth == 0
+            and self.csq_missing_in_test == 0
+            and self.csq_missing_in_truth == 0
         )
 
     def as_report_dict(self) -> dict[str, object]:
@@ -291,6 +315,8 @@ class ComparisonResult:
             ],
             "csq_order_ignore_reason": self.entry_order_ignore_reason,
             "variants_only_in_vep": self.keys_only_in_truth,
+            "csq_missing_in_vepyr": self.csq_missing_in_test,
+            "csq_missing_in_vep": self.csq_missing_in_truth,
             "csq_entry_count_match": self.entry_count_match,
             "csq_entry_count_mismatch": self.entry_count_mismatch,
             "field_match_rates": self.field_match_rates,
@@ -375,6 +401,8 @@ def compare_csq_fields(
         keys_compared=0,
         keys_only_in_test=0,
         keys_only_in_truth=0,
+        csq_missing_in_test=0,
+        csq_missing_in_truth=0,
         entry_count_match=0,
         entry_count_mismatch=0,
         entry_order_mismatch=0,
@@ -412,6 +440,13 @@ def compare_csq_fields(
 
         result.keys_compared += 1
         key_str = f"{test_key[0]}\t{test_key[1]}\t{test_key[2]}\t{test_key[3]}"
+
+        # A variant one side left entirely unannotated has no CSQ to parse, so it
+        # can reach no other counter. Count it here or it vanishes.
+        if not test_csq and truth_csq:
+            result.csq_missing_in_test += 1
+        elif test_csq and not truth_csq:
+            result.csq_missing_in_truth += 1
 
         if test_csq and truth_csq:
             test_parsed = _parse_entries(test_csq, test_fields)
@@ -554,6 +589,14 @@ def compare_vcfs(
     print(f"    Variants compared:        {result.keys_compared:,}")
     print(f"    Only in vepyr:            {result.keys_only_in_test:,}")
     print(f"    Only in VEP:              {result.keys_only_in_truth:,}")
+    print(
+        f"    CSQ missing in vepyr:     {result.csq_missing_in_test:,}"
+        "  (VEP annotated it, vepyr emitted no CSQ)"
+    )
+    print(
+        f"    CSQ missing in VEP:       {result.csq_missing_in_truth:,}"
+        "  (vepyr annotated it, VEP emitted no CSQ)"
+    )
     print(f"    CSQ count match:          {result.entry_count_match:,}")
     print(f"    CSQ count mismatch:       {result.entry_count_mismatch:,}")
     print(

--- a/tests/test_build_mini_cache.py
+++ b/tests/test_build_mini_cache.py
@@ -1,0 +1,475 @@
+"""Tests for ``scripts/build_mini_cache.py`` — the region mini-cache fixture.
+
+The mini-cache is the vepyr half of the plugin-parity gate: CI cannot ship the
+~34 GB production cache, so the gate runs against a region slice. That makes the
+slicer load-bearing in a nasty way — **a mini-cache that silently drops a feature
+manufactures phantom "core drift"**, and the parity gate's entire job is to tell
+core drift apart from plugin bugs. A slicer bug would therefore not fail loudly;
+it would quietly invalidate every verdict the gate produces.
+
+So these tests pin the two ways a slice loses data, both on synthetic parquet
+tables that mirror the real cache schemas (no 34 GB fixture required):
+
+1. **Interval tables must be overlap-filtered, not containment-filtered.** A
+   transcript straddling the region boundary still annotates variants inside the
+   region and must survive.
+2. **Transcript-owned tables must be filtered by transcript-id membership, not by
+   coordinates.** ``exon`` and ``translation_sift`` carry ``start`` / ``end``, but
+   their rows are *parts of* a transcript: coordinate-filtering them amputates the
+   out-of-region exons of a boundary-crossing transcript, silently changing that
+   transcript's structure. ``translation_core`` has no coordinates at all.
+
+Plus the FASTA window, which has the same failure mode in sequence space: a
+boundary-crossing transcript's exons are fetched from the FASTA by absolute
+coordinate, so the window must carry real bases across the *feature closure*, not
+merely the requested region — otherwise those reads silently return ``N``.
+
+The end-to-end proof (annotate a region VCF against the full chr22 cache and
+against the mini cache; require byte-identical bodies) lives in
+``test_full_vs_mini_annotation_is_identical``, which is skipped unless the built
+caches are present, since they are far too large to check in.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.compute as pc
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from build_mini_cache import (  # noqa: E402
+    FilterKind,
+    KeptTranscripts,
+    Region,
+    normalize_chrom,
+    overlap_mask,
+    write_fasta_window,
+)
+
+REGION = Region("chr22", 22_000_000, 23_500_000)
+
+
+def make_transcript_table() -> pa.Table:
+    """Four transcripts: inside, straddling each boundary, and fully outside."""
+    return pa.table(
+        {
+            "chrom": ["22", "22", "22", "22"],
+            "start": [22_100_000, 21_900_000, 23_400_000, 24_000_000],
+            "end": [22_200_000, 22_050_000, 23_600_000, 24_100_000],
+            "stable_id": ["ENST_IN", "ENST_LEFT", "ENST_RIGHT", "ENST_OUT"],
+        }
+    )
+
+
+def make_exon_table() -> pa.Table:
+    """Exons for the transcripts above, including ones outside the region.
+
+    ``ENST_LEFT``'s first exon sits at 21,900,000 (left of the region) and
+    ``ENST_RIGHT``'s last exon at 23,600,000 (right of it). Both belong to
+    transcripts that overlap the region and must therefore be kept.
+    """
+    return pa.table(
+        {
+            "chrom": ["22"] * 5,
+            "start": [22_100_000, 21_900_000, 22_040_000, 23_400_000, 23_600_000],
+            "end": [22_100_500, 21_900_500, 22_050_000, 23_400_500, 23_600_500],
+            "transcript_id": [
+                "ENST_IN",
+                "ENST_LEFT",  # OUT of region, but its transcript overlaps
+                "ENST_LEFT",
+                "ENST_RIGHT",
+                "ENST_RIGHT",  # OUT of region, but its transcript overlaps
+            ],
+        }
+    )
+
+
+class TestOverlapNotContainment:
+    """Interval tables keep boundary-crossing features."""
+
+    def test_keeps_transcripts_straddling_both_boundaries(self) -> None:
+        table = make_transcript_table()
+        kept = table.filter(overlap_mask(table, REGION))
+        assert sorted(kept["stable_id"].to_pylist()) == [
+            "ENST_IN",
+            "ENST_LEFT",
+            "ENST_RIGHT",
+        ]
+
+    def test_drops_features_fully_outside(self) -> None:
+        table = make_transcript_table()
+        kept = table.filter(overlap_mask(table, REGION))
+        assert "ENST_OUT" not in kept["stable_id"].to_pylist()
+
+    def test_containment_filter_would_lose_real_transcripts(self) -> None:
+        """Pin the bug this design avoids: containment drops the straddlers."""
+        table = make_transcript_table()
+        contained = table.filter(
+            pc.and_(
+                pc.greater_equal(table["start"], REGION.start),
+                pc.less_equal(table["end"], REGION.end),
+            )
+        )
+        assert contained.num_rows == 1  # only ENST_IN
+        overlapping = table.filter(overlap_mask(table, REGION))
+        assert overlapping.num_rows == 3  # the slicer keeps 2 more
+
+    def test_chrom_prefix_is_normalized(self) -> None:
+        """Shards store ``22``; the region says ``chr22``. They must match."""
+        assert normalize_chrom("chr22") == normalize_chrom("22") == "22"
+        table = make_transcript_table()  # stores bare "22"
+        assert table.filter(overlap_mask(table, REGION)).num_rows == 3
+
+
+class TestAnnotationFlank:
+    """Features just OUTSIDE the region still annotate variants inside it.
+
+    Regression test for a bug the full-vs-mini comparison actually caught: with a
+    bare (unflanked) overlap filter, ``ENST00000548391`` — which lies 4,723 bp
+    before the region start — was dropped, and the two variants at the region's
+    left edge silently lost their ``upstream_gene_variant`` CSQ entry. VEP's
+    default up/downstream distance is 5000 bp
+    (``transcript_distance_config`` → ``.unwrap_or((5000, 5000))``).
+    """
+
+    def test_transcript_within_flank_but_outside_region_is_kept(self) -> None:
+        upstream = pa.table(
+            {
+                "chrom": ["22"],
+                # Entirely before the region, but only ~4.7 kb before it — exactly
+                # the ENST00000548391 case.
+                "start": [21_990_000],
+                "end": [21_995_277],
+                "stable_id": ["ENST_UPSTREAM"],
+            }
+        )
+        assert upstream.filter(overlap_mask(upstream, REGION)).num_rows == 1
+
+    def test_transcript_beyond_the_flank_is_dropped(self) -> None:
+        far = pa.table(
+            {
+                "chrom": ["22"],
+                "start": [21_000_000],
+                "end": [21_100_000],  # ~900 kb away: far beyond the 5 kb flank
+                "stable_id": ["ENST_FAR"],
+            }
+        )
+        assert far.filter(overlap_mask(far, REGION)).num_rows == 0
+
+    def test_unflanked_region_would_drop_it(self) -> None:
+        """Pin the bug: flank=0 loses the upstream transcript."""
+        unflanked = Region("chr22", 22_000_000, 23_500_000, flank=0)
+        upstream = pa.table(
+            {
+                "chrom": ["22"],
+                "start": [21_990_000],
+                "end": [21_995_277],
+                "stable_id": ["ENST_UPSTREAM"],
+            }
+        )
+        assert upstream.filter(overlap_mask(upstream, unflanked)).num_rows == 0
+        assert upstream.filter(overlap_mask(upstream, REGION)).num_rows == 1
+
+    def test_default_flank_matches_the_engine_default(self) -> None:
+        from build_mini_cache import DEFAULT_FLANK
+
+        assert DEFAULT_FLANK == 5000
+        assert Region("chr22", 22_000_000, 23_500_000).padded == (
+            21_995_000,
+            23_505_000,
+        )
+
+
+class TestTranscriptMembership:
+    """Transcript-owned tables are filtered by id, never by coordinate."""
+
+    def test_keeps_out_of_region_exons_of_kept_transcripts(self) -> None:
+        transcripts = make_transcript_table()
+        kept_ids = transcripts.filter(overlap_mask(transcripts, REGION))["stable_id"]
+        exons = make_exon_table()
+        by_membership = exons.filter(
+            pc.is_in(exons["transcript_id"], value_set=kept_ids)
+        )
+        assert by_membership.num_rows == 5  # every exon of the 3 kept transcripts
+
+    def test_coordinate_filtering_exons_would_truncate_transcripts(self) -> None:
+        """The phantom-drift bug, pinned: coordinate-filtering amputates exons."""
+        exons = make_exon_table()
+        by_coordinate = exons.filter(overlap_mask(exons, REGION))
+        lost = {
+            (tid, start)
+            for tid, start in zip(
+                exons["transcript_id"].to_pylist(), exons["start"].to_pylist()
+            )
+        } - {
+            (tid, start)
+            for tid, start in zip(
+                by_coordinate["transcript_id"].to_pylist(),
+                by_coordinate["start"].to_pylist(),
+            )
+        }
+        # ENST_LEFT's 21.9 Mb exon and ENST_RIGHT's 23.6 Mb exon would vanish,
+        # silently changing the structure of two transcripts we DID keep.
+        assert lost == {("ENST_LEFT", 21_900_000), ("ENST_RIGHT", 23_600_000)}
+
+    def test_policy_marks_transcript_owned_tables(self) -> None:
+        from build_mini_cache import TABLE_POLICIES
+
+        by_name = {p.name: p for p in TABLE_POLICIES}
+        for owned in ("exon", "translation_core"):
+            assert by_name[owned].kind is FilterKind.TRANSCRIPT_MEMBERSHIP, (
+                f"{owned} must be membership-filtered; coordinate-filtering it "
+                "truncates boundary-crossing transcripts"
+            )
+        # translation_sift has neither coordinates nor a stable id — only the
+        # packed `key = (transcript_uid << 32) | position`.
+        assert by_name["translation_sift"].kind is FilterKind.TRANSCRIPT_UID_KEY
+        for interval in ("variation", "transcript", "regulatory", "motif"):
+            assert by_name[interval].kind is FilterKind.INTERVAL
+
+
+class TestSiftUidKey:
+    """``translation_sift`` is sliced through its packed uid key."""
+
+    def test_sift_rows_follow_their_transcript(self) -> None:
+        """Only sift rows whose ``key >> 32`` is a kept transcript's uid survive."""
+        kept = KeptTranscripts(
+            stable_ids=pa.array(["ENST_IN", "ENST_LEFT"]),
+            uids=pa.array([7, 9], type=pa.uint32()),
+        )
+        # uid 7 and 9 are kept; uid 42 belongs to a transcript outside the region.
+        keys = [(7 << 32) | 1, (9 << 32) | 5, (42 << 32) | 3, (7 << 32) | 2]
+        sift = pa.table({"key": pa.array(keys, type=pa.uint64())})
+
+        uid = pc.shift_right(sift["key"], 32)
+        survived = sift.filter(pc.is_in(uid, value_set=kept.uids.cast(uid.type)))
+
+        assert survived["key"].to_pylist() == [
+            (7 << 32) | 1,
+            (9 << 32) | 5,
+            (7 << 32) | 2,
+        ]
+
+    def test_uids_are_not_renumbered(self) -> None:
+        """Renumbering ``transcript_uid`` would invalidate every sift key.
+
+        The runtime reads ``transcript_uid`` off the transcript row and rebuilds
+        ``(uid << 32) | position`` to look SIFT up, so the sliced transcript table
+        must keep its ORIGINAL (now sparse) uids.
+        """
+        transcripts = pa.table(
+            {
+                "chrom": ["22", "22", "22"],
+                "start": [22_100_000, 22_200_000, 24_000_000],
+                "end": [22_150_000, 22_250_000, 24_100_000],
+                "stable_id": ["A", "B", "OUT"],
+                "transcript_uid": pa.array([5564, 4043, 9999], type=pa.uint32()),
+            }
+        )
+        survived = transcripts.filter(overlap_mask(transcripts, REGION))
+        # Sparse and unsorted — exactly as they were in the source shard.
+        assert survived["transcript_uid"].to_pylist() == [5564, 4043]
+
+
+class TestFastaWindow:
+    """The FASTA window preserves absolute coordinates."""
+
+    @pytest.fixture
+    def source_fasta(self, tmp_path: Path) -> Path:
+        """A 1000 bp contig of cycling ACGT, with a matching ``.fai``.
+
+        Named bare ``22`` exactly like the real primary-assembly FASTA, while the
+        region is ``chr22`` — so the tests also pin that the slicer bridges the
+        two spellings without renaming the contig.
+        """
+        bases = ("ACGT" * 250)[:1000]
+        fasta = tmp_path / "ref.fa"
+        header = ">22\n"
+        lines = [bases[i : i + 60] for i in range(0, len(bases), 60)]
+        fasta.write_text(header + "\n".join(lines) + "\n")
+        fasta.with_suffix(".fa.fai").write_text(f"22\t1000\t{len(header)}\t60\t61\n")
+        return fasta
+
+    def test_source_contig_name_is_preserved(
+        self, source_fasta: Path, tmp_path: Path
+    ) -> None:
+        """The mini FASTA must keep the source spelling (``22``, not ``chr22``).
+
+        Renaming the contig would make the engine resolve names differently
+        against the mini FASTA than against the full one — a difference that has
+        nothing to do with the slice and would corrupt the parity verdict.
+        """
+        out = tmp_path / "mini.fa"
+        write_fasta_window(
+            source_fasta,
+            source_fasta.with_suffix(".fa.fai"),
+            Region("chr22", 401, 600),
+            (401, 600),
+            out,
+        )
+        assert out.read_text().splitlines()[0] == ">22"
+        assert out.with_suffix(".fa.fai").read_text().split("\t")[0] == "22"
+
+    def read_seq(self, fasta: Path) -> str:
+        return "".join(
+            line.strip()
+            for line in fasta.read_text().splitlines()
+            if not line.startswith(">")
+        )
+
+    def test_real_bases_inside_span_n_outside_and_length_preserved(
+        self, source_fasta: Path, tmp_path: Path
+    ) -> None:
+        out = tmp_path / "mini.fa"
+        region = Region("chr22", 401, 600)
+        write_fasta_window(
+            source_fasta, source_fasta.with_suffix(".fa.fai"), region, (401, 600), out
+        )
+        seq = self.read_seq(out)
+        original = self.read_seq(source_fasta)
+
+        assert len(seq) == 1000, "contig length must be preserved for coordinates"
+        # 1-based [401, 600] -> 0-based [400:600]
+        assert seq[400:600] == original[400:600]
+        assert set(seq[:400]) == {"N"}
+        assert set(seq[600:]) == {"N"}
+
+    def test_fai_is_valid_and_seeks_correctly(
+        self, source_fasta: Path, tmp_path: Path
+    ) -> None:
+        out = tmp_path / "mini.fa"
+        write_fasta_window(
+            source_fasta,
+            source_fasta.with_suffix(".fa.fai"),
+            Region("chr22", 401, 600),
+            (401, 600),
+            out,
+        )
+        name, length, offset, line_bases, line_width = (
+            out.with_suffix(".fa.fai").read_text().strip().split("\t")
+        )
+        assert (name, int(length), int(line_bases), int(line_width)) == (
+            "22",
+            1000,
+            60,
+            61,
+        )
+        # Seek to 1-based position 401 the way an indexed reader does.
+        pos = 401
+        byte = int(offset) + (pos - 1) // 60 * 61 + (pos - 1) % 60
+        with out.open("rb") as handle:
+            handle.seek(byte)
+            assert handle.read(1).decode() == self.read_seq(source_fasta)[400]
+
+    def test_window_covers_feature_closure_not_just_region(
+        self, source_fasta: Path, tmp_path: Path
+    ) -> None:
+        """A boundary-crossing transcript's bases must be real, not ``N``.
+
+        The span passed here is the feature closure (300..700), wider than the
+        requested region (401..600). Bases at 300 must be real sequence, because
+        an exon of a kept transcript lives there.
+        """
+        out = tmp_path / "mini.fa"
+        write_fasta_window(
+            source_fasta,
+            source_fasta.with_suffix(".fa.fai"),
+            Region("chr22", 401, 600),
+            (300, 700),
+            out,
+        )
+        seq = self.read_seq(out)
+        original = self.read_seq(source_fasta)
+        assert seq[299:700] == original[299:700]
+        assert seq[298] == "N"
+
+
+# --------------------------------------------------------------------------
+# End-to-end: the mini cache must annotate identically to the full cache.
+# --------------------------------------------------------------------------
+
+FULL_CACHE = Path(os.environ.get("VEPYR_FULL_CHR22_CACHE", "/tmp/mini_cache_chr22"))
+MINI_CACHE = Path(os.environ.get("VEPYR_MINI_CACHE", "/tmp/mini_cache_region"))
+REGION_VCF = Path(
+    os.environ.get("VEPYR_REGION_VCF", "/tmp/minicache_work/region_chr22.vcf")
+)
+FULL_FASTA = Path(
+    os.environ.get(
+        "VEPYR_FULL_FASTA",
+        "/Users/wojtek/Documents/vepyr/_cache_v115/"
+        "Homo_sapiens.GRCh38.dna.primary_assembly.fa",
+    )
+)
+ANNOTATE_BIN = Path(
+    os.environ.get(
+        "VEPYR_ANNOTATE_BIN",
+        "/Users/wojtek/Documents/vepyr/datafusion-bio-functions-worktrees/"
+        "plugin-engine/target/release/examples/annotate_vcf",
+    )
+)
+
+
+def body(vcf: Path) -> list[str]:
+    """The VCF's data lines (headers carry cache paths and legitimately differ)."""
+    return [ln for ln in vcf.read_text().splitlines() if not ln.startswith("#")]
+
+
+@pytest.mark.skipif(
+    not (
+        FULL_CACHE.exists()
+        and MINI_CACHE.exists()
+        and REGION_VCF.exists()
+        and ANNOTATE_BIN.exists()
+    ),
+    reason="full chr22 + mini caches not built locally (too large to check in)",
+)
+def test_full_vs_mini_annotation_is_identical(tmp_path: Path) -> None:
+    """Annotating the region against the mini cache must equal the full cache.
+
+    This is what makes the fixture trustworthy: if the slice dropped a transcript
+    or the FASTA window returned ``N`` where a base belonged, the CSQ bodies
+    diverge here rather than silently poisoning the parity gate.
+    """
+    outputs: list[Path] = []
+    for name, cache, fasta in (
+        ("full", FULL_CACHE, FULL_FASTA),
+        ("mini", MINI_CACHE, MINI_CACHE / FULL_FASTA.name),
+    ):
+        out = tmp_path / f"{name}.vcf"
+        subprocess.run(
+            [
+                str(ANNOTATE_BIN),
+                "--input",
+                str(REGION_VCF),
+                "--cache",
+                str(cache),
+                "--out",
+                str(out),
+                "--fasta",
+                str(fasta),
+                "--everything",
+                "--hgvs",
+            ],
+            check=True,
+            capture_output=True,
+        )
+        outputs.append(out)
+
+    full_body, mini_body = body(outputs[0]), body(outputs[1])
+    assert len(full_body) == len(mini_body), (
+        f"record count differs: full={len(full_body)} mini={len(mini_body)}"
+    )
+    mismatches = [
+        (i, f, m) for i, (f, m) in enumerate(zip(full_body, mini_body)) if f != m
+    ]
+    assert not mismatches, (
+        f"{len(mismatches)}/{len(full_body)} records differ between the full and "
+        f"mini cache. First: full={mismatches[0][1][:300]!r} "
+        f"mini={mismatches[0][2][:300]!r}"
+    )

--- a/tests/test_build_plugin_cache.py
+++ b/tests/test_build_plugin_cache.py
@@ -277,11 +277,11 @@ def test_filtered_build_not_blocked_by_overwrite_guard(tmp_path):
 
 def test_full_overwrite_wipes_stale_plugin_dir(tmp_path):
     """A full (chroms=None) overwrite rebuild must start from a clean slate. The
-    builder's `with_overwrite` is a no-op and `build_all` SEEDS its manifest from
-    any existing plugin manifest, preserving chroms not in the new build set — so
-    rebuilding a smaller set into the same root would leave stale chrom entries and
-    shards that `annotate()` keeps emitting. Verify the pre-existing plugin dir
-    (manifest + shards) is removed before the build runs."""
+    builder honours `with_overwrite` for the *manifest* (it starts from an empty
+    chrom list rather than seeding from the existing one), but it never deletes the
+    shard FILES of chroms outside the new build set — so rebuilding a smaller set
+    into the same root would leave orphan `<chrom>.parquet` shards behind. Verify the
+    pre-existing plugin dir (manifest + shards) is removed before the build runs."""
     repo = _init_full_repo(tmp_path)
     pc = tmp_path / "pc"
     (pc / "plugin" / "demo").mkdir(parents=True)

--- a/tests/test_parity.py
+++ b/tests/test_parity.py
@@ -1,0 +1,455 @@
+"""Tests for :mod:`vepyr.parity` — the shared VEP-vs-vepyr CSQ comparator.
+
+The comparator is the arbiter of two gates:
+
+* the WGS benchmark (``e2e-testing/scripts/run_annotation_fast.py``), and
+* the plugin-parity gate (``vepyr-plugins``), which restricts the comparison to
+  a single plugin's CSQ fields.
+
+These tests are written against real VCF pairs (a real ``##INFO=<ID=CSQ`` header
+with a ``Format:`` spec, real pipe-delimited CSQ entries) written into
+``tmp_path`` — not stubs — because the file/CSQ parsing is part of what is
+being asserted.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from vepyr.parity import ComparisonResult, compare_csq_fields, compare_vcfs
+
+# A realistic (trimmed) VEP CSQ format: core fields plus the two AlphaMissense
+# plugin fields, which is exactly the shape the plugin-parity gate sees.
+CSQ_FORMAT = (
+    "Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|"
+    "HGVSc|HGVSp|SIFT|PolyPhen|am_class|am_pathogenicity"
+)
+
+_HEADER_TEMPLATE = "\n".join(
+    [
+        "##fileformat=VCFv4.2",
+        "##contig=<ID=chr1,length=248956422>",
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+        '##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence '
+        'annotations from Ensembl VEP. Format: {csq_format}">',
+        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG002",
+    ]
+)
+
+
+def write_vcf(
+    path: Path,
+    records: list[tuple[str, int, str, str, list[str]]],
+    csq_format: str = CSQ_FORMAT,
+) -> Path:
+    """Write a VCF whose INFO column carries a VEP-style ``CSQ`` annotation.
+
+    Mirrors the shape of the real benchmark VCFs (``tests/data/golden``): 10
+    columns, i.e. INFO followed by FORMAT and a sample column.
+
+    Args:
+        path: Destination path.
+        records: ``(chrom, pos, ref, alt, csq_entries)`` tuples, where each CSQ
+            entry is a raw pipe-delimited string matching ``csq_format``.
+        csq_format: The pipe-delimited field spec advertised in the CSQ header.
+
+    Returns:
+        ``path``, for chaining.
+    """
+    lines = [_HEADER_TEMPLATE.format(csq_format=csq_format)]
+    for chrom, pos, ref, alt, entries in records:
+        info = f"DP=30;CSQ={','.join(entries)}" if entries else "DP=30"
+        lines.append(
+            f"{chrom}\t{pos}\t.\t{ref}\t{alt}\t50\tPASS\t{info}\tGT:DP\t1/1:30"
+        )
+    path.write_text("\n".join(lines) + "\n")
+    return path
+
+
+def csq(
+    *,
+    allele: str = "G",
+    consequence: str = "missense_variant",
+    impact: str = "MODERATE",
+    symbol: str = "GENE1",
+    gene: str = "ENSG00000001",
+    feature: str = "ENST00000001",
+    biotype: str = "protein_coding",
+    hgvsc: str = "ENST00000001.1:c.100A>G",
+    hgvsp: str = "ENSP00000001.1:p.Lys34Arg",
+    sift: str = "tolerated(0.21)",
+    polyphen: str = "benign(0.012)",
+    am_class: str = "likely_benign",
+    am_pathogenicity: str = "0.0812",
+) -> str:
+    """Build one pipe-delimited CSQ entry matching :data:`CSQ_FORMAT`."""
+    return "|".join(
+        [
+            allele,
+            consequence,
+            impact,
+            symbol,
+            gene,
+            "Transcript",
+            feature,
+            biotype,
+            hgvsc,
+            hgvsp,
+            sift,
+            polyphen,
+            am_class,
+            am_pathogenicity,
+        ]
+    )
+
+
+def realistic_records() -> list[tuple[str, int, str, str, list[str]]]:
+    """A few dozen records, incl. a multi-CSQ-entry variant and empty fields."""
+    records: list[tuple[str, int, str, str, list[str]]] = []
+    for i in range(30):
+        pos = 100_000 + i * 137
+        records.append(
+            (
+                "chr1",
+                pos,
+                "A",
+                "G",
+                [csq(feature=f"ENST{i:011d}", am_pathogenicity=f"0.{i:04d}")],
+            )
+        )
+    # A variant annotated against three overlapping transcripts.
+    records.append(
+        (
+            "chr1",
+            200_000,
+            "C",
+            "T",
+            [
+                csq(allele="T", feature="ENST00000900", am_pathogenicity="0.9101"),
+                csq(allele="T", feature="ENST00000901", am_pathogenicity="0.4400"),
+                csq(allele="T", feature="ENST00000902", am_pathogenicity="0.1234"),
+            ],
+        )
+    )
+    # An intron variant: AlphaMissense emits nothing for non-missense sites.
+    records.append(
+        (
+            "chr1",
+            300_000,
+            "G",
+            "A",
+            [
+                csq(
+                    allele="A",
+                    consequence="intron_variant",
+                    impact="MODIFIER",
+                    feature="ENST00000903",
+                    hgvsp="",
+                    sift="",
+                    polyphen="",
+                    am_class="",
+                    am_pathogenicity="",
+                )
+            ],
+        )
+    )
+    return records
+
+
+def test_identical_vcfs_agree(tmp_path: Path) -> None:
+    """A file compared against a byte-identical copy has zero mismatches."""
+    records = realistic_records()
+    truth = write_vcf(tmp_path / "vep.vcf", records)
+    test = write_vcf(tmp_path / "vepyr.vcf", records)
+
+    result = compare_csq_fields(truth, test)
+
+    assert isinstance(result, ComparisonResult)
+    assert result.keys_compared == len(records)
+    assert result.keys_only_in_test == 0
+    assert result.keys_only_in_truth == 0
+    assert result.entry_count_mismatch == 0
+    assert result.field_mismatches == dict.fromkeys(result.fields_compared, 0)
+    assert result.over_emissions == dict.fromkeys(result.fields_compared, 0)
+    assert "am_pathogenicity" in result.fields_compared
+    assert result.is_clean
+
+
+def test_field_mismatch_reports_key_and_both_values(tmp_path: Path) -> None:
+    """A differing field is reported with the variant key AND both values."""
+    records = realistic_records()
+    drifted = [
+        (chrom, pos, ref, alt, entries)
+        if pos != 200_000
+        else (
+            chrom,
+            pos,
+            ref,
+            alt,
+            [
+                csq(allele="T", feature="ENST00000900", am_pathogenicity="0.9101"),
+                csq(allele="T", feature="ENST00000901", am_pathogenicity="0.4400"),
+                # vepyr disagrees with VEP on this transcript's score.
+                csq(allele="T", feature="ENST00000902", am_pathogenicity="0.5678"),
+            ],
+        )
+        for chrom, pos, ref, alt, entries in records
+    ]
+    truth = write_vcf(tmp_path / "vep.vcf", records)
+    test = write_vcf(tmp_path / "vepyr.vcf", drifted)
+
+    result = compare_csq_fields(truth, test, fields=["am_class", "am_pathogenicity"])
+
+    assert result.field_mismatches["am_pathogenicity"] == 1
+    assert result.field_mismatches["am_class"] == 0
+    assert not result.is_clean
+
+    (example,) = result.field_mismatch_examples["am_pathogenicity"]
+    assert example.key == "chr1\t200000\tC\tT"
+    assert example.truth == "0.1234"
+    assert example.test == "0.5678"
+
+
+def test_over_emission_is_a_mismatch(tmp_path: Path) -> None:
+    """Populating a field VEP left empty is a FAILURE, not a bonus.
+
+    VEP emits no AlphaMissense call for an intron variant. If vepyr emits one
+    anyway, that is over-emission: the plugin fired where upstream did not.
+    """
+    records = realistic_records()
+    over_emitting = [
+        (chrom, pos, ref, alt, entries)
+        if pos != 300_000
+        else (
+            chrom,
+            pos,
+            ref,
+            alt,
+            [
+                csq(
+                    allele="A",
+                    consequence="intron_variant",
+                    impact="MODIFIER",
+                    feature="ENST00000903",
+                    hgvsp="",
+                    sift="",
+                    polyphen="",
+                    am_class="likely_benign",
+                    am_pathogenicity="0.0500",
+                )
+            ],
+        )
+        for chrom, pos, ref, alt, entries in records
+    ]
+    truth = write_vcf(tmp_path / "vep.vcf", records)
+    test = write_vcf(tmp_path / "vepyr.vcf", over_emitting)
+
+    result = compare_csq_fields(truth, test, fields=["am_class", "am_pathogenicity"])
+
+    assert not result.is_clean
+    assert result.field_mismatches == {"am_class": 1, "am_pathogenicity": 1}
+    assert result.over_emissions == {"am_class": 1, "am_pathogenicity": 1}
+
+    (example,) = result.field_mismatch_examples["am_pathogenicity"]
+    assert example.key == "chr1\t300000\tG\tA"
+    assert example.truth == ""
+    assert example.test == "0.0500"
+
+
+def test_field_restriction_ignores_drift_in_other_fields(tmp_path: Path) -> None:
+    """Restricting to a plugin's fields ignores drift in the core fields."""
+    records = realistic_records()
+    core_drift = [
+        (
+            chrom,
+            pos,
+            ref,
+            alt,
+            [
+                entry.replace("tolerated(0.21)", "deleterious(0.01)")
+                for entry in entries
+            ],
+        )
+        for chrom, pos, ref, alt, entries in records
+    ]
+    truth = write_vcf(tmp_path / "vep.vcf", records)
+    test = write_vcf(tmp_path / "vepyr.vcf", core_drift)
+
+    plugin_only = compare_csq_fields(
+        truth, test, fields=["am_class", "am_pathogenicity"]
+    )
+    assert plugin_only.fields_compared == ("am_class", "am_pathogenicity")
+    assert plugin_only.field_mismatches == {"am_class": 0, "am_pathogenicity": 0}
+    assert plugin_only.is_clean
+
+    # The same drift is a hard failure for the unrestricted (core) verdict.
+    everything = compare_csq_fields(truth, test)
+    assert everything.field_mismatches["SIFT"] > 0
+    assert not everything.is_clean
+
+
+def test_requested_field_missing_from_test_header_is_reported(tmp_path: Path) -> None:
+    """A plugin field vepyr never emits must not silently pass the gate."""
+    records = realistic_records()
+    truth = write_vcf(tmp_path / "vep.vcf", records)
+    # vepyr's CSQ header stops before the plugin fields: nothing to compare.
+    core_format = CSQ_FORMAT.rsplit("|am_class|", 1)[0]
+    test = write_vcf(
+        tmp_path / "vepyr.vcf",
+        [
+            (chrom, pos, ref, alt, ["|".join(e.split("|")[:-2]) for e in entries])
+            for chrom, pos, ref, alt, entries in records
+        ],
+        csq_format=core_format,
+    )
+
+    result = compare_csq_fields(truth, test, fields=["am_class", "am_pathogenicity"])
+
+    assert result.fields_compared == ()
+    assert result.fields_missing_from_test == ("am_class", "am_pathogenicity")
+    assert result.fields_missing_from_truth == ()
+    assert not result.is_clean
+
+
+def test_entry_count_mismatch_is_reported(tmp_path: Path) -> None:
+    """Emitting fewer CSQ entries than VEP is an entry-count mismatch."""
+    records = realistic_records()
+    dropped = [
+        (chrom, pos, ref, alt, entries if pos != 200_000 else entries[:2])
+        for chrom, pos, ref, alt, entries in records
+    ]
+    truth = write_vcf(tmp_path / "vep.vcf", records)
+    test = write_vcf(tmp_path / "vepyr.vcf", dropped)
+
+    result = compare_csq_fields(truth, test, fields=["am_pathogenicity"])
+
+    assert result.entry_count_mismatch == 1
+    assert result.entry_count_match == len(records) - 1
+    assert not result.is_clean
+
+
+def test_entry_order_mismatch_is_strict_by_default_and_can_be_ignored(
+    tmp_path: Path,
+) -> None:
+    """Same entries in a different comma order: strict by default, ignorable.
+
+    ``ignore_entry_order`` exists only for VEP's per_gene / pick_allele_gene
+    Perl-hash emission order; the reason is recorded on the result.
+    """
+    entries = [
+        csq(allele="T", feature="ENST00000900"),
+        csq(allele="T", feature="ENST00000901"),
+    ]
+    truth = write_vcf(tmp_path / "vep.vcf", [("chr1", 200_000, "C", "T", entries)])
+    test = write_vcf(
+        tmp_path / "vepyr.vcf", [("chr1", 200_000, "C", "T", list(reversed(entries)))]
+    )
+
+    strict = compare_csq_fields(truth, test)
+    assert strict.entry_order_mismatch == 1
+    assert strict.entry_order_ignored == 0
+    assert strict.entry_order_ignore_reason is None
+    assert not strict.is_clean
+    # Entries are paired by Feature before field comparison, so field values
+    # still match: only the emission order differs.
+    assert strict.field_mismatches["Feature"] == 0
+
+    lenient = compare_csq_fields(truth, test, ignore_entry_order=True)
+    assert lenient.entry_order_mismatch == 0
+    assert lenient.entry_order_ignored == 1
+    assert "per_gene" in (lenient.entry_order_ignore_reason or "")
+    assert "pick_allele_gene" in (lenient.entry_order_ignore_reason or "")
+    assert lenient.is_clean
+
+
+def test_ampersand_order_only_difference_is_not_a_mismatch(tmp_path: Path) -> None:
+    """``a&b`` vs ``b&a`` in a multi-valued field counts as a match (order-only)."""
+    truth = write_vcf(
+        tmp_path / "vep.vcf",
+        [
+            (
+                "chr1",
+                100,
+                "A",
+                "G",
+                [csq(consequence="splice_region_variant&intron_variant")],
+            )
+        ],
+    )
+    test = write_vcf(
+        tmp_path / "vepyr.vcf",
+        [
+            (
+                "chr1",
+                100,
+                "A",
+                "G",
+                [csq(consequence="intron_variant&splice_region_variant")],
+            )
+        ],
+    )
+
+    result = compare_csq_fields(truth, test, fields=["Consequence"])
+
+    assert result.field_mismatches["Consequence"] == 0
+    assert result.field_order_mismatches["Consequence"] == 1
+    (example,) = result.field_order_mismatch_examples["Consequence"]
+    assert example.truth == "splice_region_variant&intron_variant"
+    assert example.test == "intron_variant&splice_region_variant"
+
+
+def test_keys_only_in_one_side_are_counted(tmp_path: Path) -> None:
+    """Variants present on only one side are counted, not compared."""
+    truth = write_vcf(
+        tmp_path / "vep.vcf",
+        [("chr1", 100, "A", "G", [csq()]), ("chr1", 200, "A", "G", [csq()])],
+    )
+    test = write_vcf(
+        tmp_path / "vepyr.vcf",
+        [("chr1", 100, "A", "G", [csq()]), ("chr1", 300, "A", "G", [csq()])],
+    )
+
+    result = compare_csq_fields(truth, test)
+
+    assert result.keys_compared == 1
+    assert result.keys_only_in_truth == 1
+    assert result.keys_only_in_test == 1
+
+
+def test_compare_vcfs_returns_the_legacy_report_dict(tmp_path: Path, capsys) -> None:
+    """The e2e benchmark's ``compare_vcfs`` still returns its JSON report shape."""
+    records = realistic_records()
+    truth = write_vcf(tmp_path / "vep.vcf", records)
+    test = write_vcf(tmp_path / "vepyr.vcf", records)
+
+    report = compare_vcfs(str(test), str(truth), "chr1")
+
+    assert report["variants_compared"] == len(records)
+    assert report["csq_entry_count_mismatch"] == 0
+    assert report["field_mismatch_counts"] == {}
+    assert report["csq_order_ignore_reason"] is None
+    assert report["field_match_rates"]["am_pathogenicity"] == 100.0
+    assert "ALL" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("suffix", [".vcf", ".vcf.gz"])
+def test_gzipped_inputs_are_read_transparently(tmp_path: Path, suffix: str) -> None:
+    """Comparison works on plain and gzipped VCFs alike."""
+    import gzip
+
+    records = realistic_records()
+    truth = write_vcf(tmp_path / "vep.vcf", records)
+    test = write_vcf(tmp_path / "vepyr.vcf", records)
+    if suffix == ".vcf.gz":
+        for path in (truth, test):
+            gz = path.with_suffix(".vcf.gz")
+            gz.write_bytes(gzip.compress(path.read_bytes()))
+        truth = truth.with_suffix(".vcf.gz")
+        test = test.with_suffix(".vcf.gz")
+
+    result = compare_csq_fields(truth, test)
+
+    assert result.keys_compared == len(records)
+    assert result.is_clean

--- a/tests/test_parity.py
+++ b/tests/test_parity.py
@@ -27,43 +27,45 @@ CSQ_FORMAT = (
     "HGVSc|HGVSp|SIFT|PolyPhen|am_class|am_pathogenicity"
 )
 
-_HEADER_TEMPLATE = "\n".join(
-    [
-        "##fileformat=VCFv4.2",
-        "##contig=<ID=chr1,length=248956422>",
-        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
-        '##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence '
-        'annotations from Ensembl VEP. Format: {csq_format}">',
-        "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG002",
-    ]
-)
+_HEADER_LINES = [
+    "##fileformat=VCFv4.2",
+    "##contig=<ID=chr1,length=248956422>",
+    '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+    '##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence '
+    'annotations from Ensembl VEP. Format: {csq_format}">',
+]
+_COLUMNS = "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO"
 
 
 def write_vcf(
     path: Path,
     records: list[tuple[str, int, str, str, list[str]]],
     csq_format: str = CSQ_FORMAT,
+    *,
+    sites_only: bool = False,
 ) -> Path:
     """Write a VCF whose INFO column carries a VEP-style ``CSQ`` annotation.
-
-    Mirrors the shape of the real benchmark VCFs (``tests/data/golden``): 10
-    columns, i.e. INFO followed by FORMAT and a sample column.
 
     Args:
         path: Destination path.
         records: ``(chrom, pos, ref, alt, csq_entries)`` tuples, where each CSQ
             entry is a raw pipe-delimited string matching ``csq_format``.
         csq_format: The pipe-delimited field spec advertised in the CSQ header.
+        sites_only: Emit an 8-column, sites-only VCF (INFO is the final column),
+            as produced by running VEP over a sites-only region VCF. The default
+            emits 10 columns (INFO + FORMAT + sample), mirroring the real WGS
+            benchmark VCFs in ``tests/data/golden``.
 
     Returns:
         ``path``, for chaining.
     """
-    lines = [_HEADER_TEMPLATE.format(csq_format=csq_format)]
+    header = [line.format(csq_format=csq_format) for line in _HEADER_LINES]
+    header.append(_COLUMNS if sites_only else f"{_COLUMNS}\tFORMAT\tHG002")
+    lines = ["\n".join(header)]
     for chrom, pos, ref, alt, entries in records:
         info = f"DP=30;CSQ={','.join(entries)}" if entries else "DP=30"
-        lines.append(
-            f"{chrom}\t{pos}\t.\t{ref}\t{alt}\t50\tPASS\t{info}\tGT:DP\t1/1:30"
-        )
+        row = f"{chrom}\t{pos}\t.\t{ref}\t{alt}\t50\tPASS\t{info}"
+        lines.append(row if sites_only else f"{row}\tGT:DP\t1/1:30")
     path.write_text("\n".join(lines) + "\n")
     return path
 
@@ -453,3 +455,202 @@ def test_gzipped_inputs_are_read_transparently(tmp_path: Path, suffix: str) -> N
 
     assert result.keys_compared == len(records)
     assert result.is_clean
+
+
+# ── Sites-only (8-column) VCFs: the record separator is not a field value ────
+#
+# A region VEP run over a sites-only VCF emits 8 columns, so INFO is the final
+# column and the line's "\n" sits immediately after the last CSQ field. Plugin
+# fields are appended at the END of the CSQ Format string, which puts them
+# exactly where a leaked line terminator would land.
+
+
+def test_sites_only_last_csq_field_is_not_polluted_by_the_line_terminator(
+    tmp_path: Path,
+) -> None:
+    """The final CSQ field of an 8-column VCF must not absorb the newline."""
+    records = realistic_records()
+    truth = write_vcf(tmp_path / "vep.vcf", records, sites_only=True)
+    test = write_vcf(tmp_path / "vepyr.vcf", records, sites_only=True)
+
+    result = compare_csq_fields(truth, test, fields=["am_pathogenicity"])
+
+    assert result.is_clean
+    # 30 single-entry variants + one 3-entry variant + one intron variant.
+    assert result.field_totals["am_pathogenicity"] == 34
+
+
+def test_sites_only_entry_order_difference_does_not_invent_a_field_mismatch(
+    tmp_path: Path,
+) -> None:
+    """A pure CSQ entry-order difference must not manufacture a mismatch.
+
+    The line terminator used to ride on whichever CSQ entry was emitted last;
+    once entries are paired by Feature, it landed on *different* entries on the
+    two sides and produced a phantom mismatch on the final field.
+    """
+    entries = [
+        csq(allele="T", feature="ENST00000900", am_pathogenicity="0.9101"),
+        csq(allele="T", feature="ENST00000901", am_pathogenicity="0.4400"),
+    ]
+    truth = write_vcf(
+        tmp_path / "vep.vcf", [("chr1", 200_000, "C", "T", entries)], sites_only=True
+    )
+    test = write_vcf(
+        tmp_path / "vepyr.vcf",
+        [("chr1", 200_000, "C", "T", list(reversed(entries)))],
+        sites_only=True,
+    )
+
+    result = compare_csq_fields(truth, test, fields=["am_class", "am_pathogenicity"])
+
+    assert result.field_mismatches == {"am_class": 0, "am_pathogenicity": 0}
+    assert result.field_mismatch_examples["am_pathogenicity"] == []
+    # The entry-order difference itself is still reported, strictly.
+    assert result.entry_order_mismatch == 1
+
+
+def test_sites_only_over_emission_on_the_final_field_is_classified(
+    tmp_path: Path,
+) -> None:
+    """An empty final VEP field must read as ``""``, so over-emission is seen."""
+    truth = write_vcf(
+        tmp_path / "vep.vcf",
+        [("chr1", 300_000, "G", "A", [csq(am_class="", am_pathogenicity="")])],
+        sites_only=True,
+    )
+    test = write_vcf(
+        tmp_path / "vepyr.vcf",
+        [
+            (
+                "chr1",
+                300_000,
+                "G",
+                "A",
+                [csq(am_class="likely_benign", am_pathogenicity="0.0500")],
+            )
+        ],
+        sites_only=True,
+    )
+
+    result = compare_csq_fields(truth, test, fields=["am_class", "am_pathogenicity"])
+
+    assert result.field_mismatches == {"am_class": 1, "am_pathogenicity": 1}
+    assert result.over_emissions == {"am_class": 1, "am_pathogenicity": 1}
+
+    (example,) = result.field_mismatch_examples["am_pathogenicity"]
+    assert example.truth == ""
+    assert example.test == "0.0500"
+    assert example.is_over_emission
+
+
+def test_sites_only_mismatch_examples_carry_no_stray_whitespace(
+    tmp_path: Path,
+) -> None:
+    """Reported values are the values, not the values plus a line terminator."""
+    truth = write_vcf(
+        tmp_path / "vep.vcf",
+        [("chr1", 100, "A", "G", [csq(am_pathogenicity="0.1234")])],
+        sites_only=True,
+    )
+    test = write_vcf(
+        tmp_path / "vepyr.vcf",
+        [("chr1", 100, "A", "G", [csq(am_pathogenicity="0.5678")])],
+        sites_only=True,
+    )
+
+    result = compare_csq_fields(truth, test, fields=["am_pathogenicity"])
+
+    (example,) = result.field_mismatch_examples["am_pathogenicity"]
+    assert example.truth == "0.1234"
+    assert example.test == "0.5678"
+
+
+def test_crlf_line_endings_do_not_pollute_the_final_csq_field(tmp_path: Path) -> None:
+    """A CRLF-terminated sites-only VCF must not leak ``\\r`` into the last field."""
+    records = [("chr1", 100, "A", "G", [csq(am_pathogenicity="0.1234")])]
+    truth = write_vcf(tmp_path / "vep.vcf", records, sites_only=True)
+    test = write_vcf(tmp_path / "vepyr.vcf", records, sites_only=True)
+    test.write_bytes(test.read_bytes().replace(b"\n", b"\r\n"))
+
+    result = compare_csq_fields(truth, test, fields=["am_pathogenicity"])
+
+    assert result.field_mismatches["am_pathogenicity"] == 0
+    assert result.is_clean
+
+
+# ── A total annotation dropout must not read as a clean run ──────────────────
+
+
+def test_variant_with_no_csq_at_all_in_test_is_counted_not_ignored(
+    tmp_path: Path,
+) -> None:
+    """A variant vepyr left entirely unannotated is a defect, not a non-event.
+
+    A plugin cache that annotates NOTHING would otherwise show a perfectly clean
+    field table: with no CSQ to parse, the variant contributes no field totals
+    and no entry counts.
+    """
+    records = realistic_records()
+    truth = write_vcf(tmp_path / "vep.vcf", records)
+    # vepyr emits the variants but annotates none of them.
+    test = write_vcf(
+        tmp_path / "vepyr.vcf",
+        [(chrom, pos, ref, alt, []) for chrom, pos, ref, alt, _ in records],
+    )
+
+    result = compare_csq_fields(truth, test, fields=["am_class", "am_pathogenicity"])
+
+    assert result.keys_compared == len(records)
+    assert result.csq_missing_in_test == len(records)
+    assert result.csq_missing_in_truth == 0
+    # The blind spot: nothing lands in the field or entry-count buckets.
+    assert result.field_mismatches == {"am_class": 0, "am_pathogenicity": 0}
+    assert result.entry_count_mismatch == 0
+    assert not result.is_clean
+
+
+def test_variant_with_no_csq_at_all_in_truth_is_counted(tmp_path: Path) -> None:
+    """The mirror case: vepyr annotated a variant VEP did not."""
+    records = realistic_records()
+    truth = write_vcf(
+        tmp_path / "vep.vcf",
+        [(chrom, pos, ref, alt, []) for chrom, pos, ref, alt, _ in records],
+    )
+    test = write_vcf(tmp_path / "vepyr.vcf", records)
+
+    result = compare_csq_fields(truth, test)
+
+    assert result.csq_missing_in_truth == len(records)
+    assert result.csq_missing_in_test == 0
+    assert not result.is_clean
+
+
+def test_variant_unannotated_on_both_sides_is_agreement(tmp_path: Path) -> None:
+    """Neither side annotating a variant is agreement, not a dropout."""
+    records = [
+        (chrom, pos, ref, alt, []) for chrom, pos, ref, alt, _ in realistic_records()
+    ]
+    truth = write_vcf(tmp_path / "vep.vcf", records)
+    test = write_vcf(tmp_path / "vepyr.vcf", records)
+
+    result = compare_csq_fields(truth, test)
+
+    assert result.csq_missing_in_test == 0
+    assert result.csq_missing_in_truth == 0
+    assert result.is_clean
+
+
+def test_dropouts_are_surfaced_in_the_benchmark_report(tmp_path: Path) -> None:
+    """The e2e report must carry the dropout counters, not bury them."""
+    records = realistic_records()
+    truth = write_vcf(tmp_path / "vep.vcf", records)
+    test = write_vcf(
+        tmp_path / "vepyr.vcf",
+        [(chrom, pos, ref, alt, []) for chrom, pos, ref, alt, _ in records],
+    )
+
+    report = compare_vcfs(str(test), str(truth), "chr1")
+
+    assert report["csq_missing_in_vepyr"] == len(records)
+    assert report["csq_missing_in_vep"] == 0

--- a/tests/test_parity.py
+++ b/tests/test_parity.py
@@ -18,14 +18,33 @@ from pathlib import Path
 
 import pytest
 
-from vepyr.parity import ComparisonResult, compare_csq_fields, compare_vcfs
+from vepyr.parity import (
+    MAX_EXAMPLES,
+    ComparisonResult,
+    compare_csq_fields,
+    compare_vcfs,
+)
 
 # A realistic (trimmed) VEP CSQ format: core fields plus the two AlphaMissense
 # plugin fields, which is exactly the shape the plugin-parity gate sees.
+#
+# ``Protein_position`` and ``Amino_acids`` are the core engine attributes that
+# AlphaMissense's own discriminator (``{ref_aa}{Protein_position}{alt_aa}``) is
+# built from, so they are the fields through which a *core* divergence
+# masquerades as a *plugin* failure. They are here for that reason.
 CSQ_FORMAT = (
     "Allele|Consequence|IMPACT|SYMBOL|Gene|Feature_type|Feature|BIOTYPE|"
-    "HGVSc|HGVSp|SIFT|PolyPhen|am_class|am_pathogenicity"
+    "HGVSc|HGVSp|Protein_position|Amino_acids|SIFT|PolyPhen|"
+    "am_class|am_pathogenicity"
 )
+
+#: The core fields whose divergence the plugin gate must not blame on a plugin.
+#: ``ref``/``alt`` are absent because in this comparator they are not CSQ fields:
+#: they are part of the variant key, so a disagreement there cannot pair.
+CORE_FIELDS = ["Feature", "Consequence", "Amino_acids", "Protein_position"]
+
+#: The plugin's own CSQ fields — the only ones its parity gate compares.
+PLUGIN_FIELDS = ["am_class", "am_pathogenicity"]
 
 _HEADER_LINES = [
     "##fileformat=VCFv4.2",
@@ -81,6 +100,8 @@ def csq(
     biotype: str = "protein_coding",
     hgvsc: str = "ENST00000001.1:c.100A>G",
     hgvsp: str = "ENSP00000001.1:p.Lys34Arg",
+    protein_position: str = "34",
+    amino_acids: str = "K/R",
     sift: str = "tolerated(0.21)",
     polyphen: str = "benign(0.012)",
     am_class: str = "likely_benign",
@@ -99,6 +120,8 @@ def csq(
             biotype,
             hgvsc,
             hgvsp,
+            protein_position,
+            amino_acids,
             sift,
             polyphen,
             am_class,
@@ -149,6 +172,8 @@ def realistic_records() -> list[tuple[str, int, str, str, list[str]]]:
                     impact="MODIFIER",
                     feature="ENST00000903",
                     hgvsp="",
+                    protein_position="",
+                    amino_acids="",
                     sift="",
                     polyphen="",
                     am_class="",
@@ -236,6 +261,8 @@ def test_over_emission_is_a_mismatch(tmp_path: Path) -> None:
                     impact="MODIFIER",
                     feature="ENST00000903",
                     hgvsp="",
+                    protein_position="",
+                    amino_acids="",
                     sift="",
                     polyphen="",
                     am_class="likely_benign",
@@ -654,3 +681,349 @@ def test_dropouts_are_surfaced_in_the_benchmark_report(tmp_path: Path) -> None:
 
     assert report["csq_missing_in_vepyr"] == len(records)
     assert report["csq_missing_in_vep"] == 0
+
+
+# ── The uncapped mismatch-key set: the exclusion set the plugin gate rests on ─
+#
+# The plugin gate's blame rule needs the set of variants where the CORE already
+# disagrees, so those variants can be excluded before a plugin's own fields are
+# judged. An *approximate* exclusion set is worse than none: it silently
+# attributes core bugs to plugins on precisely the long tail it cannot see. The
+# capped `examples` therefore cannot serve this purpose — hence `mismatch_keys`.
+
+
+def key_of(chrom: str, pos: int, ref: str, alt: str) -> str:
+    """The comparator's rendering of a variant key: ``CHROM\\tPOS\\tREF\\tALT``."""
+    return f"{chrom}\t{pos}\t{ref}\t{alt}"
+
+
+def test_mismatch_keys_holds_every_key_while_examples_stay_capped(
+    tmp_path: Path,
+) -> None:
+    """Every mismatching key is retained; the examples remain a capped report.
+
+    The whole point of the attribute: spread the mismatches across MORE keys
+    than the example cap and the examples can no longer see them all. The
+    exclusion set must.
+    """
+    n_mismatching = MAX_EXAMPLES * 3
+    assert n_mismatching > MAX_EXAMPLES, "the cap must actually bite"
+
+    positions = [100_000 + i * 137 for i in range(n_mismatching)]
+    truth_records = [
+        (
+            "chr1",
+            pos,
+            "A",
+            "G",
+            [csq(feature=f"ENST{i:011d}", am_pathogenicity="0.1000")],
+        )
+        for i, pos in enumerate(positions)
+    ]
+    # vepyr disagrees on am_pathogenicity at EVERY one of them.
+    test_records = [
+        (
+            "chr1",
+            pos,
+            "A",
+            "G",
+            [csq(feature=f"ENST{i:011d}", am_pathogenicity="0.9000")],
+        )
+        for i, pos in enumerate(positions)
+    ]
+    truth = write_vcf(tmp_path / "vep.vcf", truth_records)
+    test = write_vcf(tmp_path / "vepyr.vcf", test_records)
+
+    result = compare_csq_fields(truth, test, fields=PLUGIN_FIELDS)
+
+    expected = {key_of("chr1", pos, "A", "G") for pos in positions}
+    assert result.field_mismatches["am_pathogenicity"] == n_mismatching
+    assert result.mismatch_keys["am_pathogenicity"] == expected
+    assert len(result.mismatch_keys["am_pathogenicity"]) == n_mismatching
+
+    # The examples are still a report, not a dump — unchanged, still capped.
+    examples = result.field_mismatch_examples["am_pathogenicity"]
+    assert len(examples) == MAX_EXAMPLES
+    assert {ex.key for ex in examples} < result.mismatch_keys["am_pathogenicity"]
+
+    # A compared field that never mismatched gets an empty set, not a KeyError.
+    assert result.mismatch_keys["am_class"] == set()
+    assert set(result.mismatch_keys) == set(result.fields_compared)
+
+
+def test_mismatch_keys_deduplicates_a_variant_mismatching_in_several_entries(
+    tmp_path: Path,
+) -> None:
+    """It is a set of *variants*, not of entry pairs: one bad variant, one key.
+
+    The counter stays per-entry-pair (three mismatching transcripts on one
+    variant are three mismatches); the key set collapses them to the one variant
+    that must be excluded.
+    """
+    truth = write_vcf(
+        tmp_path / "vep.vcf",
+        [
+            (
+                "chr1",
+                200_000,
+                "C",
+                "T",
+                [
+                    csq(allele="T", feature="ENST00000900", am_pathogenicity="0.11"),
+                    csq(allele="T", feature="ENST00000901", am_pathogenicity="0.22"),
+                    csq(allele="T", feature="ENST00000902", am_pathogenicity="0.33"),
+                ],
+            )
+        ],
+    )
+    test = write_vcf(
+        tmp_path / "vepyr.vcf",
+        [
+            (
+                "chr1",
+                200_000,
+                "C",
+                "T",
+                [
+                    csq(allele="T", feature="ENST00000900", am_pathogenicity="0.99"),
+                    csq(allele="T", feature="ENST00000901", am_pathogenicity="0.88"),
+                    csq(allele="T", feature="ENST00000902", am_pathogenicity="0.77"),
+                ],
+            )
+        ],
+    )
+
+    result = compare_csq_fields(truth, test, fields=PLUGIN_FIELDS)
+
+    assert result.field_mismatches["am_pathogenicity"] == 3
+    assert result.mismatch_keys["am_pathogenicity"] == {
+        key_of("chr1", 200_000, "C", "T")
+    }
+
+
+def test_mismatch_keys_excludes_order_only_differences(tmp_path: Path) -> None:
+    """``a&b`` vs ``b&a`` counts as a MATCH, so its key is not an exclusion.
+
+    The set must track exactly what :attr:`field_mismatches` counts — a key that
+    only differs in multi-value order is not a disagreement, and excluding it
+    would shrink the plugin gate for no reason.
+    """
+    truth = write_vcf(
+        tmp_path / "vep.vcf",
+        [
+            (
+                "chr1",
+                100,
+                "A",
+                "G",
+                [csq(consequence="splice_region_variant&intron_variant")],
+            )
+        ],
+    )
+    test = write_vcf(
+        tmp_path / "vepyr.vcf",
+        [
+            (
+                "chr1",
+                100,
+                "A",
+                "G",
+                [csq(consequence="intron_variant&splice_region_variant")],
+            )
+        ],
+    )
+
+    result = compare_csq_fields(truth, test, fields=["Consequence"])
+
+    assert result.field_order_mismatches["Consequence"] == 1
+    assert result.field_mismatches["Consequence"] == 0
+    assert result.mismatch_keys["Consequence"] == set()
+
+
+def test_mismatch_keys_are_empty_on_a_clean_run(tmp_path: Path) -> None:
+    """A clean comparison excludes nothing."""
+    records = realistic_records()
+    truth = write_vcf(tmp_path / "vep.vcf", records)
+    test = write_vcf(tmp_path / "vepyr.vcf", records)
+
+    result = compare_csq_fields(truth, test)
+
+    assert result.is_clean
+    assert result.mismatch_keys == dict.fromkeys(result.fields_compared, set())
+
+
+def test_core_mismatch_keys_let_the_gate_attribute_blame_by_set_difference(
+    tmp_path: Path,
+) -> None:
+    """The blame-attribution rule the plugin gate rests on, end to end.
+
+    A plugin's CSQ fields are *derived* from core engine attributes:
+    AlphaMissense keys its lookup on ``{ref_aa}{Protein_position}{alt_aa}``,
+    built from ``Amino_acids`` and ``Protein_position``. So when the core
+    diverges from VEP, the plugin is handed a wrong lookup key and its field
+    comes out wrong through no fault of its own — and a naive diff blames the
+    plugin.
+
+    Two verdicts over the same pair of files, one set difference:
+
+    * key A — the core agrees, the plugin's value is wrong: a GENUINE plugin bug;
+    * key B — the core disagrees (wrong amino acids), so the plugin's value is
+      wrong downstream of that: NOT the plugin's fault;
+    * key C — everything agrees.
+
+    The gate must find exactly ``{A}``.
+    """
+    key_a = ("chr1", 100, "A", "G")
+    key_b = ("chr1", 200, "C", "T")
+    key_c = ("chr1", 300, "G", "A")
+
+    truth_records = [
+        (
+            *key_a,
+            [
+                csq(
+                    feature="ENST00000A",
+                    protein_position="34",
+                    amino_acids="K/R",
+                    am_class="likely_benign",
+                    am_pathogenicity="0.1234",
+                )
+            ],
+        ),
+        (
+            *key_b,
+            [
+                csq(
+                    feature="ENST00000B",
+                    protein_position="88",
+                    amino_acids="E/K",
+                    am_class="likely_pathogenic",
+                    am_pathogenicity="0.9500",
+                )
+            ],
+        ),
+        (
+            *key_c,
+            [
+                csq(
+                    feature="ENST00000C",
+                    protein_position="12",
+                    amino_acids="A/T",
+                    am_class="likely_benign",
+                    am_pathogenicity="0.0500",
+                )
+            ],
+        ),
+    ]
+    test_records = [
+        # A: core identical, plugin score wrong — the plugin's own bug.
+        (
+            *key_a,
+            [
+                csq(
+                    feature="ENST00000A",
+                    protein_position="34",
+                    amino_acids="K/R",
+                    am_class="likely_benign",
+                    am_pathogenicity="0.5678",
+                )
+            ],
+        ),
+        # B: the CORE diverges — wrong amino acids and protein position, so the
+        # discriminator AlphaMissense looks up is wrong, so its score is wrong.
+        # The plugin is downstream of a core bug, not the cause of it.
+        (
+            *key_b,
+            [
+                csq(
+                    feature="ENST00000B",
+                    protein_position="89",
+                    amino_acids="E/Q",
+                    am_class="likely_benign",
+                    am_pathogenicity="0.2222",
+                )
+            ],
+        ),
+        # C: agreement.
+        (
+            *key_c,
+            [
+                csq(
+                    feature="ENST00000C",
+                    protein_position="12",
+                    amino_acids="A/T",
+                    am_class="likely_benign",
+                    am_pathogenicity="0.0500",
+                )
+            ],
+        ),
+    ]
+    truth = write_vcf(tmp_path / "vep.vcf", truth_records)
+    test = write_vcf(tmp_path / "vepyr.vcf", test_records)
+
+    # Verdict 1: the core fields — which variants does vepyr ALREADY get wrong?
+    core = compare_csq_fields(truth, test, fields=CORE_FIELDS)
+    # Verdict 2: the plugin's own fields, over the same pair of files.
+    plugin = compare_csq_fields(truth, test, fields=PLUGIN_FIELDS)
+
+    core_diverged = set().union(*core.mismatch_keys.values())
+    plugin_failed = set().union(*plugin.mismatch_keys.values())
+
+    assert core_diverged == {key_of(*key_b)}
+    assert plugin_failed == {key_of(*key_a), key_of(*key_b)}
+
+    # The rule. Exactly one genuine plugin failure — key A.
+    genuine_plugin_failures = plugin_failed - core_diverged
+    assert genuine_plugin_failures == {key_of(*key_a)}
+
+    # And what the naive diff would have said: TWO plugin failures, one of them
+    # a core bug wearing a plugin's name.
+    assert plugin.field_mismatches["am_pathogenicity"] == 2
+
+
+def test_mismatch_keys_is_not_added_to_the_report(tmp_path: Path) -> None:
+    """A new attribute for programmatic consumers — NOT a report change.
+
+    Every archived benchmark report reads :meth:`as_report_dict`'s shape, so the
+    payload's key set is frozen. The printed report is likewise untouched.
+    """
+    records = realistic_records()
+    truth = write_vcf(tmp_path / "vep.vcf", records)
+    # Mismatch am_class on every annotated variant — far more keys than the cap.
+    test = write_vcf(
+        tmp_path / "vepyr.vcf",
+        [
+            (
+                chrom,
+                pos,
+                ref,
+                alt,
+                [e.replace("|likely_benign|", "|likely_pathogenic|") for e in entries],
+            )
+            for chrom, pos, ref, alt, entries in records
+        ],
+    )
+
+    report = compare_vcfs(str(test), str(truth), "chr1")
+
+    assert set(report) == {
+        "variants_compared",
+        "variants_only_in_vepyr",
+        "csq_order_mismatch",
+        "csq_order_mismatch_examples",
+        "csq_order_ignored",
+        "csq_order_ignored_examples",
+        "csq_order_ignore_reason",
+        "variants_only_in_vep",
+        "csq_missing_in_vepyr",
+        "csq_missing_in_vep",
+        "csq_entry_count_match",
+        "csq_entry_count_mismatch",
+        "field_match_rates",
+        "field_mismatch_counts",
+        "field_mismatch_examples",
+        "field_order_mismatch_counts",
+        "field_order_mismatch_examples",
+    }
+    # The report still carries only the CAPPED examples, and no key sets.
+    assert len(report["field_mismatch_examples"]["am_class"]) == MAX_EXAMPLES  # type: ignore[index]


### PR DESCRIPTION
Plan B of the VEP plugin port factory. Plan: `docs/superpowers/plans/2026-07-14-plugin-factory-toolkit.md` (in this PR).

**949 tests pass** (910 pre-existing + 39 new), clippy/ruff/fmt clean.

## What this gives Plan C

`pip install vepyr` + a 14 MB mini-cache download is now enough to build a plugin cache from a TOML manifest and diff two VCFs field-by-field — no Rust toolchain, no 34 GB cache, no Perl.

## The mini-cache had to be BUILT, not sliced

The spec said "slice the existing cache to a region". That is impossible, and finding out why was the most useful thing this plan did. The local variation cache has **no `tier` column** (76 columns, none of them tier) while `plugin_cache::join` selects it — and it turns out it also has **no `chrom_manifest.json`**, so the current runtime cannot even open it. It predates the tiering work. So the region cache is now *rebuilt* with the current builder (`scripts/build_mini_cache.py`), which supplies `tier` (821,751 warm / 14,320,816 cold on chr22).

**The fixture's own test earned its keep immediately.** It compares annotation of the region with the FULL cache vs the MINI cache and demands body-identity — and it *failed first*, on a real slicer bug: the mini-cache had dropped a transcript sitting **4,723 bp before the region**, because VEP annotates transcripts up to `--distance` (default 5000 bp) away. A bare overlap filter excluded it while the annotator still wanted it. That is precisely the phantom "core drift" that would have poisoned Plan C's blame-attribution rule. Fixed with a 5 kb flank; now:

```
full: 990 records | mini: 990 records → BODY-IDENTICAL (matching sha256)
```

Result: **14 MB** tarball (63 MB extracted). Not published — that needs your approval.

## `vepyr.parity` — one comparator, two consumers

`compare_vcfs` lived inside an 809-line benchmark script. Plan C needs it; copying it would fork the arbiter of a 4-million-variant WGS benchmark. Extracted to `vepyr.parity`, and the extraction is **proven behaviour-preserving**: the original was loaded from `git show HEAD:` and run against the new one over real golden VEP VCFs — 18 comparisons, byte-identical stdout.

**Two real bugs surfaced, both landing squarely on the plugin gate, both fixed in their own commit:**

1. **A trailing newline was captured into the last CSQ field on sites-only VCFs.** `CSQ=([^;\t]+)` matches `\n`. The WGS benchmark is safe (it has FORMAT+sample, so INFO is never last) — but a *region* VEP run produces sites-only output, and plugin fields are appended at the **end** of the CSQ format string, which is exactly the field that catches the newline. The gate would have read an empty VEP value as `"\n"` and manufactured phantom mismatches. Proof it's fixed: the only field that moved in any run is `TRANSCRIPTION_FACTORS` — literally the last field of the real VEP format string.
2. **A total annotation dropout was invisible.** A variant where one side emitted no CSQ at all counted as "compared" and contributed nothing. A plugin that annotates *nothing* would have shown a clean field table.

## End-to-end proof

Real AlphaMissense data, sliced by binary-searching BGZF block boundaries over HTTP (26.5 MB fetched, not 613 MB), built through the Python API against the mini-cache: `[('chr22', 54624, warm=147, cold=54477)]`.

At `chr22:22,893,742 C>G` — the locus of the original manual parity run:
```
ENST00000390320  missense_variant  C/W  p.17  am_class=ambiguous  am_pathogenicity=0.4833
ENST00000390321  upstream_gene_variant   —    (empty)             (empty)
```
Values match the source rows byte-for-byte. The missense gate holds: **10,895 non-missense entries, 0 populated.**

## Also fixed: the `warm == 0` guard was muted through Python

`env_logger`'s default filter is `error`; the engine's guard is `warn`. So a broken manifest returned `[('chr22', 54624, 0, 54624)]` — not one row joined the variation cache — and printed **nothing**, on exactly the path Plan C's CI will use. Defaulted to `warn`. Plan C additionally asserts on the returned tuple rather than trusting a log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011JaQJ1j5wfA54dRxYmEtQs