### PR TITLE
ci: install VCF tools in publish tests

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -80,6 +80,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: astral-sh/setup-uv@v5
+      - name: Install VCF command-line tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bcftools tabix
       - name: Build and test
         run: |
           uv python install 3.12


### PR DESCRIPTION
## Summary

- install `bcftools` and `tabix` before running the Python test gate in the PyPI publish workflow
- keep the publish test environment aligned with the regular Linux CI matrix

## Root cause

The VEP comparison tests invoke `bgzip`. Regular CI installs the package that provides it, but the PyPI workflow did not. Release run [30552645037](https://github.com/biodatageeks/vepyr/actions/runs/30552645037) therefore failed in `test-python` with `FileNotFoundError: bgzip`: 6 failed and 14 errored tests, while 1,087 passed.

All other release jobs that completed before run termination passed. The Windows wheel job was externally cancelled while compiling and its log contains no compiler error. Publish and GitHub Release were skipped because their required gates did not all succeed. The exact Python 3.12 suite passes on the same master commit in normal CI when these packages are installed.

## Validation

- `uv run pytest -q tests/test_comparison_vcfio.py tests/test_comparison_compare.py` — 35 passed
- workflow YAML parses successfully
- `git diff --check` — clean

After merge, the 0.3.0 release must be started as a new workflow dispatch so it uses the updated workflow definition; rerunning the original failed job would reuse the old definition.