### PR TITLE
feat: byte-identical VCF output — preserve the input's INFO and FORMAT key order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,8 +1150,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-core"
-version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=7c866e07540aa8ae12d46e4878487911f659e8b9#7c866e07540aa8ae12d46e4878487911f659e8b9"
+version = "1.11.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=80f3a6c043899f8ded44eaab204b42735f805272#80f3a6c043899f8ded44eaab204b42735f805272"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1173,8 +1173,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-ensembl-cache"
-version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=7c866e07540aa8ae12d46e4878487911f659e8b9#7c866e07540aa8ae12d46e4878487911f659e8b9"
+version = "1.11.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=80f3a6c043899f8ded44eaab204b42735f805272#80f3a6c043899f8ded44eaab204b42735f805272"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1191,8 +1191,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-vcf"
-version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=7c866e07540aa8ae12d46e4878487911f659e8b9#7c866e07540aa8ae12d46e4878487911f659e8b9"
+version = "1.11.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=80f3a6c043899f8ded44eaab204b42735f805272#80f3a6c043899f8ded44eaab204b42735f805272"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1222,8 +1222,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-function-vep"
-version = "0.15.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=b90cbfc0fbd677ddadd63f230ff12a1363c8d7d6#b90cbfc0fbd677ddadd63f230ff12a1363c8d7d6"
+version = "0.16.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=e937e49ace4b4ba997a53be05da7bd7d6db0d399#e937e49ace4b4ba997a53be05da7bd7d6db0d399"
 dependencies = [
  "ahash",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,7 +1151,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-core"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=917962818b6a83179bd34b1ef9237000014ca250#917962818b6a83179bd34b1ef9237000014ca250"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=cdeb3d7f6676b32fdabd1682fb226b90638dcc14#cdeb3d7f6676b32fdabd1682fb226b90638dcc14"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1174,7 +1174,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-ensembl-cache"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=917962818b6a83179bd34b1ef9237000014ca250#917962818b6a83179bd34b1ef9237000014ca250"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=cdeb3d7f6676b32fdabd1682fb226b90638dcc14#cdeb3d7f6676b32fdabd1682fb226b90638dcc14"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1192,7 +1192,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-vcf"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=917962818b6a83179bd34b1ef9237000014ca250#917962818b6a83179bd34b1ef9237000014ca250"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=cdeb3d7f6676b32fdabd1682fb226b90638dcc14#cdeb3d7f6676b32fdabd1682fb226b90638dcc14"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1223,7 +1223,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-function-vep"
 version = "0.15.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=21a65f439766daa60658c2031bbd5c820ac51f9b#21a65f439766daa60658c2031bbd5c820ac51f9b"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=fe3735e05cb2eaf48f8aaa56d8df9163e0e1c0dd#fe3735e05cb2eaf48f8aaa56d8df9163e0e1c0dd"
 dependencies = [
  "ahash",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,7 +1151,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-core"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=cdeb3d7f6676b32fdabd1682fb226b90638dcc14#cdeb3d7f6676b32fdabd1682fb226b90638dcc14"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=7c866e07540aa8ae12d46e4878487911f659e8b9#7c866e07540aa8ae12d46e4878487911f659e8b9"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1174,7 +1174,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-ensembl-cache"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=cdeb3d7f6676b32fdabd1682fb226b90638dcc14#cdeb3d7f6676b32fdabd1682fb226b90638dcc14"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=7c866e07540aa8ae12d46e4878487911f659e8b9#7c866e07540aa8ae12d46e4878487911f659e8b9"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1192,7 +1192,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-vcf"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=cdeb3d7f6676b32fdabd1682fb226b90638dcc14#cdeb3d7f6676b32fdabd1682fb226b90638dcc14"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=7c866e07540aa8ae12d46e4878487911f659e8b9#7c866e07540aa8ae12d46e4878487911f659e8b9"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1223,7 +1223,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-function-vep"
 version = "0.15.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=fe3735e05cb2eaf48f8aaa56d8df9163e0e1c0dd#fe3735e05cb2eaf48f8aaa56d8df9163e0e1c0dd"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=b90cbfc0fbd677ddadd63f230ff12a1363c8d7d6#b90cbfc0fbd677ddadd63f230ff12a1363c8d7d6"
 dependencies = [
  "ahash",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,7 +1151,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-core"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.10.0#0d9730c83f3ac936efa1595335caee0b0e538fa1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=917962818b6a83179bd34b1ef9237000014ca250#917962818b6a83179bd34b1ef9237000014ca250"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1174,7 +1174,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-ensembl-cache"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.10.0#0d9730c83f3ac936efa1595335caee0b0e538fa1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=917962818b6a83179bd34b1ef9237000014ca250#917962818b6a83179bd34b1ef9237000014ca250"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1192,7 +1192,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-vcf"
 version = "1.10.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.10.0#0d9730c83f3ac936efa1595335caee0b0e538fa1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=917962818b6a83179bd34b1ef9237000014ca250#917962818b6a83179bd34b1ef9237000014ca250"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1223,7 +1223,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-function-vep"
 version = "0.15.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?tag=v0.17.0#391f94bd94ff2ba815fc42e6114d71276b3dc54a"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=21a65f439766daa60658c2031bbd5c820ac51f9b#21a65f439766daa60658c2031bbd5c820ac51f9b"
 dependencies = [
  "ahash",
  "async-trait",
@@ -1231,6 +1231,7 @@ dependencies = [
  "chrono",
  "coitrees",
  "datafusion",
+ "datafusion-bio-format-core",
  "datafusion-bio-format-ensembl-cache",
  "datafusion-bio-format-vcf",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,14 +42,16 @@ log = "0.4"
 env_logger = { version = "0.11", default-features = false }
 serde_json = "1"
 
-# Released bio-functions v0.17.0 and bio-formats v1.10.0 tags. v0.16.0 brought the
-# contig-context prefetch (bio-functions PR #210); v0.17.0 adds the matching
-# bio-formats bump (PR #211). These two MUST move together: bio-function-vep pins
-# its own bio-formats tag, and two different tags are two different sources to
-# cargo, so a mismatch compiles the formats crates twice and `CacheSourceType` /
-# the VCF writer types then fail to cross into `CacheBuilder` (E0308).
-# These pins make the vepyr 0.2.0 VEP 115.2/116.0 support contract reproducible
-# without machine-local patches.
-datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "21a65f439766daa60658c2031bbd5c820ac51f9b", features = ["cache-builder"] }
-datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "917962818b6a83179bd34b1ef9237000014ca250" }
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "917962818b6a83179bd34b1ef9237000014ca250" }
+# Byte-parity revisions: bio-formats PR #243 carries each record's INFO and
+# FORMAT key order through a read/write round trip, and bio-functions PR #216
+# turns that on for annotation output. Together with the merged header and QUAL
+# work they make vepyr's VCF output byte-identical to Ensembl VEP 116.0.
+# The two MUST move together: bio-function-vep pins its own bio-formats rev, and
+# two different revs are two different sources to cargo, so a mismatch compiles
+# the formats crates twice and `CacheSourceType` / the VCF writer types then fail
+# to cross into `CacheBuilder` (E0308).
+# Revisions, not tags, until those PRs merge and the engines cut releases.
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "fe3735e05cb2eaf48f8aaa56d8df9163e0e1c0dd", features = ["cache-builder"] }
+datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "cdeb3d7f6676b32fdabd1682fb226b90638dcc14" }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "cdeb3d7f6676b32fdabd1682fb226b90638dcc14" }
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,8 @@ serde_json = "1"
 # the formats crates twice and `CacheSourceType` / the VCF writer types then fail
 # to cross into `CacheBuilder` (E0308).
 # Revisions, not tags, until those PRs merge and the engines cut releases.
-datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "fe3735e05cb2eaf48f8aaa56d8df9163e0e1c0dd", features = ["cache-builder"] }
-datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "cdeb3d7f6676b32fdabd1682fb226b90638dcc14" }
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "cdeb3d7f6676b32fdabd1682fb226b90638dcc14" }
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "b90cbfc0fbd677ddadd63f230ff12a1363c8d7d6", features = ["cache-builder"] }
+datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "7c866e07540aa8ae12d46e4878487911f659e8b9" }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "7c866e07540aa8ae12d46e4878487911f659e8b9" }
+
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,6 @@ serde_json = "1"
 # the VCF writer types then fail to cross into `CacheBuilder` (E0308).
 # These pins make the vepyr 0.2.0 VEP 115.2/116.0 support contract reproducible
 # without machine-local patches.
-datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", tag = "v0.17.0", features = ["cache-builder"] }
-datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.10.0" }
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.10.0" }
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "21a65f439766daa60658c2031bbd5c820ac51f9b", features = ["cache-builder"] }
+datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "917962818b6a83179bd34b1ef9237000014ca250" }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "917962818b6a83179bd34b1ef9237000014ca250" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,17 +42,19 @@ log = "0.4"
 env_logger = { version = "0.11", default-features = false }
 serde_json = "1"
 
-# Byte-parity revisions: bio-formats PR #243 carries each record's INFO and
-# FORMAT key order through a read/write round trip, and bio-functions PR #216
-# turns that on for annotation output. Together with the merged header and QUAL
-# work they make vepyr's VCF output byte-identical to Ensembl VEP 116.0.
+# Released bio-formats v1.11.0 and bio-functions v0.18.0, pinned by the commit
+# each tag names. v1.11.0 carries each record's INFO and FORMAT key order through
+# a read/write round trip; v0.18.0 turns that on for annotation output and stops
+# stripping field metadata from the annotation schema, without which the carry
+# reaches the writer unrecognised. Together with the merged header and QUAL work
+# they make vepyr's VCF output byte-identical to Ensembl VEP 116.0 on all 22
+# autosomes of HG002.
 # The two MUST move together: bio-function-vep pins its own bio-formats rev, and
 # two different revs are two different sources to cargo, so a mismatch compiles
 # the formats crates twice and `CacheSourceType` / the VCF writer types then fail
 # to cross into `CacheBuilder` (E0308).
-# Revisions, not tags, until those PRs merge and the engines cut releases.
-datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "b90cbfc0fbd677ddadd63f230ff12a1363c8d7d6", features = ["cache-builder"] }
-datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "7c866e07540aa8ae12d46e4878487911f659e8b9" }
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "7c866e07540aa8ae12d46e4878487911f659e8b9" }
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "e937e49ace4b4ba997a53be05da7bd7d6db0d399", features = ["cache-builder"] }
+datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "80f3a6c043899f8ded44eaab204b42735f805272" }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "80f3a6c043899f8ded44eaab204b42735f805272" }
 
 

--- a/docs/testing-vep.md
+++ b/docs/testing-vep.md
@@ -437,6 +437,42 @@ inputs. Both plain and block-gzipped VCFs are accepted on the vepyr and VEP side
 when the reference is bgzipped and indexed, the per-contig slice is a tabix seek
 rather than a full scan.
 
+## Checking byte-level agreement
+
+The field-by-field comparison above answers whether the annotation *content* matches.
+`md5_concordance.py` answers the stricter question of whether the *bytes* match, which
+is what makes vepyr's output a drop-in replacement for VEP's rather than an equivalent
+one. It hashes each file's header and record body separately and compares the digests.
+
+```bash
+cd e2e-testing/scripts
+
+# One pair, with a breakdown of what differs
+uv run python md5_concordance.py \
+    --pair ../results/116/fast_chr21/vep_chr21_merged.vcf /tmp/vepyr_chr21.vcf \
+    --mode strict --explain
+
+# Every per-contig pair under a results directory
+uv run python md5_concordance.py --results-dir ../results/116 --mode strict
+```
+
+`--mode canonical` (the default) normalizes the differences that are known to be
+cosmetic before hashing — QUAL rendered numerically, INFO and FORMAT keys sorted,
+FORMAT keys missing in every sample dropped — so a matching canonical digest means the
+two files carry identical annotation content and differ only in how they were written.
+`--mode strict` hashes the record bytes as-is.
+
+Each tool stamps the header with run provenance that can never match (wall-clock time,
+absolute cache paths, tool versions), so those lines are excluded from the header digest
+on both sides. A `HEADER DIFF` alongside a passing body is therefore a real difference
+worth reading — most often a `##bcftools_normCommand` showing that the two sides were
+annotated from differently normalized inputs.
+
+!!! note "Whole-genome runs are disk-hungry"
+    A plain-text annotated WGS output is ~29 GB, and the parallel path needs roughly
+    twice that while it assembles worker shards. Compare one contig at a time and
+    delete each output before starting the next.
+
 See [`e2e-testing/README.md`](https://github.com/biodatageeks/vepyr/blob/master/e2e-testing/README.md)
 for the full flag reference, the profile-to-reference-file mapping, the expected data
 directory layout, and the dependency-bump workflow.

--- a/e2e-testing/README.md
+++ b/e2e-testing/README.md
@@ -138,6 +138,57 @@ The aggregate summary contains a per-contig performance table, root cause
 classification with GitHub issue links, field-level delta vs the previous
 benchmark, and mismatch examples per field.
 
+### `md5_concordance.py` -- byte-level agreement with Ensembl VEP
+
+`run_comparison.py` answers "is the annotation content the same?" by comparing
+86 CSQ fields per record. This answers a narrower and stricter question: "are
+the bytes the same?" It hashes each file's header and record body separately
+and compares the digests, which is what qualifies vepyr's VCF output as a
+drop-in replacement for VEP's rather than merely an equivalent one.
+
+Two modes over the same digest pipeline:
+
+- `canonical` (default) normalizes the serialization differences that are known
+  to be cosmetic before hashing -- QUAL rendered numerically, INFO and FORMAT
+  keys sorted, FORMAT keys missing in every sample dropped. Two files with the
+  same canonical digest carry identical annotation content and differ only in
+  how they were written out.
+- `strict` hashes the record bytes as-is. This is the parity target: it passes
+  only once vepyr reproduces VEP's serialization exactly.
+
+```bash
+# One pair, with a breakdown of what differs
+uv run python md5_concordance.py \
+    --pair results/116/fast_chr21/vep_chr21_merged.vcf /tmp/vepyr_chr21.vcf \
+    --mode strict --explain
+
+# Every per-contig pair under a results directory
+uv run python md5_concordance.py --results-dir results/116 --mode strict
+
+# Narrow the pairing when a directory holds more than one output per side
+uv run python md5_concordance.py --results-dir results/116 \
+    --vepyr-glob 'vepyr_parquet_*.vcf'
+```
+
+Exit status is 0 when every pair concords in the selected mode and 1 otherwise;
+2 signals a usage or input error. `--explain` classifies each differing record
+by column, which is how a serialization gap gets named -- `INFO order`,
+`FORMAT KEYS (-['PS'] +[])` and `SAMPLE1 keys` were the three classes that the
+record-layout carry closed.
+
+**Reading the header column.** Header and body are hashed separately because
+each tool stamps its own run provenance -- wall-clock time, absolute cache
+paths, tool versions -- that can never match. Those lines are excluded from the
+header digest on both sides (`##VEP*` for VEP, `##datafusion-bio-function-vep*`
+for vepyr). A run that reports `PASS` with `HEADER DIFF` therefore has a real,
+non-provenance header difference worth reading: when both sides are annotated
+from the *same* normalized input the header should agree exactly, and a
+`##bcftools_normCommand` difference means they were not.
+
+Whole-genome runs need care about disk: a plain-text output is ~29 GB per
+worker-count and the parallel path needs roughly twice that while assembling,
+so compare one contig at a time and delete each output before the next.
+
 ### `verify_parity_gate.py` -- machine-enforced release gate
 
 The comparison runner produces evidence; the parity gate decides whether that

--- a/e2e-testing/scripts/md5_concordance.py
+++ b/e2e-testing/scripts/md5_concordance.py
@@ -1,0 +1,457 @@
+#!/usr/bin/env python3
+"""MD5 concordance between Ensembl VEP and vepyr VCF output.
+
+Two modes, same digest pipeline:
+
+  canonical (default)
+      Normalizes the serialization differences that are known to be cosmetic
+      before hashing: QUAL rendered numerically, INFO and FORMAT keys sorted,
+      FORMAT keys that are missing in every sample dropped. Two files with the
+      same canonical digest carry identical annotation content and differ only
+      in how they were written out.
+
+  strict
+      Hashes the record bytes as-is. This is the eventual parity target: it
+      passes only once vepyr reproduces VEP's serialization exactly.
+
+Headers are hashed separately from the body in both modes, because VEP appends
+run-specific provenance (``##VEP=`` carries a timestamp) that never matches and
+is not meant to.
+
+Exit status is 0 when every pair concords in the selected mode, 1 otherwise.
+
+Examples
+--------
+Compare one directory of per-chromosome runs::
+
+    ./md5_concordance.py --results-dir ../results/116
+
+Compare a single pair, and explain what differs::
+
+    ./md5_concordance.py --pair vep_chr21.vcf vepyr_chr21.vcf --explain
+
+Gate a release on exact bytes::
+
+    ./md5_concordance.py --results-dir ../results/116 --mode strict
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from dataclasses import dataclass, field
+import hashlib
+import os
+from pathlib import Path
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from comparison import vcfio  # noqa: E402
+
+# VEP appends these to the input header; they carry run-specific provenance
+# (wall-clock time, absolute cache path, per-module git hashes), so they can
+# never match byte for byte and are excluded from the header digest.
+VOLATILE_HEADER_PREFIXES = ("##VEP=", "##VEP-command-line=")
+
+MISSING = (".", "")
+
+# Default per-chromosome layout under e2e-testing/results/<release>/:
+#   fast_chr21/vep_chr21_merged.vcf
+#   fast_chr21/vepyr_parquet_chr21_merged.vcf
+DEFAULT_VEP_GLOB = "vep_*.vcf*"
+DEFAULT_VEPYR_GLOB = "vepyr_*.vcf*"
+
+_CHR_RE = re.compile(r"(chr(?:\d+|[XYM]|MT))", re.IGNORECASE)
+
+
+class ConcordanceError(RuntimeError):
+    """Raised when inputs cannot be paired or read."""
+
+
+# --------------------------------------------------------------------------
+# canonicalization
+# --------------------------------------------------------------------------
+
+
+def normalize_qual(value: str) -> str:
+    """Render QUAL numerically so ``50`` and ``50.00`` collapse to one form."""
+    if value in MISSING:
+        return "."
+    try:
+        q = float(value)
+    except ValueError:
+        return value
+    return str(int(q)) if q == int(q) else repr(q)
+
+
+def canonical_record(line: str) -> str:
+    """Canonicalize one VCF data line.
+
+    Sorts INFO and FORMAT keys, normalizes QUAL, and drops FORMAT keys whose
+    value is missing in every sample. Leaves every value untouched — this
+    reorders and reformats, it never rewrites content.
+    """
+    cols = line.split("\t")
+    if len(cols) < 8:
+        return line
+
+    cols[5] = normalize_qual(cols[5])
+    cols[7] = ";".join(sorted(cols[7].split(";")))
+
+    if len(cols) > 9:
+        keys = cols[8].split(":")
+        samples = [c.split(":") for c in cols[9:]]
+        # A sample may truncate trailing keys; pad so key/value zips line up.
+        samples = [s + ["."] * (len(keys) - len(s)) for s in samples]
+        keep = sorted(
+            (i for i in range(len(keys)) if any(s[i] not in MISSING for s in samples)),
+            key=lambda i: keys[i],
+        )
+        cols[8] = ":".join(keys[i] for i in keep)
+        for n, s in enumerate(samples):
+            cols[9 + n] = ":".join(s[i] for i in keep)
+
+    return "\t".join(cols)
+
+
+# --------------------------------------------------------------------------
+# digests
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class Digest:
+    """Header and body digests for one VCF, plus a record count."""
+
+    header: str
+    body: str
+    records: int
+    header_lines: int
+
+
+def digest_vcf(path: str, mode: str) -> Digest:
+    """Hash a VCF's header and body separately under `mode`."""
+    header = hashlib.md5()
+    body = hashlib.md5()
+    records = 0
+    header_lines = 0
+
+    with vcfio.open_text(path) as handle:
+        for line in handle:
+            if line.startswith("#"):
+                if line.startswith(VOLATILE_HEADER_PREFIXES):
+                    continue
+                header_lines += 1
+                header.update(line.encode())
+                continue
+            records += 1
+            if mode == "strict":
+                body.update(line.encode())
+            else:
+                body.update((canonical_record(line.rstrip("\n")) + "\n").encode())
+
+    return Digest(header.hexdigest(), body.hexdigest(), records, header_lines)
+
+
+# --------------------------------------------------------------------------
+# explain
+# --------------------------------------------------------------------------
+
+
+def classify_difference(vep_line: str, vepyr_line: str) -> list[str]:
+    """Name the ways two records differ, ignoring nothing."""
+    names = ["CHROM", "POS", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO", "FORMAT"]
+    a, b = vep_line.split("\t"), vepyr_line.split("\t")
+    if len(a) != len(b):
+        return [f"column count {len(a)} vs {len(b)}"]
+
+    out: list[str] = []
+    for i, (x, y) in enumerate(zip(a, b)):
+        if x == y:
+            continue
+        name = names[i] if i < len(names) else f"SAMPLE{i - 8}"
+
+        if name == "QUAL":
+            same = normalize_qual(x) == normalize_qual(y)
+            out.append("QUAL format" if same else "QUAL VALUE")
+        elif name == "INFO":
+            ax = {kv.split("=")[0]: kv for kv in x.split(";") if kv}
+            by = {kv.split("=")[0]: kv for kv in y.split(";") if kv}
+            if set(ax) != set(by):
+                out.append(
+                    f"INFO KEYS (-{sorted(set(ax) - set(by))} +{sorted(set(by) - set(ax))})"
+                )
+            elif any(ax[k] != by[k] for k in ax):
+                out.append("INFO VALUES")
+            else:
+                out.append("INFO order")
+        elif name == "FORMAT":
+            ax, by = x.split(":"), y.split(":")
+            if set(ax) != set(by):
+                out.append(
+                    f"FORMAT KEYS (-{sorted(set(ax) - set(by))} +{sorted(set(by) - set(ax))})"
+                )
+            else:
+                out.append("FORMAT order")
+        elif name.startswith("SAMPLE"):
+            ma = dict(zip(a[8].split(":"), x.split(":")))
+            mb = dict(zip(b[8].split(":"), y.split(":")))
+            shared = set(ma) & set(mb)
+            if any(ma[k] != mb[k] for k in shared):
+                out.append(f"{name} VALUES")
+            elif set(ma) != set(mb):
+                out.append(f"{name} keys")
+            else:
+                out.append(f"{name} order")
+        else:
+            out.append(f"{name} VALUE")
+    return out
+
+
+def explain(vep: str, vepyr: str, limit: int) -> Counter:
+    """Classify every differing record. Returns a histogram of difference kinds."""
+    kinds: Counter = Counter()
+    with vcfio.open_text(vep) as fa, vcfio.open_text(vepyr) as fb:
+        rows_a = (ln.rstrip("\n") for ln in fa if not ln.startswith("#"))
+        rows_b = (ln.rstrip("\n") for ln in fb if not ln.startswith("#"))
+        for n, (x, y) in enumerate(zip(rows_a, rows_b), start=1):
+            if x == y:
+                kinds["identical"] += 1
+                continue
+            for kind in classify_difference(x, y):
+                kinds[kind] += 1
+            if limit and n >= limit:
+                break
+    return kinds
+
+
+def diff_headers(vep: str, vepyr: str) -> tuple[list[str], list[str]]:
+    """Return (only-in-VEP, only-in-vepyr) header lines, volatile ones excluded."""
+
+    def load(path: str) -> list[str]:
+        with vcfio.open_text(path) as handle:
+            return [
+                ln.rstrip("\n")
+                for ln in handle
+                if ln.startswith("#") and not ln.startswith(VOLATILE_HEADER_PREFIXES)
+            ]
+
+    a, b = load(vep), load(vepyr)
+    sa, sb = set(a), set(b)
+    return [ln for ln in a if ln not in sb], [ln for ln in b if ln not in sa]
+
+
+# --------------------------------------------------------------------------
+# pairing
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class Pair:
+    """One VEP/vepyr file pair to compare."""
+
+    label: str
+    vep: str
+    vepyr: str
+
+
+@dataclass
+class Result:
+    """Outcome of comparing one pair."""
+
+    pair: Pair
+    vep: Digest
+    vepyr: Digest
+    notes: list[str] = field(default_factory=list)
+
+    @property
+    def body_match(self) -> bool:
+        return self.vep.body == self.vepyr.body
+
+    @property
+    def header_match(self) -> bool:
+        return self.vep.header == self.vepyr.header
+
+    @property
+    def count_match(self) -> bool:
+        return self.vep.records == self.vepyr.records
+
+
+def label_for(path: Path) -> str:
+    """Derive a short label from a path, preferring an embedded contig name."""
+    match = _CHR_RE.search(path.name) or _CHR_RE.search(path.parent.name)
+    return match.group(1).lower() if match else path.parent.name or path.stem
+
+
+def sort_key(label: str) -> tuple[int, int, str]:
+    """Order labels so chr2 sorts before chr10 and chrX comes last."""
+    match = _CHR_RE.fullmatch(label)
+    if not match:
+        return (2, 0, label)
+    name = match.group(1)[3:].upper()
+    return (0, int(name), "") if name.isdigit() else (1, 0, name)
+
+
+def discover_pairs(results_dir: Path, vep_glob: str, vepyr_glob: str) -> list[Pair]:
+    """Find VEP/vepyr pairs in `results_dir`, one per subdirectory."""
+    pairs: list[Pair] = []
+    candidates = sorted(p for p in results_dir.iterdir() if p.is_dir())
+    if not candidates:
+        candidates = [results_dir]
+
+    for directory in candidates:
+        vep = sorted(directory.glob(vep_glob))
+        vepyr = sorted(directory.glob(vepyr_glob))
+        if not vep or not vepyr:
+            continue
+        if len(vep) > 1 or len(vepyr) > 1:
+            raise ConcordanceError(
+                f"{directory}: ambiguous match — "
+                f"vep={[p.name for p in vep]} vepyr={[p.name for p in vepyr]}. "
+                "Narrow it with --vep-glob/--vepyr-glob."
+            )
+        pairs.append(Pair(label_for(vep[0]), str(vep[0]), str(vepyr[0])))
+
+    pairs.sort(key=lambda p: sort_key(p.label))
+    return pairs
+
+
+# --------------------------------------------------------------------------
+# reporting
+# --------------------------------------------------------------------------
+
+
+def compare(pair: Pair, mode: str) -> Result:
+    """Digest both sides of `pair` and note any structural mismatch."""
+    result = Result(pair, digest_vcf(pair.vep, mode), digest_vcf(pair.vepyr, mode))
+    if not result.count_match:
+        result.notes.append(
+            f"record count {result.vep.records} vs {result.vepyr.records}"
+        )
+    if not result.header_match:
+        result.notes.append(
+            f"header differs ({result.vep.header_lines} vs "
+            f"{result.vepyr.header_lines} lines, volatile ##VEP lines excluded)"
+        )
+    return result
+
+
+def print_table(results: list[Result], mode: str) -> None:
+    width = max((len(r.pair.label) for r in results), default=5)
+    print(f"\n  mode: {mode}    body digest over {len(results)} pair(s)\n")
+    print(f"  {'':<{width}}  {'RECORDS':>10}  {'BODY MD5':<34}  BODY  HEADER")
+    print(f"  {'-' * width}  {'-' * 10}  {'-' * 34}  ----  ------")
+    for r in results:
+        digest = (
+            r.vep.body if r.body_match else f"{r.vep.body[:12]}…/{r.vepyr.body[:12]}…"
+        )
+        print(
+            f"  {r.pair.label:<{width}}  {r.vep.records:>10,}  {digest:<34}  "
+            f"{'ok' if r.body_match else 'DIFF':<4}  {'ok' if r.header_match else 'DIFF'}"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument(
+        "--results-dir",
+        help="Directory of per-contig run directories (e.g. ../results/116).",
+    )
+    source.add_argument(
+        "--pair",
+        nargs=2,
+        metavar=("VEP_VCF", "VEPYR_VCF"),
+        help="Compare exactly one VEP/vepyr file pair.",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("canonical", "strict"),
+        default="canonical",
+        help="canonical normalizes cosmetic serialization first (default); "
+        "strict hashes record bytes as-is.",
+    )
+    parser.add_argument("--vep-glob", default=DEFAULT_VEP_GLOB)
+    parser.add_argument("--vepyr-glob", default=DEFAULT_VEPYR_GLOB)
+    parser.add_argument(
+        "--explain",
+        action="store_true",
+        help="For each mismatching pair, classify how the records differ.",
+    )
+    parser.add_argument(
+        "--explain-limit",
+        type=int,
+        default=0,
+        metavar="N",
+        help="Stop classifying after N records (0 = all).",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        if args.pair:
+            vep, vepyr = args.pair
+            pairs = [Pair(label_for(Path(vep)), vep, vepyr)]
+        else:
+            results_dir = Path(args.results_dir).expanduser().resolve()
+            if not results_dir.is_dir():
+                raise ConcordanceError(f"not a directory: {results_dir}")
+            pairs = discover_pairs(results_dir, args.vep_glob, args.vepyr_glob)
+            if not pairs:
+                raise ConcordanceError(
+                    f"no VEP/vepyr pairs under {results_dir} matching "
+                    f"{args.vep_glob!r} and {args.vepyr_glob!r}"
+                )
+
+        results = [compare(pair, args.mode) for pair in pairs]
+    except ConcordanceError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except OSError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    print_table(results, args.mode)
+
+    mismatched = [r for r in results if not r.body_match]
+
+    for r in results:
+        if r.notes:
+            print(f"\n  {r.pair.label}:")
+            for note in r.notes:
+                print(f"    - {note}")
+            if not r.header_match:
+                only_vep, only_vepyr = diff_headers(r.pair.vep, r.pair.vepyr)
+                for line in only_vep[:8]:
+                    print(f"      VEP only  : {line[:110]}")
+                for line in only_vepyr[:8]:
+                    print(f"      vepyr only: {line[:110]}")
+
+    if args.explain and mismatched:
+        for r in mismatched:
+            print(f"\n  {r.pair.label} — record differences:")
+            for kind, count in explain(
+                r.pair.vep, r.pair.vepyr, args.explain_limit
+            ).most_common():
+                print(f"    {count:>12,}  {kind}")
+
+    total = sum(r.vep.records for r in results)
+    if mismatched:
+        print(
+            f"\n  FAIL: {len(mismatched)}/{len(results)} pair(s) differ "
+            f"in {args.mode} mode ({total:,} records compared)\n"
+        )
+        return 1
+
+    print(
+        f"\n  PASS: {len(results)}/{len(results)} pair(s) concord "
+        f"in {args.mode} mode ({total:,} records compared)\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/e2e-testing/scripts/md5_concordance.py
+++ b/e2e-testing/scripts/md5_concordance.py
@@ -50,10 +50,16 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from comparison import vcfio  # noqa: E402
 
-# VEP appends these to the input header; they carry run-specific provenance
-# (wall-clock time, absolute cache path, per-module git hashes), so they can
-# never match byte for byte and are excluded from the header digest.
-VOLATILE_HEADER_PREFIXES = ("##VEP=", "##VEP-command-line=")
+# Each tool appends its own provenance to the input header: wall-clock time,
+# absolute cache paths, tool and per-module versions. None of it can match byte
+# for byte, and none of it is meant to, so both sides' lines are excluded from
+# the header digest.
+VOLATILE_HEADER_PREFIXES = (
+    "##VEP=",
+    "##VEP-command-line=",
+    "##datafusion-bio-function-vep=",
+    "##datafusion-bio-function-vep-command-line=",
+)
 
 MISSING = (".", "")
 
@@ -333,7 +339,8 @@ def compare(pair: Pair, mode: str) -> Result:
     if not result.header_match:
         result.notes.append(
             f"header differs ({result.vep.header_lines} vs "
-            f"{result.vepyr.header_lines} lines, volatile ##VEP lines excluded)"
+            f"{result.vepyr.header_lines} lines, "
+            "each side's own provenance lines excluded)"
         )
     return result
 

--- a/performance-tests/vepyr/scripts/benchmark_vepyr_once.py
+++ b/performance-tests/vepyr/scripts/benchmark_vepyr_once.py
@@ -45,6 +45,16 @@ def parse_args() -> argparse.Namespace:
             "with the published plain-output numbers"
         ),
     )
+    parser.add_argument(
+        "--preserve-record-layout",
+        choices=("on", "off"),
+        default="on",
+        help=(
+            "Write each record's own INFO and FORMAT key order (annotate()'s "
+            "default). 'off' is the ablation arm: same binary, one flag, so a "
+            "cost can be attributed to the carry rather than to the build"
+        ),
+    )
     return parser.parse_args()
 
 
@@ -92,6 +102,7 @@ def main() -> int:
         "cache_type": args.cache_type,
         "reference_fasta": str(args.reference_fasta),
         "compression": args.compression,
+        "preserve_record_layout": args.preserve_record_layout == "on",
         "output_vcf": str(args.output_vcf),
         "workers": args.workers,
         "vep_expected_records": args.expected_records,
@@ -135,6 +146,7 @@ def main() -> int:
             workers=args.workers,
             hgvs=True,
             output_vcf=str(args.output_vcf),
+            preserve_record_layout=args.preserve_record_layout == "on",
         )
 
         annotation_seconds = time.perf_counter() - annotation_started

--- a/performance-tests/vepyr/scripts/run_vepyr_worker_scaling.py
+++ b/performance-tests/vepyr/scripts/run_vepyr_worker_scaling.py
@@ -35,6 +35,7 @@ SUMMARY_FIELDS = [
     "cache_type",
     "workers",
     "compression",
+    "preserve_record_layout",
     "status",
     "exit_status",
     "annotation_seconds",
@@ -64,6 +65,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--workers", nargs="+", type=int, default=read_worker_counts())
     parser.add_argument("--name-prefix", default="HG002")
     parser.add_argument("--minimum-free-gib", type=float, default=40.0)
+    parser.add_argument(
+        "--preserve-record-layout",
+        choices=("on", "off"),
+        default="on",
+        help="Passed through to each measured run; 'off' is the ablation arm",
+    )
     parser.add_argument("--force", action="store_true")
     parser.add_argument(
         "--compression",
@@ -310,6 +317,8 @@ def main() -> int:
             str(args.expected_records),
             "--compression",
             args.compression,
+            "--preserve-record-layout",
+            args.preserve_record_layout,
         ]
 
         print(

--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -185,117 +185,127 @@ pub fn annotate_to_vcf_file(
         )
     });
 
-    let config = AnnotateVcfConfig {
-        everything: opts
-            .get("everything")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false),
-        extended_probes: opts
-            .get("extended_probes")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(true),
-        expected_cache_version: opts
-            .get("expected_cache_version")
-            .and_then(|v| v.as_str())
-            .map(String::from),
-        reference_fasta_path: opts
-            .get("reference_fasta_path")
-            .and_then(|v| v.as_str())
-            .map(String::from),
-        hgvs: opts.get("hgvs").and_then(|v| v.as_bool()).unwrap_or(false),
-        hgvsc: opts.get("hgvsc").and_then(|v| v.as_bool()).unwrap_or(false),
-        hgvsp: opts.get("hgvsp").and_then(|v| v.as_bool()).unwrap_or(false),
-        shift_hgvs: opts.get("shift_hgvs").and_then(|v| v.as_bool()),
-        no_escape: opts
-            .get("no_escape")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false),
-        remove_hgvsp_version: opts
-            .get("remove_hgvsp_version")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false),
-        hgvsp_use_prediction: opts
-            .get("hgvsp_use_prediction")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false),
-        merged: false,
-        refseq: false,
-        gencode_basic: opts
-            .get("gencode_basic")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false),
-        gencode_primary: opts
-            .get("gencode_primary")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false),
-        all_refseq: opts
-            .get("all_refseq")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false),
-        exclude_predicted: opts
-            .get("exclude_predicted")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false),
-        pick: opts.get("pick").and_then(|v| v.as_bool()).unwrap_or(false),
-        pick_allele: opts
-            .get("pick_allele")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false),
-        per_gene: opts
-            .get("per_gene")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false),
-        pick_allele_gene: opts
-            .get("pick_allele_gene")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false),
-        flag_pick: opts
-            .get("flag_pick")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false),
-        flag_pick_allele: opts
-            .get("flag_pick_allele")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false),
-        flag_pick_allele_gene: opts
-            .get("flag_pick_allele_gene")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false),
-        pick_order: opts
-            .get("pick_order")
-            .and_then(|v| v.as_str())
-            .map(String::from),
-        failed: opts.get("failed").and_then(|v| v.as_i64()),
-        distance: opts.get("distance").and_then(|v| {
-            v.as_str()
-                .map(String::from)
-                .or_else(|| v.as_i64().map(|n| n.to_string()))
-        }),
-        buffer_size: opts
-            .get("buffer_size")
-            .and_then(|v| v.as_u64())
-            .and_then(|n| usize::try_from(n).ok())
-            .filter(|n| *n > 0)
-            .unwrap_or(datafusion_bio_function_vep::vcf_sink::VEP_DEFAULT_BUFFER_SIZE),
-        // Single annotation-concurrency knob (vepyr `workers` -> engine `workers`).
-        // The engine derives its lookup parallelism from `workers`; the sink's
-        // DataFusion `target_partitions` stays 1 so the annotated VCF is written
-        // as a single ordered output (the streaming path, which polars drains in
-        // parallel, sets its own SessionConfig partitions from `workers`).
-        workers,
-        target_partitions: 1,
-        compression: vcf_compression,
-        show_progress,
-        on_batch_written: callback,
-        plugin_cache_root: opts
-            .get("plugin_cache_root")
-            .and_then(|v| v.as_str())
-            .map(std::path::PathBuf::from),
-        // Recorded as a `tool` attribute in the output header's provenance
-        // lines. The header key itself is fixed by the engine.
-        provenance_tool_name: Some(env!("CARGO_PKG_NAME").to_string()),
-        provenance_tool_version: Some(env!("CARGO_PKG_VERSION").to_string()),
-    };
+    // `AnnotateVcfConfig` is `#[non_exhaustive]`, so it is built by assignment
+    // rather than a struct literal: a field the engine adds then defaults here
+    // instead of failing this crate's build.
+    #[allow(clippy::field_reassign_with_default)]
+    let mut config = AnnotateVcfConfig::default();
+    config.everything = opts
+        .get("everything")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    config.extended_probes = opts
+        .get("extended_probes")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
+    config.expected_cache_version = opts
+        .get("expected_cache_version")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    config.reference_fasta_path = opts
+        .get("reference_fasta_path")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    config.hgvs = opts.get("hgvs").and_then(|v| v.as_bool()).unwrap_or(false);
+    config.hgvsc = opts.get("hgvsc").and_then(|v| v.as_bool()).unwrap_or(false);
+    config.hgvsp = opts.get("hgvsp").and_then(|v| v.as_bool()).unwrap_or(false);
+    config.shift_hgvs = opts.get("shift_hgvs").and_then(|v| v.as_bool());
+    config.no_escape = opts
+        .get("no_escape")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    config.remove_hgvsp_version = opts
+        .get("remove_hgvsp_version")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    config.hgvsp_use_prediction = opts
+        .get("hgvsp_use_prediction")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    config.merged = false;
+    config.refseq = false;
+    config.gencode_basic = opts
+        .get("gencode_basic")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    config.gencode_primary = opts
+        .get("gencode_primary")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    config.all_refseq = opts
+        .get("all_refseq")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    config.exclude_predicted = opts
+        .get("exclude_predicted")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    config.pick = opts.get("pick").and_then(|v| v.as_bool()).unwrap_or(false);
+    config.pick_allele = opts
+        .get("pick_allele")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    config.per_gene = opts
+        .get("per_gene")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    config.pick_allele_gene = opts
+        .get("pick_allele_gene")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    config.flag_pick = opts
+        .get("flag_pick")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    config.flag_pick_allele = opts
+        .get("flag_pick_allele")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    config.flag_pick_allele_gene = opts
+        .get("flag_pick_allele_gene")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    config.pick_order = opts
+        .get("pick_order")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    config.failed = opts.get("failed").and_then(|v| v.as_i64());
+    config.distance = opts.get("distance").and_then(|v| {
+        v.as_str()
+            .map(String::from)
+            .or_else(|| v.as_i64().map(|n| n.to_string()))
+    });
+    config.buffer_size = opts
+        .get("buffer_size")
+        .and_then(|v| v.as_u64())
+        .and_then(|n| usize::try_from(n).ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(datafusion_bio_function_vep::vcf_sink::VEP_DEFAULT_BUFFER_SIZE);
+    // Single annotation-concurrency knob (vepyr `workers` -> engine `workers`).
+    // The engine derives its lookup parallelism from `workers`; the sink's
+    // DataFusion `target_partitions` stays 1 so the annotated VCF is written
+    // as a single ordered output (the streaming path, which polars drains in
+    // parallel, sets its own SessionConfig partitions from `workers`).
+    config.workers = workers;
+    config.target_partitions = 1;
+    config.compression = vcf_compression;
+    config.show_progress = show_progress;
+    config.on_batch_written = callback;
+    config.plugin_cache_root = opts
+        .get("plugin_cache_root")
+        .and_then(|v| v.as_str())
+        .map(std::path::PathBuf::from);
+    // Recorded as a `tool` attribute in the output header's provenance
+    // lines. The header key itself is fixed by the engine.
+    config.provenance_tool_name = Some(env!("CARGO_PKG_NAME").to_string());
+    config.provenance_tool_version = Some(env!("CARGO_PKG_VERSION").to_string());
+    // Reproduce each input record's INFO key order and FORMAT key list in the
+    // output. On unless the caller opts out: byte agreement with Ensembl VEP is
+    // the point of the VCF path, and neither survives the typed columns.
+    config.preserve_record_layout = opts
+        .get("preserve_record_layout")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
 
     // Release the GIL so the Python background thread (in __init__.py) can
     // let Jupyter's main thread pump display updates for tqdm progress bars.

--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -291,6 +291,10 @@ pub fn annotate_to_vcf_file(
             .get("plugin_cache_root")
             .and_then(|v| v.as_str())
             .map(std::path::PathBuf::from),
+        // Recorded as a `tool` attribute in the output header's provenance
+        // lines. The header key itself is fixed by the engine.
+        provenance_tool_name: Some(env!("CARGO_PKG_NAME").to_string()),
+        provenance_tool_version: Some(env!("CARGO_PKG_VERSION").to_string()),
     };
 
     // Release the GIL so the Python background thread (in __init__.py) can

--- a/src/vepyr/__init__.py
+++ b/src/vepyr/__init__.py
@@ -740,6 +740,7 @@ def annotate(
     plugin_cache_root: str | None = None,
     # Output mode
     output_vcf: str | None = None,
+    preserve_record_layout: bool = True,
     show_progress: bool = True,
     compression: str | None = None,
     on_batch_written: "Callable[[int, int, int], None] | None" = None,
@@ -858,6 +859,14 @@ def annotate(
         Compression is auto-detected from the file extension: ``.vcf`` for
         plain text, ``.vcf.gz`` or ``.vcf.bgz`` for block-gzipped (bgzf).
         Override with the ``compression`` parameter.
+    preserve_record_layout : bool
+        Write each record's INFO fields in the order the input wrote them, and
+        its own FORMAT keys (default: True). Both are per record and neither
+        survives the typed columns, so turning this off reorders INFO to schema
+        order and drops any FORMAT key whose value is missing in every sample.
+        Ensembl VEP keeps both by copying the input line and only appending to
+        INFO, so byte agreement with it needs this on. Only used when
+        ``output_vcf`` is set.
     show_progress : bool
         Show a progress bar on stderr during VCF output (default: True).
         Only used when ``output_vcf`` is set.
@@ -1012,6 +1021,8 @@ def annotate(
         opts["workers"] = workers
     if plugin_cache_root is not None:
         opts["plugin_cache_root"] = plugin_cache_root
+    if not preserve_record_layout:
+        opts["preserve_record_layout"] = False
 
     options_json = json.dumps(opts)
 

--- a/tests/test_md5_concordance.py
+++ b/tests/test_md5_concordance.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+SCRIPTS_DIR = Path(__file__).parents[1] / "e2e-testing" / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import md5_concordance as mc  # noqa: E402
+
+RECORD = "chr21\t100\t.\tA\tT\t50\tPASS\tDP=1;CSQ=T|missense\tGT\t0/1\n"
+
+VEP_HEADER = """##fileformat=VCFv4.2
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Depth">
+##VEP="v116" time="2026-08-23 09:00:00" cache="/opt/vep/.vep"
+##VEP-command-line='vep --everything'
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG002
+"""
+
+VEPYR_HEADER = """##fileformat=VCFv4.2
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Depth">
+##datafusion-bio-function-vep="0.15.0" cache="/home/me/cache" tool="vepyr 0.3.0"
+##datafusion-bio-function-vep-command-line='{"engine":"datafusion-bio-function-vep"}'
+#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tHG002
+"""
+
+
+def write(tmp_path: Path, name: str, header: str, record: str = RECORD) -> str:
+    path = tmp_path / name
+    path.write_text(header + record)
+    return str(path)
+
+
+def test_each_sides_own_provenance_is_left_out_of_the_header_digest(tmp_path):
+    """Both tools stamp the header with run-specific provenance — wall-clock
+    time, absolute cache paths, tool versions — that can never match. Only
+    VEP's was excluded, so vepyr's own lines reported as a header difference
+    against output that is otherwise identical."""
+    vep = mc.digest_vcf(write(tmp_path, "vep.vcf", VEP_HEADER), "strict")
+    vepyr = mc.digest_vcf(write(tmp_path, "vepyr.vcf", VEPYR_HEADER), "strict")
+
+    assert vep.header == vepyr.header
+    assert vep.header_lines == vepyr.header_lines == 3
+
+
+def test_excluded_provenance_does_not_hide_a_real_header_difference(tmp_path):
+    other = VEPYR_HEADER.replace('Description="Depth"', 'Description="Read depth"')
+    vep = mc.digest_vcf(write(tmp_path, "vep.vcf", VEP_HEADER), "strict")
+    vepyr = mc.digest_vcf(write(tmp_path, "vepyr.vcf", other), "strict")
+
+    assert vep.header != vepyr.header
+    only_vep, only_vepyr = mc.diff_headers(
+        write(tmp_path, "vep2.vcf", VEP_HEADER),
+        write(tmp_path, "vepyr2.vcf", other),
+    )
+    assert only_vep == ['##INFO=<ID=DP,Number=1,Type=Integer,Description="Depth">']
+    assert only_vepyr == [
+        '##INFO=<ID=DP,Number=1,Type=Integer,Description="Read depth">'
+    ]
+
+
+def test_provenance_lines_never_reach_the_body_digest(tmp_path):
+    vep = mc.digest_vcf(write(tmp_path, "vep.vcf", VEP_HEADER), "strict")
+    vepyr = mc.digest_vcf(write(tmp_path, "vepyr.vcf", VEPYR_HEADER), "strict")
+
+    assert vep.body == vepyr.body
+    assert vep.records == vepyr.records == 1


### PR DESCRIPTION
Closes the last gap between vepyr's VCF output and Ensembl VEP's.

> **Depends on** biodatageeks/datafusion-bio-formats#243 and biodatageeks/datafusion-bio-functions#216, pinned here by rev. Merge those and cut engine releases before this lands on a tag.

## Result

`md5_concordance.py --mode strict` now **passes on all 22 autosomes** of HG002 against Ensembl VEP 116.0 — **4,096,123 records**, byte-identical bodies.

| | chr21 | chr22 | all 22 |
|---|---|---|---|
| records | 55,812 | 50,861 | 4,096,123 |
| strict body | ✅ match | ✅ match | ✅ 22/22 |

Before this change strict mode reported three classes on every record:

```
55,812  FORMAT KEYS (-['PS'] +[])
55,812  SAMPLE1 keys
55,714  INFO order
```

## Why they could not be fixed in the writer

A record's INFO key order and its FORMAT key list are **per record**, and the engine reads a VCF into typed columns where every record carries every key the header declares, in schema order.

- **No file-level key order exists.** chr6 carries both `GT:PS:DP:ADALL:AD:GQ` and `GT:AD:PS` in one file.
- **`PS` cannot be recovered.** `Type=Integer` means a source `.` parses to null — identical to the key being absent. The writer inferred the key list from which values were non-missing and dropped it.

Ensembl VEP avoids the whole problem by never re-rendering: it copies the input line and appends to INFO (`OutputFactory/VCF.pm`).

## The change

The engine now carries two dictionary-encoded key-order columns from reader to writer (values are not carried — they already round-trip). `annotate()` gains `preserve_record_layout`, **on by default**, because byte agreement is the point of the VCF path. Passing `False` restores the previous output — verified byte-identical to the pre-change build's record body.

`AnnotateVcfConfig` is `#[non_exhaustive]` upstream now, so the config is built by assignment rather than a struct literal. That is what stops the next engine field addition from breaking this crate's build, as the last two did.

## Also here

The comparator excluded VEP's `##VEP*` provenance from the header digest but not vepyr's own `##datafusion-bio-function-vep*`, so identical output still reported a header difference. Both sides' provenance is excluded now, with tests that a real header difference still surfaces. chr21's header report goes from "234 vs 236 lines" with four differing lines to "234 vs 234" with one — the `##bcftools_normCommand` the reference run's different normalization left behind, which is a harness artifact and evidence the header passthrough works.

## Verification

- 1,110 Python tests (2 skipped), including the full golden suite with the flag defaulting on; clippy and ruff clean.
- 22/22 chromosomes in strict mode, run one at a time so the gate never needed more than one extra output on a disk already at 96%.
- Serial and `workers=4` produce the same body digest on chr21 (`a42bbf6468779da3c6ad0102c5bfd8e2`), so the sharded path does not diverge.

## Residual

QUAL is byte-correct for this corpus but not in general: it renders at f32 source precision, so an input written `50.0` returns as `50`. Every QUAL in HG002 is integral. Arbitrary-input parity still depends on datafusion-bio-formats#241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NifnHcLFdXTnLepZtnAxsB