### PR TITLE
test(e2e): plugin comparison profiles + representation-only field equality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1149,6 +1149,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-bio-format-bed"
+version = "1.11.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=80f3a6c043899f8ded44eaab204b42735f805272#80f3a6c043899f8ded44eaab204b42735f805272"
+dependencies = [
+ "async-compression",
+ "async-stream",
+ "async-trait",
+ "bytes",
+ "datafusion",
+ "datafusion-bio-format-core",
+ "datafusion-execution",
+ "env_logger",
+ "futures",
+ "futures-util",
+ "log",
+ "noodles-bed",
+ "noodles-bgzf 0.49.0",
+ "opendal",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "datafusion-bio-format-core"
 version = "1.11.0"
 source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=80f3a6c043899f8ded44eaab204b42735f805272#80f3a6c043899f8ded44eaab204b42735f805272"
@@ -1223,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-function-vep"
 version = "0.16.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=e937e49ace4b4ba997a53be05da7bd7d6db0d399#e937e49ace4b4ba997a53be05da7bd7d6db0d399"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=86fd72d4b716fd3cdd2d85520ab81dea325507be#86fd72d4b716fd3cdd2d85520ab81dea325507be"
 dependencies = [
  "ahash",
  "async-trait",
@@ -1231,6 +1254,7 @@ dependencies = [
  "chrono",
  "coitrees",
  "datafusion",
+ "datafusion-bio-format-bed",
  "datafusion-bio-format-core",
  "datafusion-bio-format-ensembl-cache",
  "datafusion-bio-format-vcf",
@@ -3162,6 +3186,20 @@ dependencies = [
  "noodles-vcf",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "noodles-bed"
+version = "0.36.0"
+source = "git+https://github.com/biodatageeks/noodles.git?rev=42a3c0165617b7b8f9f5c5905287968eef92e31e#42a3c0165617b7b8f9f5c5905287968eef92e31e"
+dependencies = [
+ "bstr",
+ "lexical-core",
+ "memchr",
+ "noodles-bgzf 0.49.0",
+ "noodles-core 0.20.0",
+ "noodles-csi",
+ "noodles-tabix",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,8 +1245,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-function-vep"
-version = "0.16.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=1345fd5ca5b7dc097825813b05856ad8c3bca578#1345fd5ca5b7dc097825813b05856ad8c3bca578"
+version = "0.17.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=01fa21f8533de17aeffa5ee9042381c4171ef02b#01fa21f8533de17aeffa5ee9042381c4171ef02b"
 dependencies = [
  "ahash",
  "async-trait",
@@ -1266,7 +1266,10 @@ dependencies = [
  "log",
  "nohash-hasher",
  "noodles-core 0.16.0",
+ "noodles-core 0.20.0",
+ "noodles-csi",
  "noodles-fasta",
+ "noodles-tabix",
  "parquet",
  "rapidhash",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-function-vep"
 version = "0.16.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=86fd72d4b716fd3cdd2d85520ab81dea325507be#86fd72d4b716fd3cdd2d85520ab81dea325507be"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=1345fd5ca5b7dc097825813b05856ad8c3bca578#1345fd5ca5b7dc097825813b05856ad8c3bca578"
 dependencies = [
  "ahash",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,17 +42,19 @@ log = "0.4"
 env_logger = { version = "0.11", default-features = false }
 serde_json = "1"
 
-# Released bio-formats v1.11.0 and bio-functions v0.18.0, pinned by the commit
+# Released bio-formats v1.11.0 and bio-functions v0.19.0, pinned by the commit
 # each tag names. v1.11.0 carries each record's INFO and FORMAT key order through
-# a read/write round trip; v0.18.0 turns that on for annotation output and stops
-# stripping field metadata from the annotation schema, without which the carry
-# reaches the writer unrecognised. Together with the merged header and QUAL work
-# they make vepyr's VCF output byte-identical to Ensembl VEP 116.0 on all 22
-# autosomes of HG002.
+# a read/write round trip; v0.18.0 turned that on for annotation output and
+# stopped stripping field metadata from the annotation schema, without which the
+# carry reaches the writer unrecognised. v0.19.0 adds the plugin cache-builder
+# work: source-level tabix selection for indexed delimited sources, multi-part
+# manifests, and registration of the tabix staging slice as headerless. Together
+# with the merged header and QUAL work they make vepyr's VCF output
+# byte-identical to Ensembl VEP 116.0 on all 22 autosomes of HG002.
 # The two MUST move together: bio-function-vep pins its own bio-formats rev, and
 # two different revs are two different sources to cargo, so a mismatch compiles
 # the formats crates twice and `CacheSourceType` / the VCF writer types then fail
 # to cross into `CacheBuilder` (E0308).
-datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "1345fd5ca5b7dc097825813b05856ad8c3bca578", features = ["cache-builder"] }
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "01fa21f8533de17aeffa5ee9042381c4171ef02b", features = ["cache-builder"] }
 datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "80f3a6c043899f8ded44eaab204b42735f805272" }
 datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "80f3a6c043899f8ded44eaab204b42735f805272" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,6 @@ serde_json = "1"
 # two different revs are two different sources to cargo, so a mismatch compiles
 # the formats crates twice and `CacheSourceType` / the VCF writer types then fail
 # to cross into `CacheBuilder` (E0308).
-datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "e937e49ace4b4ba997a53be05da7bd7d6db0d399", features = ["cache-builder"] }
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "86fd72d4b716fd3cdd2d85520ab81dea325507be", features = ["cache-builder"] }
 datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "80f3a6c043899f8ded44eaab204b42735f805272" }
 datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "80f3a6c043899f8ded44eaab204b42735f805272" }
-
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,6 @@ serde_json = "1"
 # two different revs are two different sources to cargo, so a mismatch compiles
 # the formats crates twice and `CacheSourceType` / the VCF writer types then fail
 # to cross into `CacheBuilder` (E0308).
-datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "86fd72d4b716fd3cdd2d85520ab81dea325507be", features = ["cache-builder"] }
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "1345fd5ca5b7dc097825813b05856ad8c3bca578", features = ["cache-builder"] }
 datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "80f3a6c043899f8ded44eaab204b42735f805272" }
 datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "80f3a6c043899f8ded44eaab204b42735f805272" }

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -101,8 +101,19 @@ Two rules are in use upstream:
 
 | rule | what Ensembl does | plugins |
 |---|---|---|
-| `minimised` | calls `get_matched_variant_alleles()`, which runs `trim_sequences()` over **both** the variant and the data row — trimming shared prefix *and* suffix, in both orders — then compares `(ref, alt, pos)` | CADD, AlphaMissense |
-| `exact` | compares `(start, ref, alt)` verbatim | SpliceAI, dbNSFP, and core `--custom ...,exact` (ClinVar) |
+| `minimised` | calls `get_matched_variant_alleles()`, which runs `trim_sequences()` over **both** the variant and the data row — trimming shared prefix *and* suffix, in both orders — then compares `(ref, alt, pos)` | CADD, AlphaMissense, ClinVar |
+| `exact` | compares `(start, ref, alt)` verbatim | SpliceAI, dbNSFP |
+
+**ClinVar is `minimised`, despite being loaded with `--custom ...,exact`.** The
+`exact` there names the *overlap mode*, not the allele rule — core still
+minimises the alleles first, then requires exact overlap. The golden VEP 116
+reference settles it: `chr1:65364614 GT>TT` is annotated `ClinVar=1258041`,
+whose source record is the 1 bp SNV `G>T` at the same position. Reaching it
+from `GT/TT` needs the shared trailing `T` trimmed, so this is full
+`trim_sequences()` behaviour — a suffix trim, not just the narrower
+leading-anchor-base shift. A verbatim comparison would emit nothing, and a
+1 bp feature could not have exactly overlapped the 2 bp unminimised variant
+either.
 
 The distinction bites whenever a record is **not in minimal form**. `bcftools
 norm -m -both` splits a multi-allelic record without re-trimming its halves, so

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -85,8 +85,72 @@ source and map it to CSQ fields.
   plugins (the value is emitted on every transcript line).
 - **`[[value_columns]]`** *(1+)* — `column`, `csq_field` (output field name),
   `type` (`Utf8` / `Float32` / `Int32`). **Declaration order = CSQ output order.**
+- **`allele_match`** *(optional)* — `"exact"` (default) or `"minimised"`. Which
+  one is correct is decided by the plugin's own Ensembl implementation, not by
+  preference; see [Allele matching](#allele-matching-exact-vs-minimised).
 
 There is **no `[tier]` block** — tiering is inherited from the variation cache.
+
+## Allele matching: `exact` vs `minimised`
+
+Ensembl's plugins do **not** agree on how a variant is compared to a row of
+their data file, so neither can vepyr. Getting this wrong is silent: the wrong
+setting either drops annotations Ensembl reports, or invents ones it does not.
+
+Two rules are in use upstream:
+
+| rule | what Ensembl does | plugins |
+|---|---|---|
+| `minimised` | calls `get_matched_variant_alleles()`, which runs `trim_sequences()` over **both** the variant and the data row — trimming shared prefix *and* suffix, in both orders — then compares `(ref, alt, pos)` | CADD, AlphaMissense |
+| `exact` | compares `(start, ref, alt)` verbatim | SpliceAI, dbNSFP, and core `--custom ...,exact` (ClinVar) |
+
+The distinction bites whenever a record is **not in minimal form**. `bcftools
+norm -m -both` splits a multi-allelic record without re-trimming its halves, so
+this is routine rather than exotic:
+
+```text
+chr21:13973877  REF=TTGTGTGTGTGTG  ALT=GTGTGTGTGTGTG   # really just T>G
+chr21:26062230  REF=AAC            ALT=ACAC            # really just an inserted C
+```
+
+CADD keys the first as `T/G` in its per-base file. Under `minimised` Ensembl
+reduces the variant and matches; under `exact` it does not — and SpliceAI, whose
+rows at that position are plain SNVs, reports nothing. Both are correct *for
+their own plugin*.
+
+### Trim order is load-bearing
+
+`trim_sequences()` can trim prefix-first or suffix-first, and for a non-minimal
+indel **the two orders land on different coordinates — and therefore different
+variants**. Ensembl's VCF parser builds the `VariationFeature` prefix-first
+(left-first), so that is the only order that reproduces its output:
+
+| VCF record | left-first (Ensembl) | right-first |
+|---|---|---|
+| `CGTGTGT/CGTGT` | `GT/-` at 13836153 — no row there, so empty, as VEP reports | `GT/-` at 13836149 — a **different variant's** score |
+| `AAC/ACAC` | `-/C` at 26062231 — the row VEP reports | same |
+
+Getting this backwards is silent and produces confident wrong answers: on chr21
+a right-first reduction invented 5,288 CADD scores VEP does not emit, and
+regressed ClinVar and SpliceAI from clean.
+
+!!! warning "Never set `minimised` to gain hits"
+    Reducing alleles for an `exact` plugin produces annotations Ensembl does not
+    emit — SpliceAI gained 68 spurious hits on chr21 that way. The setting is a
+    statement about what upstream does, not a tuning knob.
+
+To decide the setting for a new plugin, read its `.pm`: if `run()` calls
+`get_matched_variant_alleles`, use `minimised`; if it compares `$vf->{start}`
+and the allele strings with `==`/`eq`, use `exact`.
+
+!!! note "Ensembl's fetch window"
+    `get_matched_variant_alleles` is not the whole story upstream. CADD.pm first
+    fetches `[VF.start - 2, VF.end]` from the tabix file, so a row whose *file*
+    position falls outside that window is never even considered — which is why
+    VEP reports nothing for `CGTGTGT/CGTGT` even though a `GT/-` row exists
+    nearby. Left-first reduction happens to land outside that row's reach too,
+    so vepyr agrees without emulating the window; if a future mismatch traces
+    back here, this is the mechanism to check.
 
 ### Example: AlphaMissense (per-transcript)
 

--- a/docs/testing-vep.md
+++ b/docs/testing-vep.md
@@ -398,9 +398,17 @@ uv run python run_comparison.py --release 115
 # A specific pick-mode profile
 uv run python run_comparison.py --release 115 --profile merged_pick_allele_gene
 
-# Plugin fields, against a VEP reference built with the same five plugins
-uv run python run_comparison.py --release 116 --profile merged_plugins
+# Plugin fields, against a VEP reference built with the same five plugins.
+# Plugin references are written one file per contig, so name the contig.
+uv run python run_comparison.py --release 116 --profile merged_plugins --chroms 22
 ```
+
+!!! note "Plugin profiles need a contig"
+    `generate_vep_plugin_references.sh` writes one reference per contig under
+    `output/{release}/plugins/`, so unlike the whole-genome profiles there is no
+    single file to slice. Pass a single `--chroms` value, or `--vep` explicitly.
+    Modes that read no reference at all, such as `--skip-annotate` aggregation
+    of stored reports, do not need either.
 
 !!! note "Plugin profiles"
     `merged_plugins` attaches the plugin cache

--- a/docs/testing-vep.md
+++ b/docs/testing-vep.md
@@ -397,7 +397,23 @@ uv run python run_comparison.py --release 115
 
 # A specific pick-mode profile
 uv run python run_comparison.py --release 115 --profile merged_pick_allele_gene
+
+# Plugin fields, against a VEP reference built with the same five plugins
+uv run python run_comparison.py --release 116 --profile merged_plugins
 ```
+
+!!! note "Plugin profiles"
+    `merged_plugins` attaches the plugin cache
+    (`cache/plugin_cache_{release}/`, or `--plugin-cache`) so ClinVar, SpliceAI,
+    CADD, AlphaMissense, and dbNSFP CSQ fields are comparable against a VEP
+    reference produced with the same five plugins. `merged_plugins_base` reads
+    that same reference with no plugin cache attached: the comparison then
+    restricts itself to the shared fields, which separates a core-field
+    difference from anything the plugin machinery introduced.
+
+    These are comparison scenarios, not release gates. `verify_parity_gate.py`
+    pins the Ensembl core CSQ contract and refuses a plugin profile outright
+    rather than silently gating a field set it does not describe.
 
 !!! note "`--release` is required"
     It selects both the Parquet cache (`cache/{release}_GRCh38_{flavour}`) and the VEP
@@ -416,6 +432,7 @@ uv run python run_comparison.py --release 115 --profile merged_pick_allele_gene
     merged                                     ok           ok
     refseq                                     ok           ok
     merged_pick_allele                         ok no reference
+    merged_plugins                              -  no plugins
     ```
 
 Contigs default to whatever the reference's tabix index contains, intersected with the

--- a/e2e-testing/scripts/build_vep_plugin_reference.sh
+++ b/e2e-testing/scripts/build_vep_plugin_reference.sh
@@ -45,10 +45,27 @@ fetch_slice() {
   local output="$3"
   local kind="$4"
 
+  # A slice indexed for the right contig is not necessarily current: rolling
+  # sources keep their filename. Reusing a stale one would be recorded by
+  # plugin_provenance() as having been built from the *current* corpus, so the
+  # sidecar would vouch for data the reference never saw. Bind reuse to the
+  # identity the slice was actually cut from.
+  local want=""
+  if [[ -n "$SOURCE_BASE" ]]; then
+    want="$(source_identity "$SOURCE_BASE" "$remote_path" 2>/dev/null || true)"
+  fi
+
   if [[ -s "$output" && -s "$output.tbi" ]] && \
       tabix -l "$output" | grep -Fxq "$region"; then
-    echo "Reusing slice: $output"
-    return
+    if [[ -z "$want" ]]; then
+      echo "Reusing slice (source identity unavailable): $output"
+      return
+    fi
+    if [[ -s "$output.identity" && "$(cat "$output.identity")" == "$want" ]]; then
+      echo "Reusing slice: $output"
+      return
+    fi
+    echo "Re-slicing $output: source changed since it was cut"
   fi
 
   if [[ -z "$SOURCE_BASE" ]]; then
@@ -73,6 +90,12 @@ fetch_slice() {
   if ! tabix -l "$output" | grep -Fxq "$region"; then
     echo "ERROR: slice $output contains no indexed region $region" >&2
     exit 1
+  fi
+
+  if [[ -n "$want" ]]; then
+    printf '%s\n' "$want" > "$output.identity"
+  else
+    rm -f "$output.identity"
   fi
 }
 
@@ -245,16 +268,35 @@ normalize_lexical() {
 # Absolute, symlink-free where the path exists, ".."-free always. The leaf need
 # not exist yet.
 canonical_path() {
-  local path dir base
+  local path dir rest resolved
   path="$(normalize_lexical "$1")"
   if [[ -d "$path" ]]; then
     ( cd "$path" 2>/dev/null && pwd -P )
     return
   fi
-  dir="$(dirname "$path")"
-  base="$(basename "$path")"
+  # Walk up to the longest existing ancestor and resolve that, then re-append
+  # the components that do not exist yet. Looking only at the immediate parent
+  # is not enough: with several missing components the parent is absent too,
+  # and returning the lexical path would leave a symlinked ancestor unresolved
+  # -- so "$DATA/link/new/sub", where link points outside $DATA, would still
+  # pass the containment test below.
+  rest=""
+  dir="$path"
+  while [[ "$dir" != "/" && ! -d "$dir" ]]; do
+    if [[ -z "$rest" ]]; then
+      rest="$(basename "$dir")"
+    else
+      rest="$(basename "$dir")/$rest"
+    fi
+    dir="$(dirname "$dir")"
+  done
   if [[ -d "$dir" ]]; then
-    printf '%s/%s\n' "$( cd "$dir" 2>/dev/null && pwd -P )" "$base"
+    resolved="$( cd "$dir" 2>/dev/null && pwd -P )"
+    if [[ "$resolved" == "/" ]]; then
+      printf '/%s\n' "$rest"
+    else
+      printf '%s/%s\n' "$resolved" "$rest"
+    fi
   else
     printf '%s\n' "$path"
   fi

--- a/e2e-testing/scripts/build_vep_plugin_reference.sh
+++ b/e2e-testing/scripts/build_vep_plugin_reference.sh
@@ -36,6 +36,8 @@ mkdir -p "$WORK/input" "$WORK/output" "$WORK/plugins" "$SLICES"
 # still receives ordinary local indexed files. Existing complete slices are
 # reused, making an interrupted build resumable.
 SOURCE_BASE="${VEP_PLUGIN_SOURCE_URL:-}"
+# shellcheck source=lib/source_identity.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/source_identity.sh"
 
 fetch_slice() {
   local remote_path="$1"
@@ -193,8 +195,19 @@ verify_plugin dbNSFP 1574736e0371b12378211914db6f5de720eeba395cd42517fbe689ceded
 plugin_provenance() {
   local plugin
   for plugin in AlphaMissense CADD SpliceAI dbNSFP; do
-    printf '%s %s\n' "$plugin" "$(sha256_file "$PLUGIN_DIR/${plugin}.pm")"
+    printf 'PLUGIN %s %s\n' "$plugin" "$(sha256_file "$PLUGIN_DIR/${plugin}.pm")"
   done
+  # The reference also depends on the plugin *data*, and several sources roll
+  # under a fixed filename (ClinVar above all). Record what the server reported
+  # for each, so a data refresh invalidates the reference too.
+  if [[ -n "$SOURCE_BASE" ]]; then
+    all_source_identities "$SOURCE_BASE" || {
+      echo "ERROR: could not read source identities from $SOURCE_BASE" >&2
+      exit 1
+    }
+  else
+    echo "SOURCE unavailable (slices reused; VEP_PLUGIN_SOURCE_URL unset)"
+  fi
 }
 
 if ! grep -q 'my \$alt_alleles = \$bvf->alt_alleles' "$PLUGIN_DIR/CADD.pm"; then

--- a/e2e-testing/scripts/build_vep_plugin_reference.sh
+++ b/e2e-testing/scripts/build_vep_plugin_reference.sh
@@ -58,7 +58,20 @@ fetch_slice() {
   if [[ -s "$output" && -s "$output.tbi" ]] && \
       tabix -l "$output" | grep -Fxq "$region"; then
     if [[ -z "$want" ]]; then
-      echo "Reusing slice (source identity unavailable): $output"
+      # No SOURCE_BASE at all means slices were supplied by hand and there is
+      # nothing to verify against -- that is a declared mode, and the sidecar
+      # records "unavailable". A configured server that merely failed to answer
+      # is different: reusing blind would let connectivity recover before
+      # plugin_provenance() runs, which would then stamp the current identity
+      # onto output cut from a stale slice -- exactly the false witness the
+      # identity record exists to prevent.
+      if [[ -n "$SOURCE_BASE" ]]; then
+        echo "ERROR: cannot reach $SOURCE_BASE to verify $output" >&2
+        echo "       Refusing to reuse a slice whose currency cannot be established." >&2
+        echo "       Retry when the source server is reachable, or delete the slice." >&2
+        exit 1
+      fi
+      echo "Reusing slice (no source server configured): $output"
       return
     fi
     if [[ -s "$output.identity" && "$(cat "$output.identity")" == "$want" ]]; then

--- a/e2e-testing/scripts/build_vep_plugin_reference.sh
+++ b/e2e-testing/scripts/build_vep_plugin_reference.sh
@@ -31,6 +31,64 @@ PLUGIN_DIR="${VEP_PLUGIN_DIR:-$WORK/plugins}"
 SLICES="$WORK/slices"
 mkdir -p "$WORK/input" "$WORK/output" "$WORK/plugins" "$SLICES"
 
+# Optionally materialise chromosome slices directly from a range-readable
+# bgzip/tabix source tree. This keeps the 168 GB source corpus remote while VEP
+# still receives ordinary local indexed files. Existing complete slices are
+# reused, making an interrupted build resumable.
+SOURCE_BASE="${VEP_PLUGIN_SOURCE_URL:-}"
+
+fetch_slice() {
+  local remote_path="$1"
+  local region="$2"
+  local output="$3"
+  local kind="$4"
+
+  if [[ -s "$output" && -s "$output.tbi" ]] && \
+      tabix -l "$output" | grep -Fxq "$region"; then
+    echo "Reusing slice: $output"
+    return
+  fi
+
+  if [[ -z "$SOURCE_BASE" ]]; then
+    echo "ERROR: missing slice $output and VEP_PLUGIN_SOURCE_URL is unset" >&2
+    exit 1
+  fi
+
+  local partial="${output}.partial.$$.gz"
+  echo "Slicing ${SOURCE_BASE%/}/${remote_path} region $region"
+  tabix -h "${SOURCE_BASE%/}/${remote_path}" "$region" | bgzip -c > "$partial"
+  mv "$partial" "$output"
+
+  case "$kind" in
+    vcf) tabix -f -p vcf "$output" ;;
+    tsv) tabix -f -s 1 -b 2 -e 2 "$output" ;;
+    *)
+      echo "ERROR: unsupported slice kind: $kind" >&2
+      exit 1
+      ;;
+  esac
+
+  if ! tabix -l "$output" | grep -Fxq "$region"; then
+    echo "ERROR: slice $output contains no indexed region $region" >&2
+    exit 1
+  fi
+}
+
+if [[ -n "$SOURCE_BASE" ]]; then
+  fetch_slice "clinvar/clinvar.vcf.gz" "$CHROM" \
+    "$SLICES/clinvar_chr${CHROM}.vcf.gz" vcf
+  fetch_slice "spliceai/spliceai_scores.masked.snv.ensembl_mane.grch38.110.vcf.gz" \
+    "$CHROM" "$SLICES/spliceai_chr${CHROM}.vcf.gz" vcf
+  fetch_slice "alphamissense/AlphaMissense_hg38.bgz.tsv.gz" "chr${CHROM}" \
+    "$SLICES/alphamissense_chr${CHROM}.tsv.gz" tsv
+  fetch_slice "dbnsfp/dbNSFP5.3.1a_grch38.gz" "$CHROM" \
+    "$SLICES/dbNSFP5.3.1a_grch38_chr${CHROM}.gz" tsv
+  fetch_slice "cadd/whole_genome_SNVs.tsv.gz" "$CHROM" \
+    "$SLICES/cadd_snv_chr${CHROM}.tsv.gz" tsv
+  fetch_slice "cadd/gnomad.genomes.r4.0.indel.tsv.gz" "$CHROM" \
+    "$SLICES/cadd_indel_chr${CHROM}.tsv.gz" tsv
+fi
+
 # ---------------------------------------------------------------------------
 # 1. Normalized input
 # ---------------------------------------------------------------------------
@@ -156,3 +214,7 @@ if [[ "$n_plugin" -ne 38 ]]; then
 fi
 echo "OK: chr${CHROM} — $(grep -vc '^#' "$OUT") records, $n_plugin plugin CSQ fields"
 echo "     $OUT.gz"
+
+if [[ "${VEP_KEEP_PLAIN:-1}" == "0" ]]; then
+  rm -f "$OUT"
+fi

--- a/e2e-testing/scripts/build_vep_plugin_reference.sh
+++ b/e2e-testing/scripts/build_vep_plugin_reference.sh
@@ -36,8 +36,8 @@ mkdir -p "$WORK/input" "$WORK/output" "$WORK/plugins" "$SLICES"
 # still receives ordinary local indexed files. Existing complete slices are
 # reused, making an interrupted build resumable.
 SOURCE_BASE="${VEP_PLUGIN_SOURCE_URL:-}"
-# shellcheck source=lib/source_identity.sh
-. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/source_identity.sh"
+# shellcheck source=source_identity.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/source_identity.sh"
 
 fetch_slice() {
   local remote_path="$1"

--- a/e2e-testing/scripts/build_vep_plugin_reference.sh
+++ b/e2e-testing/scripts/build_vep_plugin_reference.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+#
+# Build the five-plugin Ensembl VEP reference for one chromosome.
+#
+# This is the golden output `run_comparison.py --profile merged_plugins` is
+# compared against. It must be produced from a **normalized** input and a VEP
+# release that matches vepyr's registered support target, or the comparison
+# either refuses to run or pairs records that are not the same records.
+#
+# Usage:
+#   ./build_vep_plugin_reference.sh 21 [outdir]
+#   VEP_PLUGIN_DIR=/path/to/plugins ./build_vep_plugin_reference.sh 1
+#
+# Requires: docker, bcftools, bgzip, tabix, and the raw plugin sources tabix-
+# indexed (see docs — they can be sliced over HTTP with `rclone serve http`
+# instead of downloading 168 GB).
+
+set -euo pipefail
+
+CHROM="${1:?usage: $0 <chrom> [outdir]}"
+DATA="${DATA_VEPYR_DIR:-$HOME/workspace/data_vepyr}"
+WORK="${2:-$DATA/vep116_chr${CHROM}}"
+IMAGE="ensemblorg/ensembl-vep:release_116.0"
+PLUGIN_DIR="${VEP_PLUGIN_DIR:-$WORK/plugins}"
+
+# The image must match vepyr's supported target exactly (vep 116.0 / API 116 /
+# ensembl 116.c0cf13d / ensembl-variation 116.2fb834b), or
+# validate_vep_reference_identity() rejects the reference. release_116.0 has a
+# native arm64 build, so no emulation on Apple silicon.
+
+SLICES="$WORK/slices"
+mkdir -p "$WORK/input" "$WORK/output" "$WORK/plugins" "$SLICES"
+
+# ---------------------------------------------------------------------------
+# 1. Normalized input
+# ---------------------------------------------------------------------------
+# Every other reference in the suite is built from a `bcftools norm -m -both`
+# input. The original five-plugin reference was not, which left 602 chr21
+# records multi-allelic and unpairable against vepyr's split output. Splitting
+# here keeps this reference consistent with the rest of the set.
+NORM="${VEP_NORMALIZED_VCF:-$DATA/input/HG002_norm.vcf.gz}"
+if [[ ! -f "$NORM" ]]; then
+  mkdir -p "$(dirname "$NORM")"
+  bcftools norm -m -both -Oz -o "$NORM" \
+    "$DATA/HG002_GRCh38_1_22_v4.2.1_benchmark.vcf.gz"
+  tabix -f -p vcf "$NORM"
+fi
+IN="$WORK/input/HG002_norm_chr${CHROM}.vcf.gz"
+{ tabix -H "$NORM"; tabix "$NORM" "chr${CHROM}"; } | bgzip -c > "$IN"
+tabix -f -p vcf "$IN"
+
+# ---------------------------------------------------------------------------
+# 2. Plugin data slices — three file-shape traps
+# ---------------------------------------------------------------------------
+#  a) dbNSFP parses its *version from the filename*: a slice named
+#     `dbnsfp_chr21.tsv.gz` is rejected outright and its 19 fields silently
+#     vanish from the output. The name must contain e.g. `5.3.1a`.
+#  b) The official CADD VEP plugin opens its SNV and indel sources through
+#     Bio::DB::HTS::Tabix. Keep them as two bgzipped, tabix-indexed files. This
+#     differs intentionally from vepyr's cache builder, whose manifest ingests
+#     one combined plain-text source.
+#  c) VEP 116.0/116.1 CADD.pm reads the HGVS-shifted overlap allele and therefore
+#     misses valid annotations. The golden reference requires the corrected
+#     CADD.pm from mwiewior/VEP_plugins commit 7a1f6450fd12. Other plugin files
+#     must remain at their original VEP 116 comparison versions.
+#
+# Expected slice names in $SLICES:
+#   clinvar_chr${CHROM}.vcf.gz
+#   spliceai_chr${CHROM}.vcf.gz
+#   alphamissense_chr${CHROM}.tsv.gz
+#   dbNSFP5.3.1a_grch38_chr${CHROM}.gz
+#   cadd_snv_chr${CHROM}.tsv.gz  +  cadd_indel_chr${CHROM}.tsv.gz
+for plugin in AlphaMissense CADD SpliceAI dbNSFP; do
+  if [[ ! -f "$PLUGIN_DIR/${plugin}.pm" ]]; then
+    echo "ERROR: missing $PLUGIN_DIR/${plugin}.pm" >&2
+    exit 1
+  fi
+done
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+verify_plugin() {
+  local plugin="$1"
+  local expected="$2"
+  local actual
+  actual="$(sha256_file "$PLUGIN_DIR/${plugin}.pm")"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "ERROR: unexpected ${plugin}.pm SHA-256: $actual (expected $expected)" >&2
+    exit 1
+  fi
+}
+
+# Plugin code is not represented in VEP's output header. Pin its bytes here so
+# a checkout drift cannot manufacture or hide parity mismatches.
+verify_plugin AlphaMissense 25e7164d2da4ff69f3ad42b4fbfc27022050933c6427b8d7ec483c978e68d14b
+verify_plugin CADD f0bbe7ab1d4aff0de9e45aeedd4e112824394e81cc3e201ea1b8f001dd9e5cb4
+verify_plugin SpliceAI d08ce7d8c2e6b3229cef638beff145e465e224f0e3fcd43fd49d501ebc2740b1
+verify_plugin dbNSFP 1574736e0371b12378211914db6f5de720eeba395cd42517fbe689cededb9f67
+
+if ! grep -q 'my \$alt_alleles = \$bvf->alt_alleles' "$PLUGIN_DIR/CADD.pm"; then
+  echo "ERROR: CADD.pm lacks the HGVS-shift fix from VEP_plugins 7a1f6450fd12" >&2
+  exit 1
+fi
+
+DBNSFP_COLS="SIFT4G_score,SIFT4G_pred,Polyphen2_HDIV_score,Polyphen2_HVAR_score,\
+MutationTaster_score,MutationTaster_pred,PROVEAN_score,PROVEAN_pred,VEST4_score,\
+MetaSVM_score,MetaSVM_pred,MetaLR_score,MetaLR_pred,REVEL_score,GERP++_RS,\
+phyloP100way_vertebrate,phastCons100way_vertebrate,CADD_raw,CADD_phred"
+
+OUT="${VEP_OUTPUT_VCF:-$WORK/output/HG002_chr${CHROM}_5plugins_vep116_caddfix.vcf}"
+
+# ---------------------------------------------------------------------------
+# 3. Annotate
+# ---------------------------------------------------------------------------
+# Plugin flag ORDER IS SIGNIFICANT: VEP emits each plugin's CSQ block in the
+# order the flags appear, and appends --custom blocks last. vepyr reproduces
+# that layout via `csq_rank` in each plugin's source manifest, so changing the
+# order here desynchronises the two without changing any value.
+#
+# NOTE: `--database 0` appears in VEP's own ##VEP-command-line header but is
+# NOT valid input (it parses as a stray positional). `--offline` covers it.
+docker run --rm --user "$(id -u):$(id -g)" \
+  -v "$DATA":/data -v "$PLUGIN_DIR":/plugins:ro "$IMAGE" \
+  vep --cache --cache_version 116 --dir_cache /data --offline --merged \
+      --everything --no_stats --force_overwrite --vcf \
+      --fasta /data/input/Homo_sapiens.GRCh38.dna.primary_assembly.fa \
+      --input_file "/data/${IN#"$DATA/"}" \
+      --output_file "/data/${OUT#"$DATA/"}" \
+      --dir_plugins /plugins \
+      --custom "/data/${SLICES#"$DATA/"}/clinvar_chr${CHROM}.vcf.gz,ClinVar,vcf,exact,0,CLNSIG,CLNREVSTAT,CLNDN,CLNVC,CLNVI" \
+      --plugin "SpliceAI,snv=/data/${SLICES#"$DATA/"}/spliceai_chr${CHROM}.vcf.gz,indel=/data/${SLICES#"$DATA/"}/spliceai_chr${CHROM}.vcf.gz" \
+      --plugin "CADD,snv=/data/${SLICES#"$DATA/"}/cadd_snv_chr${CHROM}.tsv.gz,indels=/data/${SLICES#"$DATA/"}/cadd_indel_chr${CHROM}.tsv.gz" \
+      --plugin "AlphaMissense,file=/data/${SLICES#"$DATA/"}/alphamissense_chr${CHROM}.tsv.gz" \
+      --plugin "dbNSFP,/data/${SLICES#"$DATA/"}/dbNSFP5.3.1a_grch38_chr${CHROM}.gz,$DBNSFP_COLS"
+
+# ---------------------------------------------------------------------------
+# 4. Index, and check the plugin fields actually landed
+# ---------------------------------------------------------------------------
+# A plugin that fails to instantiate only WARNS — its fields disappear from the
+# CSQ header and the run still exits 0. Fail loudly here instead.
+bgzip -f -c "$OUT" > "$OUT.gz"
+tabix -f -p vcf "$OUT.gz"
+
+n_plugin=$(tabix -H "$OUT.gz" | grep -m1 '^##INFO=<ID=CSQ' | tr '|' '\n' | grep -cE \
+  'SpliceAI_pred|CADD_(RAW|PHRED|raw|phred)|am_(class|pathogenicity)|ClinVar|SIFT4G|Polyphen2|MutationTaster|PROVEAN|VEST4|MetaSVM|MetaLR|REVEL|GERP|phyloP|phastCons')
+if [[ "$n_plugin" -ne 38 ]]; then
+  echo "ERROR: expected 38 plugin CSQ fields, found $n_plugin — a plugin failed to load" >&2
+  grep -i 'failed to instantiate' "${OUT}_warnings.txt" >&2 || true
+  exit 1
+fi
+echo "OK: chr${CHROM} — $(grep -vc '^#' "$OUT") records, $n_plugin plugin CSQ fields"
+echo "     $OUT.gz"

--- a/e2e-testing/scripts/build_vep_plugin_reference.sh
+++ b/e2e-testing/scripts/build_vep_plugin_reference.sh
@@ -98,9 +98,25 @@ fi
 # here keeps this reference consistent with the rest of the set.
 NORM="${VEP_NORMALIZED_VCF:-$DATA/input/HG002_norm.vcf.gz}"
 if [[ ! -f "$NORM" ]]; then
+  # The documented layout keeps the downloaded benchmark under $DATA/input/;
+  # older data roots have it beside it. Mirror the comparison profiles'
+  # legacy fallback so a fresh standard layout works on the first build.
+  BENCHMARK_NAME="HG002_GRCh38_1_22_v4.2.1_benchmark.vcf.gz"
+  BENCHMARK="${VEP_BENCHMARK_VCF:-}"
+  if [[ -z "$BENCHMARK" ]]; then
+    if [[ -f "$DATA/input/$BENCHMARK_NAME" ]]; then
+      BENCHMARK="$DATA/input/$BENCHMARK_NAME"
+    elif [[ -f "$DATA/$BENCHMARK_NAME" ]]; then
+      BENCHMARK="$DATA/$BENCHMARK_NAME"
+      echo "Note: using legacy location $BENCHMARK; move it under input/" >&2
+    else
+      # Name the documented path in the failure, not the legacy one.
+      BENCHMARK="$DATA/input/$BENCHMARK_NAME"
+    fi
+  fi
+  [[ -f "$BENCHMARK" ]] || { echo "ERROR: benchmark VCF not found: $BENCHMARK" >&2; exit 1; }
   mkdir -p "$(dirname "$NORM")"
-  bcftools norm -m -both -Oz -o "$NORM" \
-    "$DATA/HG002_GRCh38_1_22_v4.2.1_benchmark.vcf.gz"
+  bcftools norm -m -both -Oz -o "$NORM" "$BENCHMARK"
   tabix -f -p vcf "$NORM"
 fi
 IN="$WORK/input/HG002_norm_chr${CHROM}.vcf.gz"

--- a/e2e-testing/scripts/build_vep_plugin_reference.sh
+++ b/e2e-testing/scripts/build_vep_plugin_reference.sh
@@ -116,8 +116,16 @@ if [[ ! -f "$NORM" ]]; then
   fi
   [[ -f "$BENCHMARK" ]] || { echo "ERROR: benchmark VCF not found: $BENCHMARK" >&2; exit 1; }
   mkdir -p "$(dirname "$NORM")"
-  bcftools norm -m -both -Oz -o "$NORM" "$BENCHMARK"
-  tabix -f -p vcf "$NORM"
+  # generate_vep_plugin_references.sh runs VEP_REFERENCE_JOBS chromosomes at
+  # once, and on a fresh data root every one of them reaches this branch. Build
+  # under a unique name and publish atomically so concurrent jobs cannot write
+  # the same file, or read a half-written one. The index is moved into place
+  # first: $NORM appearing is what the existence check above keys on.
+  norm_tmp="${NORM}.tmp.$$"
+  bcftools norm -m -both -Oz -o "$norm_tmp" "$BENCHMARK"
+  tabix -f -p vcf "$norm_tmp"
+  mv -f "$norm_tmp.tbi" "$NORM.tbi"
+  mv -f "$norm_tmp" "$NORM"
 fi
 IN="$WORK/input/HG002_norm_chr${CHROM}.vcf.gz"
 { tabix -H "$NORM"; tabix "$NORM" "chr${CHROM}"; } | bgzip -c > "$IN"
@@ -187,6 +195,21 @@ MutationTaster_score,MutationTaster_pred,PROVEAN_score,PROVEAN_pred,VEST4_score,
 MetaSVM_score,MetaSVM_pred,MetaLR_score,MetaLR_pred,REVEL_score,GERP++_RS,\
 phyloP100way_vertebrate,phastCons100way_vertebrate,CADD_raw,CADD_phred"
 
+# Only $DATA is mounted at /data, so a work/output directory outside it is
+# invisible to VEP. Stripping the prefix off such a path is a no-op and yields
+# "/data//abs/host/path", which VEP reports as a missing input rather than as
+# the configuration error it is. Translate through here and fail loudly.
+docker_path() {
+  local label="$1" path="$2" rel
+  rel="${path#"$DATA/"}"
+  if [[ "$rel" == "$path" ]]; then
+    echo "ERROR: $label must live under \$DATA ($DATA) so the VEP container can reach it." >&2
+    echo "       got: $path" >&2
+    return 1
+  fi
+  printf '/data/%s\n' "$rel"
+}
+
 OUT="${VEP_OUTPUT_VCF:-$WORK/output/HG002_chr${CHROM}_5plugins_vep116_caddfix.vcf}"
 
 # ---------------------------------------------------------------------------
@@ -199,19 +222,23 @@ OUT="${VEP_OUTPUT_VCF:-$WORK/output/HG002_chr${CHROM}_5plugins_vep116_caddfix.vc
 #
 # NOTE: `--database 0` appears in VEP's own ##VEP-command-line header but is
 # NOT valid input (it parses as a stray positional). `--offline` covers it.
+IN_C="$(docker_path "the input VCF (work dir / VEP_NORMALIZED_VCF)" "$IN")"
+OUT_C="$(docker_path "the output VCF (VEP_OUTPUT_VCF)" "$OUT")"
+SLICES_C="$(docker_path "the plugin slices directory (work dir)" "$SLICES")"
+
 docker run --rm --user "$(id -u):$(id -g)" \
   -v "$DATA":/data -v "$PLUGIN_DIR":/plugins:ro "$IMAGE" \
   vep --cache --cache_version 116 --dir_cache /data --offline --merged \
       --everything --no_stats --force_overwrite --vcf \
       --fasta /data/input/Homo_sapiens.GRCh38.dna.primary_assembly.fa \
-      --input_file "/data/${IN#"$DATA/"}" \
-      --output_file "/data/${OUT#"$DATA/"}" \
+      --input_file "$IN_C" \
+      --output_file "$OUT_C" \
       --dir_plugins /plugins \
-      --custom "/data/${SLICES#"$DATA/"}/clinvar_chr${CHROM}.vcf.gz,ClinVar,vcf,exact,0,CLNSIG,CLNREVSTAT,CLNDN,CLNVC,CLNVI" \
-      --plugin "SpliceAI,snv=/data/${SLICES#"$DATA/"}/spliceai_chr${CHROM}.vcf.gz,indel=/data/${SLICES#"$DATA/"}/spliceai_chr${CHROM}.vcf.gz" \
-      --plugin "CADD,snv=/data/${SLICES#"$DATA/"}/cadd_snv_chr${CHROM}.tsv.gz,indels=/data/${SLICES#"$DATA/"}/cadd_indel_chr${CHROM}.tsv.gz" \
-      --plugin "AlphaMissense,file=/data/${SLICES#"$DATA/"}/alphamissense_chr${CHROM}.tsv.gz" \
-      --plugin "dbNSFP,/data/${SLICES#"$DATA/"}/dbNSFP5.3.1a_grch38_chr${CHROM}.gz,$DBNSFP_COLS"
+      --custom "$SLICES_C/clinvar_chr${CHROM}.vcf.gz,ClinVar,vcf,exact,0,CLNSIG,CLNREVSTAT,CLNDN,CLNVC,CLNVI" \
+      --plugin "SpliceAI,snv=$SLICES_C/spliceai_chr${CHROM}.vcf.gz,indel=$SLICES_C/spliceai_chr${CHROM}.vcf.gz" \
+      --plugin "CADD,snv=$SLICES_C/cadd_snv_chr${CHROM}.tsv.gz,indels=$SLICES_C/cadd_indel_chr${CHROM}.tsv.gz" \
+      --plugin "AlphaMissense,file=$SLICES_C/alphamissense_chr${CHROM}.tsv.gz" \
+      --plugin "dbNSFP,$SLICES_C/dbNSFP5.3.1a_grch38_chr${CHROM}.gz,$DBNSFP_COLS"
 
 # ---------------------------------------------------------------------------
 # 4. Index, and check the plugin fields actually landed

--- a/e2e-testing/scripts/build_vep_plugin_reference.sh
+++ b/e2e-testing/scripts/build_vep_plugin_reference.sh
@@ -185,6 +185,18 @@ verify_plugin CADD f0bbe7ab1d4aff0de9e45aeedd4e112824394e81cc3e201ea1b8f001dd9e5
 verify_plugin SpliceAI d08ce7d8c2e6b3229cef638beff145e465e224f0e3fcd43fd49d501ebc2740b1
 verify_plugin dbNSFP 1574736e0371b12378211914db6f5de720eeba395cd42517fbe689cededb9f67
 
+# The checks above run only when this script runs. A reference already on disk
+# carries no record of which plugin bytes produced it -- VEP's header does not
+# name them -- so a generator that reuses it cannot tell a current reference
+# from one built with an older CADD.pm. Emit the provenance beside the output
+# so reuse can be gated on it.
+plugin_provenance() {
+  local plugin
+  for plugin in AlphaMissense CADD SpliceAI dbNSFP; do
+    printf '%s %s\n' "$plugin" "$(sha256_file "$PLUGIN_DIR/${plugin}.pm")"
+  done
+}
+
 if ! grep -q 'my \$alt_alleles = \$bvf->alt_alleles' "$PLUGIN_DIR/CADD.pm"; then
   echo "ERROR: CADD.pm lacks the HGVS-shift fix from VEP_plugins 7a1f6450fd12" >&2
   exit 1
@@ -199,12 +211,55 @@ phyloP100way_vertebrate,phastCons100way_vertebrate,CADD_raw,CADD_phred"
 # invisible to VEP. Stripping the prefix off such a path is a no-op and yields
 # "/data//abs/host/path", which VEP reports as a missing input rather than as
 # the configuration error it is. Translate through here and fail loudly.
+# Collapse "." and ".." lexically. Needed because the target directory may not
+# exist yet, and `cd`-based resolution silently leaves such a path untouched --
+# which would let "$DATA/../scratch" keep matching a "$DATA/" prefix test.
+normalize_lexical() {
+  local path="$1" part
+  local -a out=()
+  [[ "$path" != /* ]] && path="$PWD/$path"
+  local IFS=/
+  for part in $path; do
+    case "$part" in
+      ''|.) ;;
+      ..) [[ ${#out[@]} -gt 0 ]] && unset "out[$((${#out[@]} - 1))]" && out=("${out[@]}") ;;
+      *) out+=("$part") ;;
+    esac
+  done
+  printf '/%s\n' "${out[*]}"
+}
+
+# Absolute, symlink-free where the path exists, ".."-free always. The leaf need
+# not exist yet.
+canonical_path() {
+  local path dir base
+  path="$(normalize_lexical "$1")"
+  if [[ -d "$path" ]]; then
+    ( cd "$path" 2>/dev/null && pwd -P )
+    return
+  fi
+  dir="$(dirname "$path")"
+  base="$(basename "$path")"
+  if [[ -d "$dir" ]]; then
+    printf '%s/%s\n' "$( cd "$dir" 2>/dev/null && pwd -P )" "$base"
+  else
+    printf '%s\n' "$path"
+  fi
+}
+
 docker_path() {
-  local label="$1" path="$2" rel
-  rel="${path#"$DATA/"}"
-  if [[ "$rel" == "$path" ]]; then
-    echo "ERROR: $label must live under \$DATA ($DATA) so the VEP container can reach it." >&2
+  local label="$1" path="$2" rel canon data_canon
+  # A lexical prefix test is not containment: "$DATA/../scratch" passes it and
+  # becomes /data/../scratch, which resolves inside the container to /scratch --
+  # outside the only bind mount. Canonicalise both sides first, so `..` and
+  # escaping symlinks are rejected rather than silently redirected.
+  canon="$(canonical_path "$path")"
+  data_canon="$(canonical_path "$DATA")"
+  rel="${canon#"$data_canon/"}"
+  if [[ "$rel" == "$canon" ]]; then
+    echo "ERROR: $label must live under \$DATA ($data_canon) so the VEP container can reach it." >&2
     echo "       got: $path" >&2
+    [[ "$canon" != "$path" ]] && echo "       resolves to: $canon" >&2
     return 1
   fi
   printf '/data/%s\n' "$rel"
@@ -255,6 +310,7 @@ if [[ "$n_plugin" -ne 38 ]]; then
   grep -i 'failed to instantiate' "${OUT}_warnings.txt" >&2 || true
   exit 1
 fi
+plugin_provenance > "$OUT.gz.plugins"
 echo "OK: chr${CHROM} — $(grep -vc '^#' "$OUT") records, $n_plugin plugin CSQ fields"
 echo "     $OUT.gz"
 

--- a/e2e-testing/scripts/comparison/cli.py
+++ b/e2e-testing/scripts/comparison/cli.py
@@ -108,6 +108,12 @@ def parse_args(argv=None):
         default=None,
         help="Parquet cache (default: from profile x release)",
     )
+    p.add_argument(
+        "--plugin-cache",
+        default=None,
+        help="Plugin cache root, used only by plugin profiles "
+        "(default: $DATA/cache/plugin_cache_<release>)",
+    )
 
     args = p.parse_args(argv)
     if args.workers <= 0:
@@ -305,6 +311,9 @@ def run_contig(
     }
     if reference_identity is not None:
         result["reference_identity"] = reference_identity
+    # Only for plugin profiles, so a non-plugin report keeps its exact shape.
+    if resolved.plugin_cache_root is not None:
+        result["plugin_cache_path"] = resolved.plugin_cache_root
 
     path = report.report_json_path(report_dir, chrom, resolved.suffix, resolved.release)
     with open(path, "w") as f:
@@ -347,6 +356,8 @@ def _run_contig_isolated(chrom, args):
         cmd += ["--vep", args.vep]
     if args.cache_dir:
         cmd += ["--cache-dir", args.cache_dir]
+    if args.plugin_cache:
+        cmd += ["--plugin-cache", args.plugin_cache]
     return subprocess.run(cmd).returncode == 0
 
 
@@ -359,6 +370,7 @@ def main(argv=None):
             args.release,
             cache_dir=args.cache_dir,
             vep_vcf=args.vep,
+            plugin_cache_root=args.plugin_cache,
             require_cache=not args.skip_annotate,
             require_reference=not args.skip_compare and not args.skip_annotate,
         )
@@ -404,6 +416,8 @@ def main(argv=None):
     print(f"  profile:   {resolved.profile}")
     print(f"  release:   {resolved.release}")
     print(f"  cache_dir: {resolved.cache_dir}")
+    if resolved.plugin_cache_root:
+        print(f"  plugins:   {resolved.plugin_cache_root}")
     print(f"  vep_vcf:   {resolved.vep_vcf}")
     print(f"  results:   {results_dir}")
     print("=" * 60)

--- a/e2e-testing/scripts/comparison/cli.py
+++ b/e2e-testing/scripts/comparison/cli.py
@@ -365,6 +365,15 @@ def main(argv=None):
     args = parse_args(argv)
 
     try:
+        # Per-contig plugin references resolve one file at a time, so hand the
+        # sole requested contig to resolution. Without it the per-contig lookup
+        # is unreachable from here and every plugin run is rejected -- including
+        # the single-contig form the rejection itself recommends.
+        sole_chrom = (
+            args.chroms[0]
+            if args.chroms is not None and len(args.chroms) == 1
+            else None
+        )
         resolved = profiles.resolve(
             args.profile,
             args.release,
@@ -373,6 +382,7 @@ def main(argv=None):
             plugin_cache_root=args.plugin_cache,
             require_cache=not args.skip_annotate,
             require_reference=not args.skip_compare and not args.skip_annotate,
+            chrom=sole_chrom,
         )
     except profiles.ProfileUnavailable as exc:
         print(f"Error: {exc}", file=sys.stderr)

--- a/e2e-testing/scripts/comparison/compare.py
+++ b/e2e-testing/scripts/comparison/compare.py
@@ -3,6 +3,14 @@
 This module remains pure with respect to vepyr: it accepts paths, emits an
 optional JSONL mismatch ledger, and returns JSON-serialisable counters. It does
 not import the native extension or infer release identity from directory names.
+
+Byte equality is the only thing counted as a plain match. Two weaker forms of
+agreement are absorbed into the match rate but counted separately so they stay
+visible: '&'-list order differences (``field_order_mismatch_counts``) and
+representation-only differences such as decimal padding or VEP's "." missing
+marker (``field_format_mismatch_counts``). Both keep the parity gate honest --
+it fails on either total being non-zero -- while keeping a plugin comparison
+readable instead of drowned in formatting noise.
 """
 
 import hashlib
@@ -218,6 +226,46 @@ def _equality_bucket(vepyr_value, vep_value):
     return "both_nonempty_unequal"
 
 
+def _tokens_equivalent(vepyr_token, vep_token):
+    """True when two unequal single values encode the same datum.
+
+    Exact float equality after parsing, not a tolerance: it absorbs decimal
+    padding and shortest-round-trip formatting without ever calling two
+    different numbers equal.
+    """
+    if {vepyr_token, vep_token} == {"", "."}:
+        return True
+    try:
+        return float(vepyr_token) == float(vep_token)
+    except ValueError:
+        return False
+
+
+def _values_equivalent(vepyr_value, vep_value):
+    """True when two byte-unequal CSQ values carry the same data.
+
+    Two representations differ here without the data differing:
+
+    - Float formatting. vepyr prints Rust's shortest round-trip form ("0",
+      "0.57985"); the plugin sources Ensembl VEP passes through print a fixed
+      number of decimals ("0.00", "0.579850"). Same number, different string.
+    - Missing-value marker. VEP emits the VCF "." for a field it has no value
+      for, where vepyr emits the empty string.
+
+    '&'-joined multi-value fields are compared token-wise so one padded float
+    does not condemn the whole field. Differing token counts are a real
+    difference, never a formatting one.
+    """
+    vepyr_tokens = vepyr_value.split("&")
+    vep_tokens = vep_value.split("&")
+    if len(vepyr_tokens) != len(vep_tokens):
+        return False
+    return all(
+        _tokens_equivalent(vepyr_token, vep_token)
+        for vepyr_token, vep_token in zip(vepyr_tokens, vep_tokens)
+    )
+
+
 def compare_vcfs(
     vepyr_vcf,
     vep_vcf,
@@ -285,6 +333,8 @@ def _compare_vcfs(
     field_mismatch_examples = {field: [] for field in shared_fields}
     field_order_mismatches = {field: 0 for field in shared_fields}
     field_order_mismatch_examples = {field: [] for field in shared_fields}
+    field_format_mismatches = {field: 0 for field in shared_fields}
+    field_format_mismatch_examples = {field: [] for field in shared_fields}
     field_equality_counts = {
         field: {bucket: 0 for bucket in _EQUALITY_BUCKETS} for field in shared_fields
     }
@@ -405,6 +455,20 @@ def _compare_vcfs(
                             )
                         continue
 
+                if _values_equivalent(vepyr_value, vep_value):
+                    field_matches[field] += 1
+                    field_format_mismatches[field] += 1
+                    if len(field_format_mismatch_examples[field]) < 10:
+                        field_format_mismatch_examples[field].append(
+                            {
+                                "variant": key_str,
+                                "vepyr": vepyr_value,
+                                "vep": vep_value,
+                                **identity_fields,
+                            }
+                        )
+                    continue
+
                 field_mismatches[field] += 1
                 record = {
                     "kind": "field_mismatch",
@@ -455,19 +519,29 @@ def _compare_vcfs(
     print(f"\n  Per-field match rates ({n_compared:,} variants):")
     print(
         f"  {'Field':<30} {'Match%':>8} {'Matches':>10} "
-        f"{'Mismatches':>10} {'OrderOnly':>10} {'Total':>10}"
+        f"{'Mismatches':>10} {'OrderOnly':>10} {'FormatOnly':>10} {'Total':>10}"
     )
-    print(f"  {'-' * 30} {'-' * 8} {'-' * 10} {'-' * 10} {'-' * 10} {'-' * 10}")
+    print(
+        f"  {'-' * 30} {'-' * 8} {'-' * 10} {'-' * 10} {'-' * 10} {'-' * 10} {'-' * 10}"
+    )
     for field in shared_fields:
         total = field_total[field]
         matches = field_matches[field]
         mismatches = field_mismatches[field]
         order_only = field_order_mismatches[field]
+        format_only = field_format_mismatches[field]
         rate = (matches / total * 100) if total > 0 else 0
-        flag = " <--" if mismatches > 0 else " (order)" if order_only > 0 else ""
+        if mismatches > 0:
+            flag = " <--"
+        elif order_only > 0:
+            flag = " (order)"
+        elif format_only > 0:
+            flag = " (format)"
+        else:
+            flag = ""
         print(
-            f"  {field:<30} {rate:>7.2f}% {matches:>10,} "
-            f"{mismatches:>10,} {order_only:>10,} {total:>10,}{flag}"
+            f"  {field:<30} {rate:>7.2f}% {matches:>10,} {mismatches:>10,} "
+            f"{order_only:>10,} {format_only:>10,} {total:>10,}{flag}"
         )
 
     fields_with_mismatches = [
@@ -525,6 +599,16 @@ def _compare_vcfs(
             field: field_order_mismatch_examples[field]
             for field in shared_fields
             if field_order_mismatch_examples[field]
+        },
+        "field_format_mismatch_counts": {
+            field: field_format_mismatches[field]
+            for field in shared_fields
+            if field_format_mismatches[field] > 0
+        },
+        "field_format_mismatch_examples": {
+            field: field_format_mismatch_examples[field]
+            for field in shared_fields
+            if field_format_mismatch_examples[field]
         },
         "field_equality_counts": field_equality_counts,
         "equality_bucket_counts": {

--- a/e2e-testing/scripts/comparison/compare.py
+++ b/e2e-testing/scripts/comparison/compare.py
@@ -18,6 +18,7 @@ import json
 import os
 import re
 from collections import defaultdict
+from decimal import Decimal, InvalidOperation
 
 from . import vcfio
 
@@ -32,6 +33,13 @@ VEP_HASH_ORDER_PICK_IGNORE_REASON = (
 )
 
 _CSQ_RE = re.compile(r"(?:^|;)CSQ=([^;\t]+)")
+# A token we will treat as a number rather than as an opaque string. Narrower
+# than what Decimal() itself accepts: no whitespace, no 'Infinity'/'NaN', and
+# no leading zero on the integer part, so "01" stays distinct from "1" the way
+# a zero-padded identifier must.
+_NUMERIC_RE = re.compile(
+    r"^[+-]?(?:(?:0|[1-9][0-9]*)(?:\.[0-9]*)?|\.[0-9]+)(?:[eE][+-]?[0-9]+)?$"
+)
 _EQUALITY_BUCKETS = (
     "both_empty",
     "both_nonempty_equal",
@@ -229,15 +237,24 @@ def _equality_bucket(vepyr_value, vep_value):
 def _tokens_equivalent(vepyr_token, vep_token):
     """True when two unequal single values encode the same datum.
 
-    Exact float equality after parsing, not a tolerance: it absorbs decimal
-    padding and shortest-round-trip formatting without ever calling two
-    different numbers equal.
+    Exact Decimal equality over canonical numeric literals -- not a tolerance,
+    and deliberately not float(). float() would absorb genuine differences:
+    it accepts whitespace and '_' separators, collapses integers past 2**53
+    ("12345678901234567" == "...568"), turns any large exponent into inf, and
+    reads "01" as 1 -- so a zero-padded code or a long numeric identifier
+    would be written off as formatting. Decimal over _NUMERIC_RE absorbs
+    decimal padding and shortest-round-trip forms and nothing else.
     """
-    if {vepyr_token, vep_token} == {"", "."}:
+    # One direction only: VEP writes the VCF missing marker where it has no
+    # value, vepyr writes the empty string. A "." coming FROM vepyr is an
+    # output defect, not a way of representing absence.
+    if vepyr_token == "" and vep_token == ".":
         return True
+    if not (_NUMERIC_RE.match(vepyr_token) and _NUMERIC_RE.match(vep_token)):
+        return False
     try:
-        return float(vepyr_token) == float(vep_token)
-    except ValueError:
+        return Decimal(vepyr_token) == Decimal(vep_token)
+    except InvalidOperation:
         return False
 
 
@@ -250,7 +267,8 @@ def _values_equivalent(vepyr_value, vep_value):
       "0.57985"); the plugin sources Ensembl VEP passes through print a fixed
       number of decimals ("0.00", "0.579850"). Same number, different string.
     - Missing-value marker. VEP emits the VCF "." for a field it has no value
-      for, where vepyr emits the empty string.
+      for, where vepyr emits the empty string. Absorbed in that direction
+      only -- a "." from vepyr is a defect, not a representation of absence.
 
     '&'-joined multi-value fields are compared token-wise so one padded float
     does not condemn the whole field. Differing token counts are a real
@@ -547,6 +565,11 @@ def _compare_vcfs(
     fields_with_mismatches = [
         field for field in shared_fields if field_mismatches[field] > 0
     ]
+    fields_absorbed = [
+        field
+        for field in shared_fields
+        if field_order_mismatches[field] or field_format_mismatches[field]
+    ]
     if fields_with_mismatches:
         print("\n  Mismatch examples (display capped; JSONL ledger is uncapped):")
         for field in fields_with_mismatches:
@@ -555,6 +578,20 @@ def _compare_vcfs(
                 print(f"      {example['variant']}")
                 print(f"        vepyr: {example['vepyr']!r}")
                 print(f"        VEP:   {example['vep']!r}")
+    elif fields_absorbed:
+        # Never print the all-match banner here: these fields DO differ byte
+        # for byte, and the parity gate fails on either count. Saying "100%"
+        # is the one sentence an operator reads as parity.
+        print(
+            f"\n  No field mismatches, but {len(fields_absorbed)} shared CSQ "
+            "field(s) differ byte-wise and were absorbed:"
+        )
+        for field in fields_absorbed:
+            print(
+                f"    {field:<30} {field_order_mismatches[field]:>10,} order-only "
+                f"{field_format_mismatches[field]:>10,} format-only"
+            )
+        print("  This is not byte parity; the parity gate rejects both counts.")
     else:
         print(f"\n  ALL {len(shared_fields)} shared CSQ fields match at 100%!")
 

--- a/e2e-testing/scripts/comparison/compare.py
+++ b/e2e-testing/scripts/comparison/compare.py
@@ -278,10 +278,34 @@ def _values_equivalent(vepyr_value, vep_value):
     vep_tokens = vep_value.split("&")
     if len(vepyr_tokens) != len(vep_tokens):
         return False
-    return all(
+    if all(
         _tokens_equivalent(vepyr_token, vep_token)
         for vepyr_token, vep_token in zip(vepyr_tokens, vep_tokens)
-    )
+    ):
+        return True
+    # Order and representation can differ at once: "0.10&0.20" vs "0.2&0.1".
+    # The caller's order check compares raw strings, so the padding defeats it;
+    # the position-wise pass above is defeated by the reordering. Neither
+    # difference is a value difference, so pair the tokens as a multiset.
+    return _tokens_equivalent_as_multiset(vepyr_tokens, vep_tokens)
+
+
+def _tokens_equivalent_as_multiset(vepyr_tokens, vep_tokens):
+    """True when the two token bags pair up one-to-one under equivalence.
+
+    Greedy pairing is safe here: numeric equality is transitive, so equivalent
+    tokens are interchangeable and consuming any one of them cannot strand a
+    later match that a different choice would have found.
+    """
+    remaining = list(vep_tokens)
+    for vepyr_token in vepyr_tokens:
+        for i, vep_token in enumerate(remaining):
+            if vepyr_token == vep_token or _tokens_equivalent(vepyr_token, vep_token):
+                del remaining[i]
+                break
+        else:
+            return False
+    return not remaining
 
 
 def compare_vcfs(

--- a/e2e-testing/scripts/comparison/profiles.py
+++ b/e2e-testing/scripts/comparison/profiles.py
@@ -49,6 +49,12 @@ class Profile:
     annotate_kwargs: dict = field(default_factory=dict)
     ignore_csq_order: bool = False
     plugins: tuple = ()
+    # Plugin references are generated one file per contig, under output/
+    # {release_dir}/plugins/, rather than as a single WGS reference. When set,
+    # this template (with {chrom}) and subdir locate them; vep_basename stays
+    # as the profile's identity for reports and summaries.
+    vep_per_contig: str = ""
+    vep_subdir: str = ""
 
 
 _PICK = {"pick_order": VEP_PICK_ORDER}
@@ -59,6 +65,14 @@ _ALL_PLUGINS = ("ClinVar", "SpliceAI", "CADD", "AlphaMissense", "dbNSFP")
 _PLUGIN_REFERENCE = (
     "HG002_annotated_wgs_everything_hgvs_merged_clinvar_spliceai_cadd_am_dbnsfp"
 )
+# What generate_vep_plugin_references.sh actually writes, per contig.
+_PLUGIN_PER_CONTIG = "HG002_chr{chrom}_5plugins_vep116_caddfix"
+
+
+def plugin_reference_basename():
+    """The reference basename shared by every plugin comparison profile."""
+    return _PLUGIN_REFERENCE
+
 
 PROFILES = {
     "ensembl": Profile(
@@ -125,11 +139,15 @@ PROFILES = {
         vep_basename=_PLUGIN_REFERENCE,
         suffix="merged_plugins",
         plugins=_ALL_PLUGINS,
+        vep_per_contig=_PLUGIN_PER_CONTIG,
+        vep_subdir="plugins",
     ),
     "merged_plugins_base": Profile(
         flavour="merged",
         vep_basename=_PLUGIN_REFERENCE,
         suffix="merged_plugins_base",
+        vep_per_contig=_PLUGIN_PER_CONTIG,
+        vep_subdir="plugins",
     ),
     "merged_pick_allele_gene": Profile(
         flavour="merged",
@@ -242,18 +260,49 @@ def raw_cache_dir_for(cache_type, release):
     return candidates[0]
 
 
-def vep_vcf_for(profile_name, release):
-    """Return the reference path, preferring .vcf.gz, or None if neither exists."""
-    base = os.path.join(
-        data_dir(),
-        "output",
-        RELEASE_DIRS[release],
-        PROFILES[profile_name].vep_basename,
-    )
+def _first_existing(base):
     for candidate in (base + ".vcf.gz", base + ".vcf"):
         if os.path.exists(candidate):
             return candidate
     return None
+
+
+def vep_per_contig_vcf_for(profile_name, release, chrom):
+    """Return one contig's plugin reference, or None when it does not exist."""
+    profile = PROFILES[profile_name]
+    if not profile.vep_per_contig:
+        return None
+    bare = str(chrom)[3:] if str(chrom).startswith("chr") else str(chrom)
+    return _first_existing(
+        os.path.join(
+            data_dir(),
+            "output",
+            RELEASE_DIRS[release],
+            profile.vep_subdir,
+            profile.vep_per_contig.format(chrom=bare),
+        )
+    )
+
+
+def vep_vcf_for(profile_name, release, chrom=None):
+    """Return the reference path, preferring .vcf.gz, or None if neither exists.
+
+    Plugin profiles have no single WGS reference: generate_vep_plugin_references.sh
+    writes one file per contig. With a contig, resolve that file; without one,
+    report the first contig that exists so availability still answers truthfully.
+    """
+    profile = PROFILES[profile_name]
+    if profile.vep_per_contig:
+        if chrom is not None:
+            return vep_per_contig_vcf_for(profile_name, release, chrom)
+        for candidate_chrom in range(1, 23):
+            found = vep_per_contig_vcf_for(profile_name, release, candidate_chrom)
+            if found:
+                return found
+        return None
+    return _first_existing(
+        os.path.join(data_dir(), "output", RELEASE_DIRS[release], profile.vep_basename)
+    )
 
 
 def availability_table():
@@ -290,6 +339,7 @@ def resolve(
     *,
     require_cache=True,
     require_reference=True,
+    chrom=None,
 ):
     """Resolve a profile and release to concrete paths, or raise ProfileUnavailable.
 
@@ -310,7 +360,19 @@ def resolve(
 
     profile = PROFILES[profile_name]
     resolved_cache = cache_dir or cache_dir_for(profile_name, release)
-    resolved_ref = vep_vcf or vep_vcf_for(profile_name, release)
+    if vep_vcf:
+        resolved_ref = vep_vcf
+    elif profile.vep_per_contig and chrom is None:
+        # Each contig is a separate file, so there is nothing to slice a
+        # multi-contig run out of. Say so instead of reporting "unavailable".
+        raise ProfileUnavailable(
+            f"profile {profile_name!r} uses per-contig references "
+            f"({profile.vep_per_contig.format(chrom='N')}.vcf.gz under "
+            f"output/{RELEASE_DIRS[release]}/{profile.vep_subdir}/). "
+            "Request a single contig with --chroms, or pass --vep explicitly."
+        )
+    else:
+        resolved_ref = vep_vcf_for(profile_name, release, chrom)
     resolved_plugin_cache = None
     if profile.plugins:
         resolved_plugin_cache = plugin_cache_root or plugin_cache_dir_for(release)

--- a/e2e-testing/scripts/comparison/profiles.py
+++ b/e2e-testing/scripts/comparison/profiles.py
@@ -364,13 +364,18 @@ def resolve(
         resolved_ref = vep_vcf
     elif profile.vep_per_contig and chrom is None:
         # Each contig is a separate file, so there is nothing to slice a
-        # multi-contig run out of. Say so instead of reporting "unavailable".
-        raise ProfileUnavailable(
-            f"profile {profile_name!r} uses per-contig references "
-            f"({profile.vep_per_contig.format(chrom='N')}.vcf.gz under "
-            f"output/{RELEASE_DIRS[release]}/{profile.vep_subdir}/). "
-            "Request a single contig with --chroms, or pass --vep explicitly."
-        )
+        # multi-contig run out of. Say so instead of reporting "unavailable" --
+        # but only when a reference is actually needed. Modes that just
+        # aggregate stored reports need none, and must not be blocked by the
+        # absence of something they never read.
+        if require_reference:
+            raise ProfileUnavailable(
+                f"profile {profile_name!r} uses per-contig references "
+                f"({profile.vep_per_contig.format(chrom='N')}.vcf.gz under "
+                f"output/{RELEASE_DIRS[release]}/{profile.vep_subdir}/). "
+                "Request a single contig with --chroms, or pass --vep explicitly."
+            )
+        resolved_ref = None
     else:
         resolved_ref = vep_vcf_for(profile_name, release, chrom)
     resolved_plugin_cache = None

--- a/e2e-testing/scripts/comparison/profiles.py
+++ b/e2e-testing/scripts/comparison/profiles.py
@@ -38,7 +38,9 @@ class Profile:
     is the reference filename inside output/{release_dir}/, without extension.
     `suffix` is stored without a leading underscore; filename templates add the
     separators. `ignore_csq_order` marks profiles where Ensembl VEP emits already
-    selected CSQ entries in Perl hash order, which carries no meaning.
+    selected CSQ entries in Perl hash order, which carries no meaning. `plugins`
+    names the VEP plugins the reference was produced with; a non-empty tuple makes
+    resolve() require the plugin cache and pass its root to vepyr.annotate().
     """
 
     flavour: str
@@ -46,9 +48,17 @@ class Profile:
     suffix: str
     annotate_kwargs: dict = field(default_factory=dict)
     ignore_csq_order: bool = False
+    plugins: tuple = ()
 
 
 _PICK = {"pick_order": VEP_PICK_ORDER}
+
+# The five plugins the release-116 plugin reference was produced with, in the
+# order they appear in that reference's filename.
+_ALL_PLUGINS = ("ClinVar", "SpliceAI", "CADD", "AlphaMissense", "dbNSFP")
+_PLUGIN_REFERENCE = (
+    "HG002_annotated_wgs_everything_hgvs_merged_clinvar_spliceai_cadd_am_dbnsfp"
+)
 
 PROFILES = {
     "ensembl": Profile(
@@ -105,6 +115,22 @@ PROFILES = {
         annotate_kwargs={"per_gene": True, **_PICK},
         ignore_csq_order=True,
     ),
+    # Both profiles below read the same five-plugin VEP reference. "merged_plugins"
+    # attaches the plugin cache, so every plugin CSQ field is comparable.
+    # "merged_plugins_base" attaches nothing: compare_vcfs() then restricts to the
+    # shared fields, which isolates whether a core-field difference comes from the
+    # plugin machinery or predates it.
+    "merged_plugins": Profile(
+        flavour="merged",
+        vep_basename=_PLUGIN_REFERENCE,
+        suffix="merged_plugins",
+        plugins=_ALL_PLUGINS,
+    ),
+    "merged_plugins_base": Profile(
+        flavour="merged",
+        vep_basename=_PLUGIN_REFERENCE,
+        suffix="merged_plugins_base",
+    ),
     "merged_pick_allele_gene": Profile(
         flavour="merged",
         vep_basename="HG002_annotated_wgs_everything_hgvs_merged_pick_allele_gene",
@@ -124,6 +150,7 @@ class Resolved:
     annotate_kwargs: dict
     suffix: str
     ignore_csq_order: bool
+    plugin_cache_root: str | None = None
 
 
 def data_dir():
@@ -177,6 +204,17 @@ def cache_dir_for(profile_name, release, warn=True):
     return _resolve_with_legacy_fallback("cache", name, os.path.isdir, warn=warn)
 
 
+def plugin_cache_dir_for(release, warn=True):
+    """Resolve the plugin cache built for one release.
+
+    Plugin caches are per-release like the Parquet cache is, and live beside it
+    under $DATA/cache/, so the same legacy fallback applies.
+    """
+    return _resolve_with_legacy_fallback(
+        "cache", f"plugin_cache_{release}", os.path.isdir, warn=warn
+    )
+
+
 def raw_cache_dir_for(cache_type, release):
     """Resolve an extracted raw cache directory containing ``info.txt``.
 
@@ -226,7 +264,12 @@ def availability_table():
         for release in RELEASES:
             has_cache = os.path.isdir(cache_dir_for(name, release, warn=False))
             has_ref = vep_vcf_for(name, release) is not None
-            if has_cache and has_ref:
+            has_plugins = not PROFILES[name].plugins or os.path.isdir(
+                plugin_cache_dir_for(release, warn=False)
+            )
+            if has_cache and has_ref and not has_plugins:
+                cells.append("no plugins")
+            elif has_cache and has_ref:
                 cells.append("ok")
             elif has_cache:
                 cells.append("no reference")
@@ -243,6 +286,7 @@ def resolve(
     release,
     cache_dir=None,
     vep_vcf=None,
+    plugin_cache_root=None,
     *,
     require_cache=True,
     require_reference=True,
@@ -267,10 +311,22 @@ def resolve(
     profile = PROFILES[profile_name]
     resolved_cache = cache_dir or cache_dir_for(profile_name, release)
     resolved_ref = vep_vcf or vep_vcf_for(profile_name, release)
+    resolved_plugin_cache = None
+    if profile.plugins:
+        resolved_plugin_cache = plugin_cache_root or plugin_cache_dir_for(release)
 
     problems = []
     if require_cache and not os.path.isdir(resolved_cache):
         problems.append(f"no Parquet cache at {resolved_cache}")
+    if (
+        require_cache
+        and resolved_plugin_cache is not None
+        and not os.path.isdir(resolved_plugin_cache)
+    ):
+        problems.append(
+            f"no plugin cache at {resolved_plugin_cache} for plugins "
+            f"{', '.join(profile.plugins)}"
+        )
     if require_reference and resolved_ref is None:
         problems.append(
             f"no VEP reference {profile.vep_basename}.vcf[.gz] under "
@@ -284,12 +340,17 @@ def resolve(
             + availability_table()
         )
 
+    annotate_kwargs = dict(profile.annotate_kwargs)
+    if resolved_plugin_cache is not None:
+        annotate_kwargs["plugin_cache_root"] = resolved_plugin_cache
+
     return Resolved(
         profile=profile_name,
         release=release,
         cache_dir=resolved_cache,
         vep_vcf=resolved_ref,
-        annotate_kwargs=dict(profile.annotate_kwargs),
+        annotate_kwargs=annotate_kwargs,
         suffix=profile.suffix,
         ignore_csq_order=profile.ignore_csq_order,
+        plugin_cache_root=resolved_plugin_cache,
     )

--- a/e2e-testing/scripts/comparison/report.py
+++ b/e2e-testing/scripts/comparison/report.py
@@ -507,11 +507,18 @@ def generate_markdown(
     total_in = sum(r["input_variants"] for r in reports)
     total_time = sum(r["annotation"]["time_s"] or 0 for r in reports)
     field_mm = agg["field_mm"]
+    field_format = agg["field_format"]
     all_fields = agg["all_fields"]
 
     n_perfect = len([f for f in all_fields if field_mm.get(f, 0) == 0])
     n_imperfect = len([f for f in all_fields if field_mm.get(f, 0) > 0])
     total_mm = sum(field_mm.values())
+    # Representation-only differences are absorbed into the match rates, so they
+    # do not move n_perfect -- but they do mean the output is not byte-identical.
+    # Reporting only field_mm here let a summary claim full parity for a run the
+    # per-contig comparison had already called non-byte-identical.
+    n_format = len([f for f in all_fields if field_format.get(f, 0) > 0])
+    total_format = sum(field_format.values())
 
     bi = build_info or {}
     span = contig_span([r["chrom"] for r in reports])
@@ -605,12 +612,19 @@ def generate_markdown(
     lines.append("## Headline")
     lines.append("")
     lines.append(
-        f"- **{n_perfect} / {len(all_fields)} CSQ fields at 100% match** (0 mismatches)"
+        f"- **{n_perfect} / {len(all_fields)} CSQ fields at 100% match** "
+        f"(0 value mismatches)"
     )
     lines.append(
         f"- **{n_imperfect} fields** with mismatches, "
         f"**{total_mm:,} total** across CSQ entries"
     )
+    if total_format:
+        lines.append(
+            f"- **{n_format} fields** with representation-only differences, "
+            f"**{total_format:,} total** — absorbed into the match rates above, "
+            f"so the output is **not** byte-identical"
+        )
     if old_mm is not None:
         old_total = sum(old_mm.values())
         n_fixed = len([f for f in old_mm if f not in field_mm or field_mm[f] == 0])

--- a/e2e-testing/scripts/comparison/report.py
+++ b/e2e-testing/scripts/comparison/report.py
@@ -226,6 +226,7 @@ def aggregate_mismatches(reports):
     all_fields = set()
     field_mm = defaultdict(int)
     field_order = defaultdict(int)
+    field_format = defaultdict(int)
     field_examples = defaultdict(list)
 
     total_compared = 0
@@ -263,6 +264,8 @@ def aggregate_mismatches(reports):
             field_mm[f] += c
         for f, c in comp.get("field_order_mismatch_counts", {}).items():
             field_order[f] += c
+        for f, c in comp.get("field_format_mismatch_counts", {}).items():
+            field_format[f] += c
         for f, exs in comp.get("field_mismatch_examples", {}).items():
             for ex in exs:
                 ex["source_chrom"] = r["chrom"]
@@ -272,6 +275,7 @@ def aggregate_mismatches(reports):
         "all_fields": all_fields,
         "field_mm": field_mm,
         "field_order": field_order,
+        "field_format": field_format,
         "field_examples": field_examples,
         "total_compared": total_compared,
         "total_csq_match": total_csq_match,

--- a/e2e-testing/scripts/comparison/report.py
+++ b/e2e-testing/scripts/comparison/report.py
@@ -519,6 +519,12 @@ def generate_markdown(
     # per-contig comparison had already called non-byte-identical.
     n_format = len([f for f in all_fields if field_format.get(f, 0) > 0])
     total_format = sum(field_format.values())
+    # Order-only differences are absorbed the same way and were invisible here
+    # for the same reason: the gate rejects the run while this summary claimed
+    # every field at 100%.
+    field_order = agg["field_order"]
+    n_order = len([f for f in all_fields if field_order.get(f, 0) > 0])
+    total_order = sum(field_order.values())
 
     bi = build_info or {}
     span = contig_span([r["chrom"] for r in reports])
@@ -623,6 +629,12 @@ def generate_markdown(
         lines.append(
             f"- **{n_format} fields** with representation-only differences, "
             f"**{total_format:,} total** — absorbed into the match rates above, "
+            f"so the output is **not** byte-identical"
+        )
+    if total_order:
+        lines.append(
+            f"- **{n_order} fields** with order-only differences, "
+            f"**{total_order:,} total** — absorbed into the match rates above, "
             f"so the output is **not** byte-identical"
         )
     if old_mm is not None:

--- a/e2e-testing/scripts/generate_vep_plugin_references.sh
+++ b/e2e-testing/scripts/generate_vep_plugin_references.sh
@@ -20,6 +20,14 @@ fi
 
 mkdir -p "$TARGET" "$WORK_ROOT" "$LOG_DIR"
 
+# The plugin .pm SHA-256s the builder pins. A reference is only reusable if it
+# records the same ones: VEP's header does not name the plugin code, so field
+# count alone cannot distinguish a current reference from one built with an
+# older CADD.pm -- and a stale golden reference reads as a vepyr mismatch.
+expected_plugin_provenance() {
+  sed -n 's/^verify_plugin \([A-Za-z]*\) \([0-9a-f]\{64\}\)$/\1 \2/p' "$BUILDER"
+}
+
 is_complete() {
   local chrom="$1"
   local output="$TARGET/HG002_chr${chrom}_5plugins_vep116_caddfix.vcf.gz"
@@ -28,7 +36,16 @@ is_complete() {
   local n_plugin
   n_plugin=$(tabix -H "$output" | grep -m1 '^##INFO=<ID=CSQ' | tr '|' '\n' | grep -cE \
     'SpliceAI_pred|CADD_(RAW|PHRED|raw|phred)|am_(class|pathogenicity)|ClinVar|SIFT4G|Polyphen2|MutationTaster|PROVEAN|VEST4|MetaSVM|MetaLR|REVEL|GERP|phyloP|phastCons')
-  [[ "$n_plugin" -eq 38 ]]
+  [[ "$n_plugin" -eq 38 ]] || return 1
+
+  if [[ ! -s "$output.plugins" ]]; then
+    echo "STALE chr${chrom}: no plugin provenance recorded; rebuilding" >&2
+    return 1
+  fi
+  if ! diff -q <(sort "$output.plugins") <(expected_plugin_provenance | sort) >/dev/null; then
+    echo "STALE chr${chrom}: built with different plugin code; rebuilding" >&2
+    return 1
+  fi
 }
 
 run_one() {

--- a/e2e-testing/scripts/generate_vep_plugin_references.sh
+++ b/e2e-testing/scripts/generate_vep_plugin_references.sh
@@ -10,8 +10,8 @@ SOURCE_URL="${VEP_PLUGIN_SOURCE_URL:-http://localhost:18080}"
 JOBS="${VEP_REFERENCE_JOBS:-2}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILDER="$SCRIPT_DIR/build_vep_plugin_reference.sh"
-# shellcheck source=lib/source_identity.sh
-. "$SCRIPT_DIR/lib/source_identity.sh"
+# shellcheck source=source_identity.sh
+. "$SCRIPT_DIR/source_identity.sh"
 WORK_ROOT="$TARGET/.work"
 LOG_DIR="$TARGET/logs"
 

--- a/e2e-testing/scripts/generate_vep_plugin_references.sh
+++ b/e2e-testing/scripts/generate_vep_plugin_references.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Generate resumable per-autosome VEP 116 five-plugin references.
+
+set -euo pipefail
+
+DATA="${DATA_VEPYR_DIR:-$HOME/workspace/data_vepyr}"
+TARGET="${VEP_PLUGIN_REFERENCE_DIR:-$DATA/output/116/plugins}"
+PLUGIN_DIR="${VEP_PLUGIN_DIR:-$TARGET/plugin_code}"
+SOURCE_URL="${VEP_PLUGIN_SOURCE_URL:-http://localhost:18080}"
+JOBS="${VEP_REFERENCE_JOBS:-2}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILDER="$SCRIPT_DIR/build_vep_plugin_reference.sh"
+WORK_ROOT="$TARGET/.work"
+LOG_DIR="$TARGET/logs"
+
+if [[ "$JOBS" -lt 1 ]]; then
+  echo "ERROR: VEP_REFERENCE_JOBS must be positive" >&2
+  exit 1
+fi
+
+mkdir -p "$TARGET" "$WORK_ROOT" "$LOG_DIR"
+
+is_complete() {
+  local chrom="$1"
+  local output="$TARGET/HG002_chr${chrom}_5plugins_vep116_caddfix.vcf.gz"
+  [[ -s "$output" && -s "$output.tbi" ]] || return 1
+
+  local n_plugin
+  n_plugin=$(tabix -H "$output" | grep -m1 '^##INFO=<ID=CSQ' | tr '|' '\n' | grep -cE \
+    'SpliceAI_pred|CADD_(RAW|PHRED|raw|phred)|am_(class|pathogenicity)|ClinVar|SIFT4G|Polyphen2|MutationTaster|PROVEAN|VEST4|MetaSVM|MetaLR|REVEL|GERP|phyloP|phastCons')
+  [[ "$n_plugin" -eq 38 ]]
+}
+
+run_one() {
+  local chrom="$1"
+  local output="$TARGET/HG002_chr${chrom}_5plugins_vep116_caddfix.vcf"
+  local log="$LOG_DIR/chr${chrom}.log"
+
+  if is_complete "$chrom"; then
+    echo "SKIP chr${chrom}: validated output already exists"
+    return
+  fi
+
+  local work
+  work=$(mktemp -d "$WORK_ROOT/chr${chrom}.XXXXXX")
+  echo "START chr${chrom}: work=$work log=$log"
+  if DATA_VEPYR_DIR="$DATA" \
+      VEP_PLUGIN_DIR="$PLUGIN_DIR" \
+      VEP_PLUGIN_SOURCE_URL="$SOURCE_URL" \
+      VEP_OUTPUT_VCF="$output" \
+      VEP_KEEP_PLAIN=0 \
+      "$BUILDER" "$chrom" "$work" > "$log" 2>&1; then
+    if ! is_complete "$chrom"; then
+      echo "ERROR chr${chrom}: builder returned success but validation failed" >&2
+      return 1
+    fi
+    rm -rf "$work"
+    echo "DONE chr${chrom}: $output.gz"
+  else
+    echo "ERROR chr${chrom}: see $log (work preserved at $work)" >&2
+    return 1
+  fi
+}
+
+if [[ "$#" -gt 0 ]]; then
+  chroms=("$@")
+else
+  chroms=({1..22})
+fi
+
+fail=0
+pids=()
+labels=()
+for chrom in "${chroms[@]}"; do
+  run_one "$chrom" &
+  pids+=("$!")
+  labels+=("$chrom")
+
+  if [[ "${#pids[@]}" -eq "$JOBS" ]]; then
+    for i in "${!pids[@]}"; do
+      if ! wait "${pids[$i]}"; then
+        echo "FAILED chr${labels[$i]}" >&2
+        fail=1
+      fi
+    done
+    pids=()
+    labels=()
+  fi
+done
+
+for i in "${!pids[@]}"; do
+  if ! wait "${pids[$i]}"; then
+    echo "FAILED chr${labels[$i]}" >&2
+    fail=1
+  fi
+done
+
+if [[ "$fail" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "All requested references are complete under $TARGET"

--- a/e2e-testing/scripts/generate_vep_plugin_references.sh
+++ b/e2e-testing/scripts/generate_vep_plugin_references.sh
@@ -10,6 +10,8 @@ SOURCE_URL="${VEP_PLUGIN_SOURCE_URL:-http://localhost:18080}"
 JOBS="${VEP_REFERENCE_JOBS:-2}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILDER="$SCRIPT_DIR/build_vep_plugin_reference.sh"
+# shellcheck source=lib/source_identity.sh
+. "$SCRIPT_DIR/lib/source_identity.sh"
 WORK_ROOT="$TARGET/.work"
 LOG_DIR="$TARGET/logs"
 
@@ -25,7 +27,18 @@ mkdir -p "$TARGET" "$WORK_ROOT" "$LOG_DIR"
 # count alone cannot distinguish a current reference from one built with an
 # older CADD.pm -- and a stale golden reference reads as a vepyr mismatch.
 expected_plugin_provenance() {
-  sed -n 's/^verify_plugin \([A-Za-z]*\) \([0-9a-f]\{64\}\)$/\1 \2/p' "$BUILDER"
+  sed -n 's/^verify_plugin \([A-Za-z]*\) \([0-9a-f]\{64\}\)$/PLUGIN \1 \2/p' "$BUILDER"
+  # Plugin code is only half of it: the reference bytes also depend on the
+  # source data, and rolling sources keep their filenames. Ask the server what
+  # it holds now, and treat a changed answer as a stale reference.
+  if [[ -n "$SOURCE_URL" ]]; then
+    all_source_identities "$SOURCE_URL" || {
+      echo "WARN: cannot reach $SOURCE_URL; reusing references on plugin code alone" >&2
+      grep '^SOURCE ' "$1" 2>/dev/null || true
+    }
+  else
+    grep '^SOURCE ' "$1" 2>/dev/null || true
+  fi
 }
 
 is_complete() {
@@ -42,8 +55,8 @@ is_complete() {
     echo "STALE chr${chrom}: no plugin provenance recorded; rebuilding" >&2
     return 1
   fi
-  if ! diff -q <(sort "$output.plugins") <(expected_plugin_provenance | sort) >/dev/null; then
-    echo "STALE chr${chrom}: built with different plugin code; rebuilding" >&2
+  if ! diff -q <(sort "$output.plugins") <(expected_plugin_provenance "$output.plugins" | sort) >/dev/null; then
+    echo "STALE chr${chrom}: plugin code or source data changed since it was built; rebuilding" >&2
     return 1
   fi
 }

--- a/e2e-testing/scripts/run_all_plugin_comparisons.sh
+++ b/e2e-testing/scripts/run_all_plugin_comparisons.sh
@@ -11,7 +11,11 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
-DATA_ROOT="${VEPYR_DATA_ROOT:-/Users/mwiewior/workspace/data_vepyr}"
+DATA_ROOT="${VEPYR_DATA_ROOT:-${DATA_VEPYR_DIR:-/Users/mwiewior/workspace/data_vepyr}}"
+# The comparison CLI resolves its input VCF, FASTA and core cache from
+# DATA_VEPYR_DIR, not from this script's variable.  Export it so overriding the
+# runner's root moves every path, not only the two passed as explicit flags.
+export DATA_VEPYR_DIR="$DATA_ROOT"
 CACHE_DIR="${VEPYR_CACHE_DIR:-$DATA_ROOT/cache/116_GRCh38_merged}"
 PLUGIN_CACHE="${VEPYR_PLUGIN_CACHE:-$DATA_ROOT/plugin_cache}"
 PLUGIN_REPO="${VEPYR_PLUGIN_REPO:-/Users/mwiewior/workspace/vepyr-plugins}"
@@ -59,7 +63,27 @@ restore_manifests() {
     fi
   done
 }
-trap restore_manifests EXIT INT TERM
+# State for the chromosome currently in flight, so an early exit under `set -e`
+# cleans up after it.  Restoring manifests alone would leave orphaned shards
+# that a later cache_complete() -- which only tests file existence -- would
+# happily reuse against a manifest that no longer describes them.
+CURRENT_CHROM=""
+CURRENT_WORK=""
+CURRENT_TRANSIENT=0
+CURRENT_KEEP=""
+
+cleanup_on_exit() {
+  if [[ "$CURRENT_TRANSIENT" -eq 1 && -n "$CURRENT_CHROM" ]]; then
+    echo "CLEANUP chr$CURRENT_CHROM removing transient artifacts" >&2
+    remove_transient_caches "$CURRENT_CHROM" "$CURRENT_KEEP" || true
+    if [[ -n "$CURRENT_WORK" && -d "$CURRENT_WORK" ]]; then
+      find "$CURRENT_WORK" -depth -delete || true
+    fi
+    CURRENT_TRANSIENT=0
+  fi
+  restore_manifests
+}
+trap cleanup_on_exit EXIT INT TERM
 
 plugin_version() {
   case "$1" in
@@ -265,11 +289,30 @@ run_comparison() {
   return 0
 }
 
-remove_transient_caches() {
+# cache_complete() demands all five shards, so a chromosome missing even one
+# rebuilds all five with overwrite=True.  Deleting all five afterwards would
+# destroy the four that were already there -- expensive, and the opposite of
+# what this script's header promises.  Record what existed at startup and keep
+# exactly those paths.
+preexisting_shards() {
   local chrom="$1" plugin shard
   for plugin in $PLUGINS; do
     shard="$PLUGIN_CACHE/plugin/$plugin/chr${chrom}.parquet"
-    [[ -f "$shard" ]] && unlink "$shard"
+    [[ -f "$shard" ]] && printf '%s\n' "$shard"
+  done
+  return 0
+}
+
+remove_transient_caches() {
+  local chrom="$1" keep="${2:-}" plugin shard
+  for plugin in $PLUGINS; do
+    shard="$PLUGIN_CACHE/plugin/$plugin/chr${chrom}.parquet"
+    [[ -f "$shard" ]] || continue
+    if [[ -n "$keep" && -f "$keep" ]] && grep -qxF "$shard" "$keep"; then
+      echo "KEEP_PREEXISTING $shard"
+      continue
+    fi
+    unlink "$shard"
   done
   restore_manifests
 }
@@ -278,10 +321,20 @@ for chrom in $CHROMS; do
   echo "CHROM_START chr$chrom $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
   transient=0
   work=""
+  keep=""
+  CURRENT_CHROM="$chrom"
+  CURRENT_WORK=""
+  CURRENT_TRANSIENT=0
+  CURRENT_KEEP=""
   if ! cache_complete "$chrom"; then
     transient=1
     work="$(mktemp -d "$WORK_ROOT/chr${chrom}.XXXXXX")"
-    echo "WORK chr$chrom $work"
+    keep="$work/preexisting_shards.txt"
+    preexisting_shards "$chrom" > "$keep"
+    CURRENT_WORK="$work"
+    CURRENT_KEEP="$keep"
+    CURRENT_TRANSIENT=1
+    echo "WORK chr$chrom $work (preserving $(wc -l < "$keep" | tr -d ' ') pre-existing shard(s))"
     build_transient_caches "$chrom" "$work"
   else
     echo "CACHE_REUSE chr$chrom"
@@ -290,9 +343,11 @@ for chrom in $CHROMS; do
   run_comparison "$chrom"
 
   if [[ "$transient" -eq 1 ]]; then
-    remove_transient_caches "$chrom"
+    remove_transient_caches "$chrom" "$keep"
     find "$work" -depth -delete
+    CURRENT_TRANSIENT=0
   fi
+  CURRENT_CHROM=""
   echo "CHROM_DONE chr$chrom $(date -u '+%Y-%m-%dT%H:%M:%SZ') free=$(df -h "$DATA_ROOT" | awk 'NR==2 {print $4}')"
 done
 

--- a/e2e-testing/scripts/run_all_plugin_comparisons.sh
+++ b/e2e-testing/scripts/run_all_plugin_comparisons.sh
@@ -71,8 +71,34 @@ CURRENT_CHROM=""
 CURRENT_WORK=""
 CURRENT_TRANSIENT=0
 CURRENT_KEEP=""
+CURRENT_PIDS=""
+
+# A signal arriving while build_transient_caches()' background builders are
+# running must reap them BEFORE anything is deleted. Otherwise a builder
+# recreates its shard or manifest after cleanup has run, which is precisely the
+# orphaned state the cleanup exists to prevent.
+terminate_builders() {
+  local pid
+  [[ -z "$CURRENT_PIDS" ]] && return 0
+  for pid in $CURRENT_PIDS; do kill "$pid" 2>/dev/null || true; done
+  for pid in $CURRENT_PIDS; do wait "$pid" 2>/dev/null || true; done
+  CURRENT_PIDS=""
+  return 0
+}
+
+# Bash resumes the interrupted command after an INT/TERM handler returns, so
+# the handler must exit rather than fall through -- the EXIT trap then performs
+# the actual cleanup, once, with no builders still alive.
+on_signal() {
+  local name="$1" num="$2"
+  echo "SIGNAL $name received; terminating builders and cleaning up" >&2
+  terminate_builders
+  trap - INT TERM
+  exit $((128 + num))
+}
 
 cleanup_on_exit() {
+  terminate_builders
   if [[ "$CURRENT_TRANSIENT" -eq 1 && -n "$CURRENT_CHROM" ]]; then
     echo "CLEANUP chr$CURRENT_CHROM removing transient artifacts" >&2
     remove_transient_caches "$CURRENT_CHROM" "$CURRENT_KEEP" || true
@@ -83,7 +109,9 @@ cleanup_on_exit() {
   fi
   restore_manifests
 }
-trap cleanup_on_exit EXIT INT TERM
+trap cleanup_on_exit EXIT
+trap 'on_signal INT 2' INT
+trap 'on_signal TERM 15' TERM
 
 plugin_version() {
   case "$1" in
@@ -231,8 +259,10 @@ build_transient_caches() {
   build_clinvar "$chrom" "$work" & pids="$pids $!"
   build_alphamissense "$chrom" "$work" & pids="$pids $!"
   build_dbnsfp "$chrom" "$work" & pids="$pids $!"
+  CURRENT_PIDS="$pids"
   failed=0
   for pid in $pids; do wait "$pid" || failed=1; done
+  CURRENT_PIDS=""
   [[ "$failed" -eq 0 ]] || return 1
 
   # SpliceAI and CADD are each memory-heavy; keep them sequential.

--- a/e2e-testing/scripts/run_all_plugin_comparisons.sh
+++ b/e2e-testing/scripts/run_all_plugin_comparisons.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+# Build transient per-chromosome plugin caches and compare vepyr with VEP 116.
+#
+# The complete five-plugin cache is larger than the available local disk.  This
+# runner therefore preserves the cache shards that existed at startup, builds
+# each missing chromosome just long enough to compare it, then removes only the
+# transient shards and restores the original manifests.  Reports, strict-body
+# logs, and compressed vepyr outputs are retained.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DATA_ROOT="${VEPYR_DATA_ROOT:-/Users/mwiewior/workspace/data_vepyr}"
+CACHE_DIR="${VEPYR_CACHE_DIR:-$DATA_ROOT/cache/116_GRCh38_merged}"
+PLUGIN_CACHE="${VEPYR_PLUGIN_CACHE:-$DATA_ROOT/plugin_cache}"
+PLUGIN_REPO="${VEPYR_PLUGIN_REPO:-/Users/mwiewior/workspace/vepyr-plugins}"
+REFERENCE_DIR="${VEP_REFERENCE_DIR:-$DATA_ROOT/output/116/plugins}"
+SOURCE_BASE="${VEP_PLUGIN_SOURCE_URL:-http://localhost:18080}"
+WORK_ROOT="${VEP_COMPARISON_WORK_ROOT:-$DATA_ROOT/output/116/plugins/.comparison_cache_work}"
+LOG_DIR="${VEP_COMPARISON_LOG_DIR:-$DATA_ROOT/output/116/plugins/comparison_logs}"
+CHROMS="${VEP_COMPARISON_CHROMS:-1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22}"
+WORKERS="${VEP_COMPARISON_WORKERS:-4}"
+
+PLUGINS="clinvar alphamissense dbnsfp spliceai cadd"
+mkdir -p "$WORK_ROOT" "$LOG_DIR"
+
+for tool in bgzip curl git tabix uv; do
+  command -v "$tool" >/dev/null || { echo "ERROR: missing required tool: $tool" >&2; exit 1; }
+done
+[[ -d "$CACHE_DIR/variation" ]] || { echo "ERROR: missing variation cache: $CACHE_DIR" >&2; exit 1; }
+[[ -d "$PLUGIN_REPO/.git" ]] || { echo "ERROR: missing plugin repo: $PLUGIN_REPO" >&2; exit 1; }
+curl --fail --silent --show-error --head "$SOURCE_BASE/clinvar/clinvar.vcf.gz" >/dev/null
+
+manifest_snapshot="$(mktemp -d "$WORK_ROOT/manifests.XXXXXX")"
+for plugin in $PLUGINS; do
+  manifest="$PLUGIN_CACHE/plugin/$plugin/manifest.json"
+  [[ -s "$manifest" ]] || { echo "ERROR: missing baseline manifest: $manifest" >&2; exit 1; }
+  cp "$manifest" "$manifest_snapshot/$plugin.json"
+done
+
+restore_manifests() {
+  local plugin
+  for plugin in $PLUGINS; do
+    if [[ -s "$manifest_snapshot/$plugin.json" ]]; then
+      cp "$manifest_snapshot/$plugin.json" "$PLUGIN_CACHE/plugin/$plugin/manifest.json"
+    fi
+  done
+}
+trap restore_manifests EXIT INT TERM
+
+plugin_version() {
+  case "$1" in
+    clinvar) echo 4c92563adb49389ce1569a77681274f8f37c9fd8 ;;
+    dbnsfp) echo c9fe785 ;;
+    alphamissense|cadd|spliceai) echo f9cfa30 ;;
+    *) echo "ERROR: unknown plugin: $1" >&2; return 1 ;;
+  esac
+}
+
+cache_complete() {
+  local chrom="$1" plugin
+  for plugin in $PLUGINS; do
+    [[ -s "$PLUGIN_CACHE/plugin/$plugin/chr${chrom}.parquet" ]] || return 1
+  done
+}
+
+slice_bgzf() {
+  local work="$1" remote="$2" region="$3" output="$4" preset="$5"
+  local partial="${output}.partial.$$.gz"
+  echo "SLICE $(basename "$output") region=$region"
+  (
+    cd "$work"
+    tabix -h "${SOURCE_BASE%/}/$remote" "$region" | bgzip -c > "$partial"
+  )
+  mv "$partial" "$output"
+  case "$preset" in
+    vcf) tabix -f -p vcf "$output" ;;
+    tsv) tabix -f -s 1 -b 2 -e 2 "$output" ;;
+    *) echo "ERROR: unknown tabix preset: $preset" >&2; return 1 ;;
+  esac
+}
+
+slice_plain() {
+  local work="$1" remote="$2" region="$3" output="$4"
+  local partial="${output}.partial.$$"
+  echo "SLICE $(basename "$output") region=$region"
+  (
+    cd "$work"
+    tabix -h "${SOURCE_BASE%/}/$remote" "$region" > "$partial"
+  )
+  mv "$partial" "$output"
+}
+
+build_cache() {
+  local chrom="$1" plugin="$2" source="$3"
+  local version log
+  version="$(plugin_version "$plugin")"
+  log="$LOG_DIR/cache_chr${chrom}_${plugin}.log"
+  echo "CACHE_START chr$chrom $plugin source=$(basename "$source")"
+  (
+    cd "$REPO_DIR"
+    uv run python -c '
+import sys
+import vepyr
+
+plugin, version, source, cache_dir, plugin_cache, chrom, plugin_repo = sys.argv[1:]
+result = vepyr.build_plugin_cache(
+    plugin,
+    version,
+    source_path=source,
+    cache_dir=cache_dir,
+    plugin_cache_root=plugin_cache,
+    chroms=[chrom],
+    plugins_repo=plugin_repo,
+    overwrite=True,
+)
+print(result)
+' "$plugin" "$version" "$source" "$CACHE_DIR" "$PLUGIN_CACHE" "$chrom" "$PLUGIN_REPO"
+  ) >"$log" 2>&1
+  echo "CACHE_DONE chr$chrom $plugin $(tail -1 "$log")"
+}
+
+build_clinvar() {
+  local chrom="$1" work="$2" source="$work/clinvar_chr${chrom}.vcf.gz"
+  slice_bgzf "$work" clinvar/clinvar.vcf.gz "$chrom" "$source" vcf
+  build_cache "$chrom" clinvar "$source"
+  unlink "$source"
+  unlink "$source.tbi"
+}
+
+build_alphamissense() {
+  local chrom="$1" work="$2" source="$work/alphamissense_chr${chrom}.tsv.gz"
+  slice_bgzf "$work" alphamissense/AlphaMissense_hg38.bgz.tsv.gz "chr${chrom}" "$source" tsv
+  build_cache "$chrom" alphamissense "$source"
+  unlink "$source"
+  unlink "$source.tbi"
+}
+
+build_dbnsfp() {
+  # The Perl plugin requires BGZF+tabix, but the cache manifest intentionally
+  # declares an uncompressed TSV provider.  Feeding its BGZF form to Arrow CSV
+  # makes the gzip header look like a one-column first record.
+  local chrom="$1" work="$2" source="$work/dbNSFP5.3.1a_grch38_chr${chrom}.tsv"
+  slice_plain "$work" dbnsfp/dbNSFP5.3.1a_grch38.gz "$chrom" "$source"
+  build_cache "$chrom" dbnsfp "$source"
+  unlink "$source"
+}
+
+build_spliceai() {
+  local chrom="$1" work="$2" source="$work/spliceai_chr${chrom}.vcf.gz"
+  slice_bgzf "$work" spliceai/spliceai_scores.masked.snv.ensembl_mane.grch38.110.vcf.gz "$chrom" "$source" vcf
+  build_cache "$chrom" spliceai "$source"
+  unlink "$source"
+  unlink "$source.tbi"
+}
+
+build_cadd() {
+  local chrom="$1" work="$2" source="$work/cadd_all_chr${chrom}.tsv"
+  local partial="${source}.partial.$$"
+  echo "SLICE $(basename "$source") region=$chrom"
+  (
+    cd "$work"
+    tabix "${SOURCE_BASE%/}/cadd/whole_genome_SNVs.tsv.gz" "$chrom" > "$partial"
+    tabix "${SOURCE_BASE%/}/cadd/gnomad.genomes.r4.0.indel.tsv.gz" "$chrom" >> "$partial"
+  )
+  mv "$partial" "$source"
+  build_cache "$chrom" cadd "$source"
+  unlink "$source"
+}
+
+build_transient_caches() {
+  local chrom="$1" work="$2" pid failed
+  local pids=""
+
+  # These three builders have low measured peak RSS and write independent
+  # manifests, so running them together is safe on the 64 GiB host.
+  build_clinvar "$chrom" "$work" & pids="$pids $!"
+  build_alphamissense "$chrom" "$work" & pids="$pids $!"
+  build_dbnsfp "$chrom" "$work" & pids="$pids $!"
+  failed=0
+  for pid in $pids; do wait "$pid" || failed=1; done
+  [[ "$failed" -eq 0 ]] || return 1
+
+  # SpliceAI and CADD are each memory-heavy; keep them sequential.
+  build_spliceai "$chrom" "$work"
+  build_cadd "$chrom" "$work"
+}
+
+run_comparison() {
+  local chrom="$1"
+  local reference="$REFERENCE_DIR/HG002_chr${chrom}_5plugins_vep116_caddfix.vcf.gz"
+  local result_dir="$REPO_DIR/e2e-testing/results/116/fast_chr${chrom}"
+  local run_log="$LOG_DIR/compare_chr${chrom}.log"
+  local strict_log="$LOG_DIR/strict_chr${chrom}.log"
+  local vep_slice="$result_dir/vep_chr${chrom}_merged_plugins.vcf"
+  local vepyr_bgzf="$result_dir/vepyr_parquet_chr${chrom}_merged_plugins.vcf.gz"
+  local vepyr_plain="$result_dir/vepyr_parquet_chr${chrom}_merged_plugins.vcf"
+  local strict_rc
+
+  [[ -s "$reference" && -s "$reference.tbi" ]] || {
+    echo "ERROR: missing reference or index for chr$chrom: $reference" >&2
+    return 1
+  }
+
+  echo "COMPARE_START chr$chrom"
+  (
+    cd "$REPO_DIR"
+    uv run python e2e-testing/scripts/run_comparison.py \
+      --release 116 --profile merged_plugins --chroms "$chrom" \
+      --plugin-cache "$PLUGIN_CACHE" --vep "$reference" \
+      --workers "$WORKERS" --bgzf --force
+  ) >"$run_log" 2>&1
+
+  [[ -s "$vep_slice" && -s "$vepyr_bgzf" ]] || {
+    echo "ERROR: comparison outputs missing for chr$chrom" >&2
+    return 1
+  }
+
+  set +e
+  (
+    cd "$REPO_DIR"
+    uv run python e2e-testing/scripts/md5_concordance.py \
+      --pair "$vep_slice" "$vepyr_bgzf" --mode strict --explain --explain-limit 0
+  ) >"$strict_log" 2>&1
+  strict_rc=$?
+  set -e
+  echo "$strict_rc" > "$LOG_DIR/strict_chr${chrom}.exit"
+  echo "COMPARE_DONE chr$chrom strict_rc=$strict_rc report=$REPO_DIR/e2e-testing/reports/fast_chr${chrom}_merged_plugins_116_report.json"
+
+  # The original reference remains compressed+indexed in REFERENCE_DIR, so its
+  # multi-gigabyte plain slice is redundant after strict hashing.  Keep the
+  # compressed vepyr output and all JSON/log evidence.
+  [[ -f "$vep_slice" ]] && unlink "$vep_slice"
+  [[ -f "$vepyr_plain" ]] && unlink "$vepyr_plain"
+  return 0
+}
+
+remove_transient_caches() {
+  local chrom="$1" plugin shard
+  for plugin in $PLUGINS; do
+    shard="$PLUGIN_CACHE/plugin/$plugin/chr${chrom}.parquet"
+    [[ -f "$shard" ]] && unlink "$shard"
+  done
+  restore_manifests
+}
+
+for chrom in $CHROMS; do
+  case "$chrom" in
+    ''|*[!0-9]*) echo "ERROR: invalid chromosome: $chrom" >&2; exit 1 ;;
+  esac
+  if (( chrom < 1 || chrom > 22 )); then
+    echo "ERROR: chromosome out of range: $chrom" >&2
+    exit 1
+  fi
+
+  echo "CHROM_START chr$chrom $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  transient=0
+  work=""
+  if ! cache_complete "$chrom"; then
+    transient=1
+    work="$(mktemp -d "$WORK_ROOT/chr${chrom}.XXXXXX")"
+    echo "WORK chr$chrom $work"
+    build_transient_caches "$chrom" "$work"
+  else
+    echo "CACHE_REUSE chr$chrom"
+  fi
+
+  run_comparison "$chrom"
+
+  if [[ "$transient" -eq 1 ]]; then
+    remove_transient_caches "$chrom"
+    find "$work" -depth -delete
+  fi
+  echo "CHROM_DONE chr$chrom $(date -u '+%Y-%m-%dT%H:%M:%SZ') free=$(df -h "$DATA_ROOT" | awk 'NR==2 {print $4}')"
+done
+
+restore_manifests
+find "$manifest_snapshot" -depth -delete
+trap - EXIT INT TERM
+echo "ALL_DONE $(date -u '+%Y-%m-%dT%H:%M:%SZ')"

--- a/e2e-testing/scripts/run_all_plugin_comparisons.sh
+++ b/e2e-testing/scripts/run_all_plugin_comparisons.sh
@@ -189,6 +189,20 @@ reference_sources_current() {
     echo "NOTE: $(basename "$reference") records no source identities; unverified" >&2
     return 0
   }
+  # The sidecar records the plugin code as well as the data. Checking only the
+  # SOURCE half would accept a reference built with the wrong CADD.pm whenever
+  # the corpus happened to be unchanged -- an artifact the generator refuses.
+  local expected_plugins
+  expected_plugins="$(sed -n 's/^verify_plugin \([A-Za-z]*\) \([0-9a-f]\{64\}\)$/PLUGIN \1 \2/p' \
+    "$SCRIPT_DIR/build_vep_plugin_reference.sh")"
+  if [[ -n "$expected_plugins" ]]; then
+    if ! diff -q <(grep '^PLUGIN ' "$sidecar" | sort) \
+        <(printf '%s\n' "$expected_plugins" | sort) >/dev/null; then
+      echo "ERROR: $(basename "$reference") was built with different plugin code" >&2
+      return 1
+    fi
+  fi
+
   current="$(all_source_identities "$SOURCE_BASE" 2>/dev/null)" || {
     echo "NOTE: cannot reach $SOURCE_BASE; source currency unverified" >&2
     return 0
@@ -196,10 +210,44 @@ reference_sources_current() {
   diff -q <(grep '^SOURCE ' "$sidecar" | sort) <(printf '%s\n' "$current" | sort) >/dev/null
 }
 
+# A shard is reusable only while the sources it was built from are still what
+# the server holds. Without this, a chromosome whose five shards predate a
+# rolling ClinVar takes the CACHE_REUSE path and the comparison reports
+# stale-cache data as a vepyr mismatch. The reference check covers the golden
+# side only; this covers ours.
+#
+# No record means a shard built before this existed -- including the whole
+# published cache -- so that warns rather than forces a 97 GiB rebuild. A
+# record that no longer matches is stale, and the shard is rebuilt.
+shard_current() {
+  local chrom="$1" plugin="$2"
+  local shard="$PLUGIN_CACHE/plugin/$plugin/chr${chrom}.parquet"
+  local record="$shard.sources"
+  local current
+  [[ -s "$record" ]] || {
+    echo "NOTE: $plugin chr$chrom has no source record; currency unverified" >&2
+    return 0
+  }
+  current="$(plugin_source_identities "$SOURCE_BASE" "$plugin" 2>/dev/null)" || {
+    echo "NOTE: cannot reach $SOURCE_BASE; $plugin chr$chrom currency unverified" >&2
+    return 0
+  }
+  diff -q <(sort "$record") <(printf '%s\n' "$current" | sort) >/dev/null
+}
+
+shard_present() {
+  local chrom="$1" plugin="$2"
+  [[ -s "$PLUGIN_CACHE/plugin/$plugin/chr${chrom}.parquet" ]] || return 1
+  shard_current "$chrom" "$plugin" || {
+    echo "STALE $plugin chr$chrom: built from different source data; rebuilding" >&2
+    return 1
+  }
+}
+
 cache_complete() {
   local chrom="$1" plugin
   for plugin in $PLUGINS; do
-    [[ -s "$PLUGIN_CACHE/plugin/$plugin/chr${chrom}.parquet" ]] || return 1
+    shard_present "$chrom" "$plugin" || return 1
   done
 }
 
@@ -273,6 +321,14 @@ result = vepyr.build_plugin_cache(
 print(result)
 ' "$plugin" "$version" "$source" "$CACHE_DIR" "$PLUGIN_CACHE" "$chrom" "$PLUGIN_REPO"
   ) >"$log" 2>&1
+  # Record what this shard was built from, so a later run can tell whether it
+  # is still current rather than assuming a file on disk is.
+  local record="$PLUGIN_CACHE/plugin/$plugin/chr${chrom}.parquet.sources"
+  if [[ -n "$SOURCE_BASE" ]] && plugin_source_identities "$SOURCE_BASE" "$plugin" > "$record.tmp.$$" 2>/dev/null; then
+    mv -f "$record.tmp.$$" "$record"
+  else
+    rm -f "$record.tmp.$$" "$record"
+  fi
   echo "CACHE_DONE chr$chrom $plugin $(tail -1 "$log")"
 }
 
@@ -322,11 +378,6 @@ build_cadd() {
   mv "$partial" "$source"
   build_cache "$chrom" cadd "$source"
   unlink "$source"
-}
-
-shard_present() {
-  local chrom="$1" plugin="$2"
-  [[ -s "$PLUGIN_CACHE/plugin/$plugin/chr${chrom}.parquet" ]]
 }
 
 # cache_complete() is all-or-nothing, so one missing plugin used to rebuild all

--- a/e2e-testing/scripts/run_all_plugin_comparisons.sh
+++ b/e2e-testing/scripts/run_all_plugin_comparisons.sh
@@ -89,11 +89,29 @@ kill_tree() {
   kill "$pid" 2>/dev/null || true
 }
 
+# Builders are launched under `set -m`, so each is its own process-group
+# leader and one signal reaches the whole tree. `wait` cannot help confirm
+# that: it reaps only the recorded child, never its descendants, so a
+# descendant that handles TERM slowly -- or forks during the kill_tree walk --
+# could outlive the call and write a shard after cleanup. Poll the group until
+# it is genuinely gone, escalating to KILL.
 terminate_builders() {
-  local pid
+  local pid deadline
   [[ -z "$CURRENT_PIDS" ]] && return 0
-  for pid in $CURRENT_PIDS; do kill_tree "$pid"; done
-  for pid in $CURRENT_PIDS; do wait "$pid" 2>/dev/null || true; done
+  for pid in $CURRENT_PIDS; do
+    kill -TERM -- "-$pid" 2>/dev/null || kill_tree "$pid"
+  done
+  for pid in $CURRENT_PIDS; do
+    deadline=$((SECONDS + 10))
+    while kill -0 -- "-$pid" 2>/dev/null; do
+      if (( SECONDS >= deadline )); then
+        kill -KILL -- "-$pid" 2>/dev/null || true
+        deadline=$((SECONDS + 5))
+      fi
+      sleep 0.2
+    done
+    wait "$pid" 2>/dev/null || true
+  done
   CURRENT_PIDS=""
   return 0
 }
@@ -277,28 +295,48 @@ build_transient_caches() {
   local chrom="$1" work="$2" pid failed plugin
   local pids=""
 
+  CURRENT_PIDS=""
   # These three builders have low measured peak RSS and write independent
   # manifests, so running them together is safe on the 64 GiB host.
+  # `set -m` puts each in its own process group; see terminate_builders().
+  set -m
   for plugin in clinvar alphamissense dbnsfp; do
     if shard_present "$chrom" "$plugin"; then
       echo "SKIP_BUILD chr$chrom $plugin (already cached)"
       continue
     fi
-    "build_$plugin" "$chrom" "$work" & pids="$pids $!"
+    "build_$plugin" "$chrom" "$work" &
+    # Publish before starting the next one: a signal arriving mid-loop would
+    # otherwise find CURRENT_PIDS still holding the pre-loop value and reap
+    # nothing, leaving a live builder to write after cleanup.
+    CURRENT_PIDS="$CURRENT_PIDS $!"
+    pids="$pids $!"
   done
-  CURRENT_PIDS="$pids"
+  set +m
   failed=0
   for pid in $pids; do wait "$pid" || failed=1; done
   CURRENT_PIDS=""
   [[ "$failed" -eq 0 ]] || return 1
 
-  # SpliceAI and CADD are each memory-heavy; keep them sequential.
+  # SpliceAI and CADD are each memory-heavy; keep them sequential. They run
+  # backgrounded-then-waited rather than in the foreground so they are tracked
+  # like the others, and so a signal during a long CADD build is handled at
+  # once instead of after it finishes.
   for plugin in spliceai cadd; do
     if shard_present "$chrom" "$plugin"; then
       echo "SKIP_BUILD chr$chrom $plugin (already cached)"
       continue
     fi
-    "build_$plugin" "$chrom" "$work"
+    set -m
+    "build_$plugin" "$chrom" "$work" &
+    pid=$!
+    CURRENT_PIDS="$pid"
+    set +m
+    if ! wait "$pid"; then
+      CURRENT_PIDS=""
+      return 1
+    fi
+    CURRENT_PIDS=""
   done
 }
 

--- a/e2e-testing/scripts/run_all_plugin_comparisons.sh
+++ b/e2e-testing/scripts/run_all_plugin_comparisons.sh
@@ -25,12 +25,24 @@ WORKERS="${VEP_COMPARISON_WORKERS:-4}"
 PLUGINS="clinvar alphamissense dbnsfp spliceai cadd"
 mkdir -p "$WORK_ROOT" "$LOG_DIR"
 
-for tool in bgzip curl git tabix uv; do
+for tool in git uv; do
   command -v "$tool" >/dev/null || { echo "ERROR: missing required tool: $tool" >&2; exit 1; }
 done
 [[ -d "$CACHE_DIR/variation" ]] || { echo "ERROR: missing variation cache: $CACHE_DIR" >&2; exit 1; }
 [[ -d "$PLUGIN_REPO/.git" ]] || { echo "ERROR: missing plugin repo: $PLUGIN_REPO" >&2; exit 1; }
-curl --fail --silent --show-error --head "$SOURCE_BASE/clinvar/clinvar.vcf.gz" >/dev/null
+
+# Validate the requested chromosomes before anything reads them, so a typo
+# reports itself rather than surfacing as a missing-shard or source-server
+# error further down.
+for chrom in $CHROMS; do
+  case "$chrom" in
+    ''|*[!0-9]*) echo "ERROR: invalid chromosome: $chrom" >&2; exit 1 ;;
+  esac
+  if (( chrom < 1 || chrom > 22 )); then
+    echo "ERROR: chromosome out of range: $chrom" >&2
+    exit 1
+  fi
+done
 
 manifest_snapshot="$(mktemp -d "$WORK_ROOT/manifests.XXXXXX")"
 for plugin in $PLUGINS; do
@@ -64,6 +76,23 @@ cache_complete() {
     [[ -s "$PLUGIN_CACHE/plugin/$plugin/chr${chrom}.parquet" ]] || return 1
   done
 }
+
+# Slicing tools and the source server are needed only when a requested
+# chromosome is missing from the cache.  With a complete cache every iteration
+# takes the CACHE_REUSE path and never opens a source, so probing for them up
+# front would fail a run that needs nothing they provide.
+needs_sources=0
+for chrom in $CHROMS; do
+  cache_complete "$chrom" || { needs_sources=1; break; }
+done
+if (( needs_sources )); then
+  for tool in bgzip curl tabix; do
+    command -v "$tool" >/dev/null || { echo "ERROR: missing required tool: $tool" >&2; exit 1; }
+  done
+  curl --fail --silent --show-error --head "$SOURCE_BASE/clinvar/clinvar.vcf.gz" >/dev/null
+else
+  echo "PREFLIGHT all requested chromosomes cached; skipping source-server checks"
+fi
 
 slice_bgzf() {
   local work="$1" remote="$2" region="$3" output="$4" preset="$5"
@@ -246,14 +275,6 @@ remove_transient_caches() {
 }
 
 for chrom in $CHROMS; do
-  case "$chrom" in
-    ''|*[!0-9]*) echo "ERROR: invalid chromosome: $chrom" >&2; exit 1 ;;
-  esac
-  if (( chrom < 1 || chrom > 22 )); then
-    echo "ERROR: chromosome out of range: $chrom" >&2
-    exit 1
-  fi
-
   echo "CHROM_START chr$chrom $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
   transient=0
   work=""

--- a/e2e-testing/scripts/run_all_plugin_comparisons.sh
+++ b/e2e-testing/scripts/run_all_plugin_comparisons.sh
@@ -102,15 +102,30 @@ terminate_builders() {
     kill -TERM -- "-$pid" 2>/dev/null || kill_tree "$pid"
   done
   for pid in $CURRENT_PIDS; do
+    # Reap the builder itself BEFORE asking whether its group is empty. `wait`
+    # is the only thing that can clear this child, and an unreaped one is still
+    # a member of its own process group -- so checking the group first would
+    # make the leader's own corpse the reason the group never looks empty.
+    # Both loops are bounded and break after escalating, so neither can spin.
     deadline=$((SECONDS + 10))
-    while kill -0 -- "-$pid" 2>/dev/null; do
+    while kill -0 "$pid" 2>/dev/null; do
       if (( SECONDS >= deadline )); then
-        kill -KILL -- "-$pid" 2>/dev/null || true
-        deadline=$((SECONDS + 5))
+        kill -KILL -- "-$pid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null || true
+        break
       fi
       sleep 0.2
     done
     wait "$pid" 2>/dev/null || true
+
+    # With the leader reaped, anything left in the group is a real survivor.
+    deadline=$((SECONDS + 10))
+    while kill -0 -- "-$pid" 2>/dev/null; do
+      if (( SECONDS >= deadline )); then
+        kill -KILL -- "-$pid" 2>/dev/null || true
+        break
+      fi
+      sleep 0.2
+    done
   done
   CURRENT_PIDS=""
   return 0

--- a/e2e-testing/scripts/run_all_plugin_comparisons.sh
+++ b/e2e-testing/scripts/run_all_plugin_comparisons.sh
@@ -77,10 +77,22 @@ CURRENT_PIDS=""
 # running must reap them BEFORE anything is deleted. Otherwise a builder
 # recreates its shard or manifest after cleanup has run, which is precisely the
 # orphaned state the cleanup exists to prevent.
+# A builder PID is the outer `build_x ... &` subshell; the work happens in
+# nested subshells running tabix, bgzip and `uv run python`. Killing only the
+# outer shell orphans those, and an orphan can still write a shard after
+# cleanup. Walk the tree depth-first so children die before their parent.
+kill_tree() {
+  local pid="$1" child
+  for child in $(pgrep -P "$pid" 2>/dev/null || true); do
+    kill_tree "$child"
+  done
+  kill "$pid" 2>/dev/null || true
+}
+
 terminate_builders() {
   local pid
   [[ -z "$CURRENT_PIDS" ]] && return 0
-  for pid in $CURRENT_PIDS; do kill "$pid" 2>/dev/null || true; done
+  for pid in $CURRENT_PIDS; do kill_tree "$pid"; done
   for pid in $CURRENT_PIDS; do wait "$pid" 2>/dev/null || true; done
   CURRENT_PIDS=""
   return 0
@@ -250,15 +262,30 @@ build_cadd() {
   unlink "$source"
 }
 
+shard_present() {
+  local chrom="$1" plugin="$2"
+  [[ -s "$PLUGIN_CACHE/plugin/$plugin/chr${chrom}.parquet" ]]
+}
+
+# cache_complete() is all-or-nothing, so one missing plugin used to rebuild all
+# five -- overwriting the four already on disk. Recording their paths does not
+# save them: preservation keeps the path, so what survives cleanup is the
+# rebuilt file, left paired with the metadata restore_manifests() puts back.
+# Build only what is genuinely absent; then the kept shard really is the
+# original, and it still matches its manifest.
 build_transient_caches() {
-  local chrom="$1" work="$2" pid failed
+  local chrom="$1" work="$2" pid failed plugin
   local pids=""
 
   # These three builders have low measured peak RSS and write independent
   # manifests, so running them together is safe on the 64 GiB host.
-  build_clinvar "$chrom" "$work" & pids="$pids $!"
-  build_alphamissense "$chrom" "$work" & pids="$pids $!"
-  build_dbnsfp "$chrom" "$work" & pids="$pids $!"
+  for plugin in clinvar alphamissense dbnsfp; do
+    if shard_present "$chrom" "$plugin"; then
+      echo "SKIP_BUILD chr$chrom $plugin (already cached)"
+      continue
+    fi
+    "build_$plugin" "$chrom" "$work" & pids="$pids $!"
+  done
   CURRENT_PIDS="$pids"
   failed=0
   for pid in $pids; do wait "$pid" || failed=1; done
@@ -266,8 +293,13 @@ build_transient_caches() {
   [[ "$failed" -eq 0 ]] || return 1
 
   # SpliceAI and CADD are each memory-heavy; keep them sequential.
-  build_spliceai "$chrom" "$work"
-  build_cadd "$chrom" "$work"
+  for plugin in spliceai cadd; do
+    if shard_present "$chrom" "$plugin"; then
+      echo "SKIP_BUILD chr$chrom $plugin (already cached)"
+      continue
+    fi
+    "build_$plugin" "$chrom" "$work"
+  done
 }
 
 run_comparison() {

--- a/e2e-testing/scripts/run_all_plugin_comparisons.sh
+++ b/e2e-testing/scripts/run_all_plugin_comparisons.sh
@@ -26,6 +26,9 @@ LOG_DIR="${VEP_COMPARISON_LOG_DIR:-$DATA_ROOT/output/116/plugins/comparison_logs
 CHROMS="${VEP_COMPARISON_CHROMS:-1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22}"
 WORKERS="${VEP_COMPARISON_WORKERS:-4}"
 
+# shellcheck source=source_identity.sh
+. "$SCRIPT_DIR/source_identity.sh"
+
 PLUGINS="clinvar alphamissense dbnsfp spliceai cadd"
 mkdir -p "$WORK_ROOT" "$LOG_DIR"
 
@@ -165,6 +168,32 @@ plugin_version() {
     alphamissense|cadd|spliceai) echo f9cfa30 ;;
     *) echo "ERROR: unknown plugin: $1" >&2; return 1 ;;
   esac
+}
+
+# A reference carries a .plugins sidecar naming the plugin code and the source
+# data it was built from. Compare the recorded source identities against what
+# the server holds now. Absent sidecar or unreachable server means "cannot
+# tell", which warns rather than blocks -- references built before the sidecar
+# existed are still usable.
+reference_sources_current() {
+  # Declared separately: under `set -u` a single `local` cannot reference a
+  # name being assigned in the same statement.
+  local reference="$1"
+  local sidecar="$reference.plugins"
+  local current
+  [[ -s "$sidecar" ]] || {
+    echo "NOTE: $(basename "$reference") has no provenance sidecar; source currency unverified" >&2
+    return 0
+  }
+  grep -q '^SOURCE ' "$sidecar" || {
+    echo "NOTE: $(basename "$reference") records no source identities; unverified" >&2
+    return 0
+  }
+  current="$(all_source_identities "$SOURCE_BASE" 2>/dev/null)" || {
+    echo "NOTE: cannot reach $SOURCE_BASE; source currency unverified" >&2
+    return 0
+  }
+  diff -q <(grep '^SOURCE ' "$sidecar" | sort) <(printf '%s\n' "$current" | sort) >/dev/null
 }
 
 cache_complete() {
@@ -370,6 +399,18 @@ run_comparison() {
     echo "ERROR: missing reference or index for chr$chrom: $reference" >&2
     return 1
   }
+
+  # Shards may be rebuilt here from the current source server while the golden
+  # reference predates a rolling source such as ClinVar. Comparing the two would
+  # report a source-version difference as a vepyr mismatch. The generator
+  # records the identities each reference was built from; check them.
+  if ! reference_sources_current "$reference"; then
+    echo "ERROR: chr$chrom reference was built from different source data" >&2
+    echo "       $reference" >&2
+    echo "       Regenerate it, or set VEP_ALLOW_STALE_REFERENCE=1 to compare anyway." >&2
+    [[ "${VEP_ALLOW_STALE_REFERENCE:-0}" == "1" ]] || return 1
+    echo "WARN: continuing against a stale reference on request" >&2
+  fi
 
   echo "COMPARE_START chr$chrom"
   (

--- a/e2e-testing/scripts/source_identity.sh
+++ b/e2e-testing/scripts/source_identity.sh
@@ -38,10 +38,18 @@ source_identity() {
 }
 
 # all_source_identities <base_url> -- one "SOURCE <path> <identity>" per line.
+#
+# All or nothing: a caller that fails partway must not have already emitted
+# lines for the sources it did reach. Callers use this in an `|| fallback`
+# without a command substitution, so partial output would be concatenated with
+# whatever the fallback prints -- producing duplicate, conflicting entries for
+# the paths that succeeded before a mid-loop network blip.
 all_source_identities() {
   local base="$1" path line
+  local -a lines=()
   for path in "${PLUGIN_SOURCE_PATHS[@]}"; do
     line="$(source_identity "$base" "$path")" || return 1
-    printf 'SOURCE %s\n' "$line"
+    lines+=("SOURCE $line")
   done
+  printf '%s\n' "${lines[@]}"
 }

--- a/e2e-testing/scripts/source_identity.sh
+++ b/e2e-testing/scripts/source_identity.sh
@@ -53,3 +53,35 @@ all_source_identities() {
   done
   printf '%s\n' "${lines[@]}"
 }
+
+# Which remote sources each plugin's cache shard is built from. A shard is only
+# reusable while these still match, so the mapping lives beside the identity
+# helper rather than being restated per script.
+plugin_source_paths() {
+  case "$1" in
+    clinvar) printf '%s\n' "clinvar/clinvar.vcf.gz" ;;
+    spliceai) printf '%s\n' "spliceai/spliceai_scores.masked.snv.ensembl_mane.grch38.110.vcf.gz" ;;
+    alphamissense) printf '%s\n' "alphamissense/AlphaMissense_hg38.bgz.tsv.gz" ;;
+    dbnsfp) printf '%s\n' "dbnsfp/dbNSFP5.3.1a_grch38.gz" ;;
+    cadd)
+      printf '%s\n' "cadd/whole_genome_SNVs.tsv.gz"
+      printf '%s\n' "cadd/gnomad.genomes.r4.0.indel.tsv.gz"
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+# plugin_source_identities <base_url> <plugin> -- all or nothing, as above.
+plugin_source_identities() {
+  local base="$1" plugin="$2" path line
+  local -a paths=() lines=()
+  while IFS= read -r path; do
+    paths+=("$path")
+  done < <(plugin_source_paths "$plugin") || return 1
+  [[ ${#paths[@]} -gt 0 ]] || return 1
+  for path in "${paths[@]}"; do
+    line="$(source_identity "$base" "$path")" || return 1
+    lines+=("SOURCE $line")
+  done
+  printf '%s\n' "${lines[@]}"
+}

--- a/e2e-testing/scripts/source_identity.sh
+++ b/e2e-testing/scripts/source_identity.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Shared between build_vep_plugin_reference.sh (which records) and
+# generate_vep_plugin_references.sh (which validates), so the two cannot drift.
+#
+# A reference's CSQ bytes depend on the plugin *data* as much as the plugin
+# code. Several sources are rolling -- ClinVar most obviously -- and keep the
+# same filename as their contents change, so a filename alone proves nothing.
+# Identify each source by what the server reports for it: ETag when present,
+# otherwise Last-Modified plus Content-Length.
+
+# The remote paths a five-plugin reference is built from.
+PLUGIN_SOURCE_PATHS=(
+  "clinvar/clinvar.vcf.gz"
+  "spliceai/spliceai_scores.masked.snv.ensembl_mane.grch38.110.vcf.gz"
+  "alphamissense/AlphaMissense_hg38.bgz.tsv.gz"
+  "dbnsfp/dbNSFP5.3.1a_grch38.gz"
+  "cadd/whole_genome_SNVs.tsv.gz"
+  "cadd/gnomad.genomes.r4.0.indel.tsv.gz"
+)
+
+# source_identity <base_url> <remote_path>
+# Prints "<remote_path> <identity>", or returns non-zero if the server cannot
+# be reached -- callers decide whether that is fatal.
+source_identity() {
+  local base="$1" path="$2" headers etag modified length identity
+  headers="$(curl --fail --silent --show-error --head "${base%/}/${path}" 2>/dev/null)" || return 1
+  etag="$(printf '%s' "$headers" | tr -d '\r' | awk 'tolower($1) == "etag:" {print $2; exit}')"
+  modified="$(printf '%s' "$headers" | tr -d '\r' | awk 'tolower($1) == "last-modified:" {$1=""; sub(/^ /,""); print; exit}')"
+  length="$(printf '%s' "$headers" | tr -d '\r' | awk 'tolower($1) == "content-length:" {print $2; exit}')"
+  if [[ -n "$etag" ]]; then
+    identity="etag=$etag"
+  elif [[ -n "$modified" || -n "$length" ]]; then
+    identity="mtime=${modified:-?};size=${length:-?}"
+  else
+    return 1
+  fi
+  printf '%s %s\n' "$path" "$identity"
+}
+
+# all_source_identities <base_url> -- one "SOURCE <path> <identity>" per line.
+all_source_identities() {
+  local base="$1" path line
+  for path in "${PLUGIN_SOURCE_PATHS[@]}"; do
+    line="$(source_identity "$base" "$path")" || return 1
+    printf 'SOURCE %s\n' "$line"
+  done
+}

--- a/e2e-testing/scripts/verify_parity_gate.py
+++ b/e2e-testing/scripts/verify_parity_gate.py
@@ -68,6 +68,18 @@ def expected_csq_fields(profile_name: str) -> frozenset[str]:
             "contract only. Plugin profiles are comparison scenarios, not release "
             "gates, until their field contract is pinned here."
         )
+    # Attaching no plugins is not the same as reading a plugin-free reference.
+    # "merged_plugins_base" deliberately attaches nothing while reading the
+    # five-plugin reference, so its report always carries that reference's
+    # plugin fields in fields_only_in_vep. Without this it slipped past the
+    # guard above and failed later, deep in validation, instead of saying why.
+    if profile.vep_basename == profiles.plugin_reference_basename():
+        raise GateError(
+            f"profile {profile_name!r} reads the five-plugin reference "
+            f"({profile.vep_basename}); this gate pins the Ensembl core CSQ "
+            "contract only. Plugin profiles are comparison scenarios, not release "
+            "gates, until their field contract is pinned here."
+        )
     fields = set(_ENSEMBL_CSQ_FIELDS)
     if profile.flavour in {"refseq", "merged"}:
         fields.update(_REFSEQ_CSQ_FIELDS)

--- a/e2e-testing/scripts/verify_parity_gate.py
+++ b/e2e-testing/scripts/verify_parity_gate.py
@@ -61,6 +61,13 @@ _REFSEQ_CSQ_FIELDS = frozenset(
 def expected_csq_fields(profile_name: str) -> frozenset[str]:
     """Return the exact Ensembl VEP CSQ contract for one comparison profile."""
     profile = profiles.PROFILES[profile_name]
+    if profile.plugins:
+        raise GateError(
+            f"profile {profile_name!r} attaches plugins "
+            f"({', '.join(profile.plugins)}); this gate pins the Ensembl core CSQ "
+            "contract only. Plugin profiles are comparison scenarios, not release "
+            "gates, until their field contract is pinned here."
+        )
     fields = set(_ENSEMBL_CSQ_FIELDS)
     if profile.flavour in {"refseq", "merged"}:
         fields.update(_REFSEQ_CSQ_FIELDS)
@@ -184,6 +191,7 @@ def _validate_equality_counts(
     calculated = {bucket: 0 for bucket in EQUALITY_BUCKETS}
     mismatch_counts = comparison.get("field_mismatch_counts", {})
     order_counts = comparison.get("field_order_mismatch_counts", {})
+    format_counts = comparison.get("field_format_mismatch_counts", {})
     for field, counts in per_field.items():
         if not isinstance(counts, dict) or set(counts) != set(EQUALITY_BUCKETS):
             raise GateError(f"{contig}/{field}: incomplete equality buckets")
@@ -206,10 +214,15 @@ def _validate_equality_counts(
         order_only = _require_nonnegative_int(
             order_counts.get(field, 0), f"{contig}/{field}/order-only"
         )
-        if mismatches + order_only != strict_unequal:
+        format_only = _require_nonnegative_int(
+            format_counts.get(field, 0), f"{contig}/{field}/format-only"
+        )
+        accounted = mismatches + order_only + format_only
+        if accounted != strict_unequal:
             raise GateError(
                 f"{contig}/{field}: equality buckets imply {strict_unequal} unequal "
-                f"values but mismatch + order-only counts are {mismatches + order_only}"
+                f"values but mismatch + order-only + format-only counts are "
+                f"{accounted}"
             )
 
     for bucket in EQUALITY_BUCKETS:
@@ -347,6 +360,9 @@ def validate_reports(
     totals = {key: 0 for key in ZERO_KEYS}
     totals["field_mismatch_total"] = 0
     totals["field_order_mismatch_total"] = 0
+    # Absorbed into the reported match rate, but a released build must be
+    # byte-identical to Ensembl VEP, so a non-zero total still fails the gate.
+    totals["field_format_mismatch_total"] = 0
     totals["mismatch_ledger_rows"] = 0
     common_target: dict[str, Any] | None = None
     common_reference: dict[str, Any] | None = None
@@ -410,6 +426,19 @@ def validate_reports(
         totals["field_order_mismatch_total"] += sum(
             _require_nonnegative_int(count, f"{expected_contig}/{field}/order-only")
             for field, count in field_order.items()
+        )
+        field_format = comparison.get("field_format_mismatch_counts")
+        if not isinstance(field_format, dict):
+            raise GateError(f"{expected_contig}: missing field_format_mismatch_counts")
+        unexpected_format_fields = set(field_format) - expected_fields
+        if unexpected_format_fields:
+            raise GateError(
+                f"{expected_contig}: format counts contain unexpected CSQ fields "
+                f"{sorted(unexpected_format_fields)}"
+            )
+        totals["field_format_mismatch_total"] += sum(
+            _require_nonnegative_int(count, f"{expected_contig}/{field}/format-only")
+            for field, count in field_format.items()
         )
         annotation = value.get("annotation")
         input_variants = _require_nonnegative_int(

--- a/tests/test_comparison_cli.py
+++ b/tests/test_comparison_cli.py
@@ -328,3 +328,38 @@ def test_failed_isolated_rerun_quarantines_and_excludes_old_evidence(
     quarantined_ledger = report_dir / (stale_ledger.name + ".stale")
     assert json.loads(quarantined_report.read_text()) == {"attempt": "failed"}
     assert quarantined_ledger.read_text() == '{"kind":"partial"}\n'
+
+
+def test_main_forwards_the_sole_contig_to_profile_resolution(monkeypatch):
+    """Per-contig plugin references need the contig at resolution time.
+
+    resolve() grew a `chrom` parameter, but main() did not forward it -- so the
+    per-contig lookup was unreachable from the CLI and every plugin run was
+    rejected, including the single-contig form the rejection recommends.
+    """
+    seen = {}
+
+    def fake_resolve(*args, **kwargs):
+        seen.update(kwargs)
+        raise profiles.ProfileUnavailable("stop here")
+
+    monkeypatch.setattr(profiles, "resolve", fake_resolve)
+
+    rc = cli.main(["--release", "116", "--profile", "merged_plugins", "--chroms", "22"])
+
+    assert rc == 2
+    assert seen["chrom"] == "chr22"
+
+
+def test_main_passes_no_contig_when_several_are_requested(monkeypatch):
+    seen = {}
+
+    def fake_resolve(*args, **kwargs):
+        seen.update(kwargs)
+        raise profiles.ProfileUnavailable("stop here")
+
+    monkeypatch.setattr(profiles, "resolve", fake_resolve)
+
+    cli.main(["--release", "116", "--profile", "merged_plugins", "--chroms", "1", "22"])
+
+    assert seen["chrom"] is None

--- a/tests/test_comparison_compare.py
+++ b/tests/test_comparison_compare.py
@@ -228,3 +228,99 @@ def test_mismatch_ledger_closes_when_comparison_raises(monkeypatch):
         )
 
     assert closed == [True]
+
+
+PLUGIN_HEADER = (
+    "##fileformat=VCFv4.2\n"
+    '##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence annotations. '
+    'Format: Allele|Feature|CADD_RAW|DS_AG|CLNSIG">\n'
+    "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\n"
+)
+
+
+@pytest.mark.parametrize(
+    "vepyr_value,vep_value",
+    [
+        ("0", "0.00"),
+        ("0.57985", "0.579850"),
+        ("1e-05", "0.00001"),
+        ("0.1&0.25", "0.10&0.250"),
+        ("", "."),
+    ],
+)
+def test_representation_only_differences_are_not_mismatches(
+    tmp_path, vepyr_value, vep_value
+):
+    """Decimal padding and VEP's '.' marker are the same datum, not a mismatch."""
+    a = _write(
+        tmp_path,
+        "vepyr.vcf",
+        PLUGIN_HEADER + f"chr1\t100\t.\tA\tT\t50\tPASS\tCSQ=T|ENST01|{vepyr_value}||\n",
+        False,
+    )
+    b = _write(
+        tmp_path,
+        "vep.vcf",
+        PLUGIN_HEADER + f"chr1\t100\t.\tA\tT\t50\tPASS\tCSQ=T|ENST01|{vep_value}||\n",
+        False,
+    )
+    result = compare.compare_vcfs(a, b, "format")
+
+    assert result["field_mismatch_counts"] == {}
+    assert result["field_format_mismatch_counts"] == {"CADD_RAW": 1}
+    assert result["field_match_rates"]["CADD_RAW"] == 100.0
+    # Absorbed into the match rate, but the equality buckets stay strict so the
+    # parity gate can still see the difference.
+    assert result["field_equality_counts"]["CADD_RAW"]["both_nonempty_equal"] == 0
+    assert result["mismatch_ledger"]["rows"] == 0
+
+
+@pytest.mark.parametrize(
+    "vepyr_value,vep_value",
+    [
+        ("0.5", "0.6"),
+        ("0", "0.000001"),
+        ("0.1&0.2", "0.1&0.2&0.3"),
+        ("PATHOGENIC", "BENIGN"),
+        ("0.1", "high"),
+    ],
+)
+def test_real_value_differences_are_still_mismatches(tmp_path, vepyr_value, vep_value):
+    """Equivalence is exact-after-parsing: no numeric tolerance is admitted."""
+    a = _write(
+        tmp_path,
+        "vepyr.vcf",
+        PLUGIN_HEADER + f"chr1\t100\t.\tA\tT\t50\tPASS\tCSQ=T|ENST01|{vepyr_value}||\n",
+        False,
+    )
+    b = _write(
+        tmp_path,
+        "vep.vcf",
+        PLUGIN_HEADER + f"chr1\t100\t.\tA\tT\t50\tPASS\tCSQ=T|ENST01|{vep_value}||\n",
+        False,
+    )
+    result = compare.compare_vcfs(a, b, "real")
+
+    assert result["field_mismatch_counts"] == {"CADD_RAW": 1}
+    assert result["field_format_mismatch_counts"] == {}
+    assert result["mismatch_ledger"]["rows"] == 1
+
+
+def test_ampersand_order_still_wins_over_format_equivalence(tmp_path):
+    """An order-only difference keeps its own counter rather than being reclassified."""
+    a = _write(
+        tmp_path,
+        "vepyr.vcf",
+        PLUGIN_HEADER + "chr1\t100\t.\tA\tT\t50\tPASS\tCSQ=T|ENST01|0.1&0.2||\n",
+        False,
+    )
+    b = _write(
+        tmp_path,
+        "vep.vcf",
+        PLUGIN_HEADER + "chr1\t100\t.\tA\tT\t50\tPASS\tCSQ=T|ENST01|0.2&0.1||\n",
+        False,
+    )
+    result = compare.compare_vcfs(a, b, "order")
+
+    assert result["field_order_mismatch_counts"] == {"CADD_RAW": 1}
+    assert result["field_format_mismatch_counts"] == {}

--- a/tests/test_comparison_compare.py
+++ b/tests/test_comparison_compare.py
@@ -283,10 +283,21 @@ def test_representation_only_differences_are_not_mismatches(
         ("0.1&0.2", "0.1&0.2&0.3"),
         ("PATHOGENIC", "BENIGN"),
         ("0.1", "high"),
+        # Everything below is absorbed by float() and must not be: two
+        # integers past 2**53 that share a double, a zero-padded identifier,
+        # stray whitespace, Python's '_' digit separator, and two distinct
+        # large exponents that both become inf.
+        ("12345678901234567", "12345678901234568"),
+        ("01", "1"),
+        (" 1", "1"),
+        ("1_0", "10"),
+        ("1e400", "1e999"),
+        # VEP's "." marks absence; a "." from vepyr is an output defect.
+        (".", ""),
     ],
 )
 def test_real_value_differences_are_still_mismatches(tmp_path, vepyr_value, vep_value):
-    """Equivalence is exact-after-parsing: no numeric tolerance is admitted."""
+    """Equivalence is exact Decimal over canonical numerics, nothing looser."""
     a = _write(
         tmp_path,
         "vepyr.vcf",
@@ -324,3 +335,33 @@ def test_ampersand_order_still_wins_over_format_equivalence(tmp_path):
 
     assert result["field_order_mismatch_counts"] == {"CADD_RAW": 1}
     assert result["field_format_mismatch_counts"] == {}
+
+
+def test_absorbed_differences_never_print_the_all_match_banner(tmp_path, capsys):
+    """'100%' is what an operator greps for; byte differences must not claim it."""
+    a = _write(
+        tmp_path,
+        "vepyr.vcf",
+        PLUGIN_HEADER + "chr1\t100\t.\tA\tT\t50\tPASS\tCSQ=T|ENST01|0||\n",
+        False,
+    )
+    b = _write(
+        tmp_path,
+        "vep.vcf",
+        PLUGIN_HEADER + "chr1\t100\t.\tA\tT\t50\tPASS\tCSQ=T|ENST01|0.00||\n",
+        False,
+    )
+    compare.compare_vcfs(a, b, "banner")
+
+    out = capsys.readouterr().out
+    assert "match at 100%!" not in out
+    assert "not byte parity" in out
+    assert "CADD_RAW" in out
+
+
+def test_the_all_match_banner_still_prints_on_real_parity(tmp_path, capsys):
+    a = _write(tmp_path, "vepyr.vcf", MATCHING, False)
+    b = _write(tmp_path, "vep.vcf", MATCHING, False)
+    compare.compare_vcfs(a, b, "parity")
+
+    assert "match at 100%!" in capsys.readouterr().out

--- a/tests/test_comparison_compare.py
+++ b/tests/test_comparison_compare.py
@@ -365,3 +365,27 @@ def test_the_all_match_banner_still_prints_on_real_parity(tmp_path, capsys):
     compare.compare_vcfs(a, b, "parity")
 
     assert "match at 100%!" in capsys.readouterr().out
+
+
+def test_values_equivalent_absorbs_order_and_format_together():
+    """A field can differ in token order AND numeric padding at once.
+
+    The caller's order check compares raw strings, so padding defeats it, and
+    the position-wise equivalence pass is defeated by the reordering. Neither
+    difference is a value difference, so the pair must still be equivalent.
+    """
+    assert compare._values_equivalent("0.10&0.20", "0.2&0.1")
+    assert compare._values_equivalent("1.0&2.00&3", "3.000&1&2")
+
+
+def test_multiset_equivalence_still_rejects_real_differences():
+    # A genuinely different value must not be absorbed by the multiset pairing.
+    assert not compare._values_equivalent("0.10&0.20", "0.2&0.3")
+    # Differing token counts stay a real difference.
+    assert not compare._values_equivalent("0.1&0.2", "0.2&0.1&0.1")
+    # Duplicates must pair one-to-one, not collapse.
+    assert not compare._values_equivalent("0.1&0.1", "0.1&0.2")
+    assert compare._values_equivalent("0.1&0.10", "0.100&0.1")
+    # Non-numeric tokens still compare by identity only.
+    assert not compare._values_equivalent("foo&bar", "foo&baz")
+    assert compare._values_equivalent("bar&foo", "foo&bar") is True

--- a/tests/test_comparison_profiles.py
+++ b/tests/test_comparison_profiles.py
@@ -274,3 +274,24 @@ def test_plugin_reference_resolves_from_the_generated_location(tmp_path, monkeyp
     # With no contig, availability still answers truthfully.
     assert profiles.vep_vcf_for("merged_plugins", "116") == str(written)
     assert profiles.vep_vcf_for("merged_plugins", "116", chrom=9) is None
+
+
+def test_plugin_profile_without_a_contig_is_allowed_when_no_reference_is_needed(
+    tmp_path, monkeypatch
+):
+    """Reference-free modes must not be blocked by a missing reference.
+
+    The per-contig rejection was unconditional, so `--skip-annotate` aggregation
+    of stored reports -- which reads no reference at all -- was refused for want
+    of something it never opens.
+    """
+    monkeypatch.setenv("DATA_VEPYR_DIR", str(tmp_path))
+
+    resolved = profiles.resolve(
+        "merged_plugins",
+        "116",
+        require_cache=False,
+        require_reference=False,
+    )
+
+    assert resolved.vep_vcf is None

--- a/tests/test_comparison_profiles.py
+++ b/tests/test_comparison_profiles.py
@@ -186,6 +186,15 @@ def test_default_input_returns_the_preferred_path_when_neither_exists(
     assert profiles.default_input("ref.fa") == str(tmp_path / "input" / "ref.fa")
 
 
+def _write_plugin_reference(tmp_path, chrom=22):
+    """Create the per-contig plugin reference generate_vep_plugin_references.sh writes."""
+    ref_dir = tmp_path / "output" / "116" / "plugins"
+    ref_dir.mkdir(parents=True, exist_ok=True)
+    name = profiles.PROFILES["merged_plugins"].vep_per_contig.format(chrom=chrom)
+    (ref_dir / f"{name}.vcf.gz").write_text("")
+    return ref_dir / f"{name}.vcf.gz"
+
+
 def test_plugin_profile_resolves_and_injects_the_plugin_cache_root(
     tmp_path, monkeypatch
 ):
@@ -193,12 +202,9 @@ def test_plugin_profile_resolves_and_injects_the_plugin_cache_root(
     (tmp_path / "cache" / "116_GRCh38_merged").mkdir(parents=True)
     plugin_cache = tmp_path / "cache" / "plugin_cache_116"
     plugin_cache.mkdir(parents=True)
-    ref_dir = tmp_path / "output" / "116"
-    ref_dir.mkdir(parents=True)
-    basename = profiles.PROFILES["merged_plugins"].vep_basename
-    (ref_dir / f"{basename}.vcf.gz").write_text("")
+    _write_plugin_reference(tmp_path)
 
-    resolved = profiles.resolve("merged_plugins", "116")
+    resolved = profiles.resolve("merged_plugins", "116", chrom=22)
 
     assert resolved.plugin_cache_root == str(plugin_cache)
     assert resolved.annotate_kwargs["plugin_cache_root"] == str(plugin_cache)
@@ -207,13 +213,10 @@ def test_plugin_profile_resolves_and_injects_the_plugin_cache_root(
 def test_plugin_profile_fails_when_the_plugin_cache_is_missing(tmp_path, monkeypatch):
     monkeypatch.setenv("DATA_VEPYR_DIR", str(tmp_path))
     (tmp_path / "cache" / "116_GRCh38_merged").mkdir(parents=True)
-    ref_dir = tmp_path / "output" / "116"
-    ref_dir.mkdir(parents=True)
-    basename = profiles.PROFILES["merged_plugins"].vep_basename
-    (ref_dir / f"{basename}.vcf.gz").write_text("")
+    _write_plugin_reference(tmp_path)
 
     with pytest.raises(profiles.ProfileUnavailable) as excinfo:
-        profiles.resolve("merged_plugins", "116")
+        profiles.resolve("merged_plugins", "116", chrom=22)
     assert "plugin_cache_116" in str(excinfo.value)
 
 
@@ -223,14 +226,12 @@ def test_plugin_base_profile_shares_the_reference_but_attaches_no_plugins(
     """The base variant isolates core-field differences against the same reference."""
     monkeypatch.setenv("DATA_VEPYR_DIR", str(tmp_path))
     (tmp_path / "cache" / "116_GRCh38_merged").mkdir(parents=True)
-    ref_dir = tmp_path / "output" / "116"
-    ref_dir.mkdir(parents=True)
+    _write_plugin_reference(tmp_path)
     basename = profiles.PROFILES["merged_plugins_base"].vep_basename
-    (ref_dir / f"{basename}.vcf.gz").write_text("")
 
     assert basename == profiles.PROFILES["merged_plugins"].vep_basename
 
-    resolved = profiles.resolve("merged_plugins_base", "116")
+    resolved = profiles.resolve("merged_plugins_base", "116", chrom=22)
     assert resolved.plugin_cache_root is None
     assert "plugin_cache_root" not in resolved.annotate_kwargs
 
@@ -247,3 +248,29 @@ def test_explicit_plugin_cache_override_skips_derivation(tmp_path, monkeypatch):
         "merged_plugins", "116", vep_vcf=str(ref), plugin_cache_root=str(custom)
     )
     assert resolved.annotate_kwargs["plugin_cache_root"] == str(custom)
+
+
+def test_plugin_profile_without_a_contig_explains_the_per_contig_layout():
+    """Plugin references are one file per contig, so there is nothing to slice.
+
+    Previously the profile declared a single WGS basename that the generator
+    never writes, so the documented command reported the profile "unavailable"
+    even with every generated reference present.
+    """
+    with pytest.raises(profiles.ProfileUnavailable) as excinfo:
+        profiles.resolve("merged_plugins", "116")
+
+    message = str(excinfo.value)
+    assert "per-contig" in message
+    assert "--chroms" in message and "--vep" in message
+
+
+def test_plugin_reference_resolves_from_the_generated_location(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_VEPYR_DIR", str(tmp_path))
+    written = _write_plugin_reference(tmp_path, chrom=7)
+
+    assert profiles.vep_vcf_for("merged_plugins", "116", chrom=7) == str(written)
+    assert profiles.vep_vcf_for("merged_plugins", "116", chrom="chr7") == str(written)
+    # With no contig, availability still answers truthfully.
+    assert profiles.vep_vcf_for("merged_plugins", "116") == str(written)
+    assert profiles.vep_vcf_for("merged_plugins", "116", chrom=9) is None

--- a/tests/test_comparison_profiles.py
+++ b/tests/test_comparison_profiles.py
@@ -184,3 +184,66 @@ def test_default_input_returns_the_preferred_path_when_neither_exists(
 ):
     monkeypatch.setenv("DATA_VEPYR_DIR", str(tmp_path))
     assert profiles.default_input("ref.fa") == str(tmp_path / "input" / "ref.fa")
+
+
+def test_plugin_profile_resolves_and_injects_the_plugin_cache_root(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("DATA_VEPYR_DIR", str(tmp_path))
+    (tmp_path / "cache" / "116_GRCh38_merged").mkdir(parents=True)
+    plugin_cache = tmp_path / "cache" / "plugin_cache_116"
+    plugin_cache.mkdir(parents=True)
+    ref_dir = tmp_path / "output" / "116"
+    ref_dir.mkdir(parents=True)
+    basename = profiles.PROFILES["merged_plugins"].vep_basename
+    (ref_dir / f"{basename}.vcf.gz").write_text("")
+
+    resolved = profiles.resolve("merged_plugins", "116")
+
+    assert resolved.plugin_cache_root == str(plugin_cache)
+    assert resolved.annotate_kwargs["plugin_cache_root"] == str(plugin_cache)
+
+
+def test_plugin_profile_fails_when_the_plugin_cache_is_missing(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_VEPYR_DIR", str(tmp_path))
+    (tmp_path / "cache" / "116_GRCh38_merged").mkdir(parents=True)
+    ref_dir = tmp_path / "output" / "116"
+    ref_dir.mkdir(parents=True)
+    basename = profiles.PROFILES["merged_plugins"].vep_basename
+    (ref_dir / f"{basename}.vcf.gz").write_text("")
+
+    with pytest.raises(profiles.ProfileUnavailable) as excinfo:
+        profiles.resolve("merged_plugins", "116")
+    assert "plugin_cache_116" in str(excinfo.value)
+
+
+def test_plugin_base_profile_shares_the_reference_but_attaches_no_plugins(
+    tmp_path, monkeypatch
+):
+    """The base variant isolates core-field differences against the same reference."""
+    monkeypatch.setenv("DATA_VEPYR_DIR", str(tmp_path))
+    (tmp_path / "cache" / "116_GRCh38_merged").mkdir(parents=True)
+    ref_dir = tmp_path / "output" / "116"
+    ref_dir.mkdir(parents=True)
+    basename = profiles.PROFILES["merged_plugins_base"].vep_basename
+    (ref_dir / f"{basename}.vcf.gz").write_text("")
+
+    assert basename == profiles.PROFILES["merged_plugins"].vep_basename
+
+    resolved = profiles.resolve("merged_plugins_base", "116")
+    assert resolved.plugin_cache_root is None
+    assert "plugin_cache_root" not in resolved.annotate_kwargs
+
+
+def test_explicit_plugin_cache_override_skips_derivation(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_VEPYR_DIR", str(tmp_path))
+    (tmp_path / "cache" / "116_GRCh38_merged").mkdir(parents=True)
+    custom = tmp_path / "elsewhere"
+    custom.mkdir()
+    ref = tmp_path / "custom.vcf.gz"
+    ref.write_text("")
+
+    resolved = profiles.resolve(
+        "merged_plugins", "116", vep_vcf=str(ref), plugin_cache_root=str(custom)
+    )
+    assert resolved.annotate_kwargs["plugin_cache_root"] == str(custom)

--- a/tests/test_comparison_report.py
+++ b/tests/test_comparison_report.py
@@ -299,3 +299,49 @@ def test_git_checkout_info_ignores_only_cargo_bookkeeping(monkeypatch, status, d
         "revision": "abc123",
         "dirty": dirty,
     }
+
+
+def test_generate_markdown_surfaces_format_only_differences():
+    """A run whose only differences are representation-only is not byte parity.
+
+    aggregate_mismatches() collected field_format_mismatch_counts, but the
+    headline derived every number from field_mismatch_counts alone -- so a
+    summary could claim all fields at 100% with zero mismatches for a run the
+    per-contig comparison had already reported as not byte-identical.
+    """
+    rep = make_chrom_report("chr1")
+    rep["comparison"]["field_format_mismatch_counts"] = {"CADD_RAW": 7}
+
+    agg = report.aggregate_mismatches([rep])
+    md = report.generate_markdown(
+        [rep],
+        agg,
+        report.classify_consequence_mismatches([]),
+        None,
+        {"branch": "main", "vepyr_rev": "abc1234", "bio_functions_rev": "def5678"},
+        release="115",
+        profile="merged",
+    )
+
+    assert "representation-only differences" in md
+    assert "**7 total**" in md
+    assert "not** byte-identical" in md
+    # The absorbed count must not be silently folded into the value-mismatch
+    # headline, which stays about byte-unequal values only.
+    assert "(0 value mismatches)" in md
+
+
+def test_generate_markdown_omits_the_format_line_when_there_are_none():
+    reports = [make_chrom_report("chr1")]
+    agg = report.aggregate_mismatches(reports)
+    md = report.generate_markdown(
+        reports,
+        agg,
+        report.classify_consequence_mismatches([]),
+        None,
+        {"branch": "main", "vepyr_rev": "abc1234", "bio_functions_rev": "def5678"},
+        release="115",
+        profile="merged",
+    )
+
+    assert "representation-only differences" not in md

--- a/tests/test_comparison_report.py
+++ b/tests/test_comparison_report.py
@@ -345,3 +345,46 @@ def test_generate_markdown_omits_the_format_line_when_there_are_none():
     )
 
     assert "representation-only differences" not in md
+
+
+def test_generate_markdown_surfaces_order_only_differences():
+    """Order-only differences break byte parity as surely as format-only ones.
+
+    The first pass at this threaded field_format into the headline but left
+    field_order behind, so a run whose only differences were &-list ordering
+    still summarised as every field at 100% with zero mismatches -- while the
+    parity gate rejected it.
+    """
+    rep = make_chrom_report("chr1")
+    rep["comparison"]["field_order_mismatch_counts"] = {"Consequence": 3}
+
+    agg = report.aggregate_mismatches([rep])
+    md = report.generate_markdown(
+        [rep],
+        agg,
+        report.classify_consequence_mismatches([]),
+        None,
+        {"branch": "main", "vepyr_rev": "abc1234", "bio_functions_rev": "def5678"},
+        release="115",
+        profile="merged",
+    )
+
+    assert "order-only differences" in md
+    assert "**3 total**" in md
+    assert "not** byte-identical" in md
+
+
+def test_generate_markdown_omits_the_order_line_when_there_are_none():
+    reports = [make_chrom_report("chr1")]
+    agg = report.aggregate_mismatches(reports)
+    md = report.generate_markdown(
+        reports,
+        agg,
+        report.classify_consequence_mismatches([]),
+        None,
+        {"branch": "main", "vepyr_rev": "abc1234", "bio_functions_rev": "def5678"},
+        release="115",
+        profile="merged",
+    )
+
+    assert "order-only differences" not in md

--- a/tests/test_verify_parity_gate.py
+++ b/tests/test_verify_parity_gate.py
@@ -367,5 +367,16 @@ def test_gate_refuses_plugin_profiles():
         gate.expected_csq_fields("merged_plugins")
 
 
-def test_gate_still_accepts_the_plugin_free_base_profile():
-    assert "Consequence" in gate.expected_csq_fields("merged_plugins_base")
+def test_gate_refuses_the_plugin_base_profile_too():
+    """Attaching no plugins is not the same as a plugin-free comparison.
+
+    This test previously asserted the opposite. "merged_plugins_base" attaches
+    nothing, so it slipped past the `profile.plugins` guard -- but it reads the
+    five-plugin reference, so its report always lists that reference's plugin
+    fields in fields_only_in_vep, which the gate rejects outright. Gating on it
+    could therefore never pass; it just failed later with "CSQ fields exist only
+    in VEP", which reads as a parity defect rather than as the wrong profile.
+    Refuse it upfront, for the same reason "merged_plugins" is refused.
+    """
+    with pytest.raises(gate.GateError, match="five-plugin reference"):
+        gate.expected_csq_fields("merged_plugins_base")

--- a/tests/test_verify_parity_gate.py
+++ b/tests/test_verify_parity_gate.py
@@ -106,6 +106,7 @@ def _write_report(report_dir: Path, contig: str = "chr1") -> dict:
             "field_match_rates": {field: 100.0 for field in fields},
             "field_mismatch_counts": {},
             "field_order_mismatch_counts": {},
+            "field_format_mismatch_counts": {},
             "field_equality_counts": equality,
             "equality_bucket_counts": {
                 "both_empty": 2 * len(fields),
@@ -327,3 +328,44 @@ def test_gate_rejects_cross_contig_identity_or_cache_drift(
 def test_exact_loader_rejects_missing_release_qualified_report(tmp_path):
     with pytest.raises(gate.GateError, match="missing release-qualified"):
         gate._load_exact_reports(tmp_path, ["chr1"], "merged", "116")
+
+
+def test_gate_rejects_format_only_differences(tmp_path):
+    """Absorbed into the reported match rate, still not release parity."""
+    value = _write_report(tmp_path)
+    comparison = value["comparison"]
+    comparison["field_format_mismatch_counts"]["Allele"] = 1
+    comparison["field_equality_counts"]["Allele"]["both_nonempty_equal"] = 7
+    comparison["field_equality_counts"]["Allele"]["both_nonempty_unequal"] = 1
+    comparison["equality_bucket_counts"]["both_nonempty_equal"] -= 1
+    comparison["equality_bucket_counts"]["both_nonempty_unequal"] += 1
+
+    with pytest.raises(gate.GateError, match="field_format_mismatch_total=1"):
+        _validate(value, tmp_path)
+
+
+def test_gate_rejects_a_report_without_format_only_counts(tmp_path):
+    """A report predating the counter cannot be silently read as zero."""
+    value = _write_report(tmp_path)
+    value["comparison"].pop("field_format_mismatch_counts")
+
+    with pytest.raises(gate.GateError, match="field_format_mismatch_counts"):
+        _validate(value, tmp_path)
+
+
+def test_gate_rejects_format_only_counts_for_unexpected_fields(tmp_path):
+    value = _write_report(tmp_path)
+    value["comparison"]["field_format_mismatch_counts"]["CADD_RAW"] = 1
+
+    with pytest.raises(gate.GateError, match="unexpected CSQ fields"):
+        _validate(value, tmp_path)
+
+
+def test_gate_refuses_plugin_profiles():
+    """Plugin profiles are comparison scenarios; the gate pins the core contract."""
+    with pytest.raises(gate.GateError, match="plugins"):
+        gate.expected_csq_fields("merged_plugins")
+
+
+def test_gate_still_accepts_the_plugin_free_base_profile():
+    assert "Consequence" in gate.expected_csq_fields("merged_plugins_base")


### PR DESCRIPTION
Rebase and port of #40 onto current `master`. #40 branched from `8e3b9b1`; `master` has since moved to `7fcaf7a`, and `aa4fd01` split the monolithic `run_annotation_fast.py` into the `e2e-testing/scripts/comparison/` package, so all five of its files conflicted. This is the port, not a replay.

## What happened to each change in #40

| #40 change | Here |
|---|---|
| Pair CSQ entries by `Feature` instead of zipping two independently sorted lists | **Dropped — already on master in a stronger form.** `_pair_entry_groups()` pairs on `(ALLELE_NUM, Allele, Feature)`, removes exact-duplicate payloads first, and reports unmatched tails as one-sided entries instead of letting a transcript-set divergence cascade. |
| `values_equivalent()` — float formatting + `.` vs `""` | **Ported, tightened.** See below. |
| `merged_116_base` / `merged_116_5plugins` profiles | **Ported** as `merged_plugins_base` / `merged_plugins`, with derived paths. |
| `[patch]` override pointing `datafusion-bio-function-vep` at `../datafusion-bio-functions` | **Not ported.** #40 flagged it as unmergeable itself; `master` already pins a released tag. |
| `run_annotation_fast_all.py` `PROFILE_SUFFIXES` entries | Obsolete — that module and dict no longer exist; suffixes live on the `Profile` dataclass. |

## Representation-only field equality

Byte equality remains the only thing counted as a plain match. A difference that is representation-only is now absorbed into the match rate and counted in its own `field_format_mismatch_counts`, exactly the way `&`-list order differences already were, with its own `FormatOnly` column in the per-field table. Two cases:

- **Decimal padding.** vepyr prints Rust's shortest round-trip form (`0`, `0.57985`); the plugin sources Ensembl VEP passes through print a fixed number of decimals (`0.00`, `0.579850`). Same number, different string.
- **Missing-value marker.** VEP emits the VCF `.` for a field it has no value for, where vepyr emits the empty string.

Without this a plugin comparison is unreadable — #40 measured CADD_RAW at ~90% and SpliceAI `DS_*` at ~50% purely on formatting.

**Deliberate change from #40:** equivalence is exact float equality after parsing, not the `rel_tol=1e-4 / abs_tol=1e-6` epsilon the original used. That `abs_tol` would have quietly called a real gnomAD AF of 6e-7 equal to zero. Every case #40 documented (`"0"`/`"0.00"`, `"0.57985"`/`"0.579850"`) is exactly equal once parsed, so no tolerance is needed to get them. If a genuine printf-rounding residual turns up, it should get an explicit documented rule rather than a blanket epsilon.

## The parity gate stays exactly as strict

`verify_parity_gate.py` demands byte-identity, and that is unchanged:

- `field_format_mismatch_counts` is validated against the profile's field set and summed into a new `field_format_mismatch_total`. Any non-zero total still fails the gate — a released build must be byte-identical to Ensembl VEP.
- The equality-bucket invariant becomes `mismatches + order_only + format_only == strict_unequal`, so the new absorption path cannot hide a difference from the strict buckets.
- The counter is **required**, not defaulted to `{}`, so a report predating it cannot be read as zero.
- `expected_csq_fields()` now refuses a plugin profile outright with a clear message, rather than gating a field set it does not describe.

## Plugin profiles

- `merged_plugins` attaches the plugin cache — derived as `$DATA/cache/plugin_cache_{release}`, overridable with the new `--plugin-cache` — so ClinVar/SpliceAI/CADD/AlphaMissense/dbNSFP CSQ fields are comparable.
- `merged_plugins_base` reads the same five-plugin reference with nothing attached; the comparison then restricts to shared fields, isolating whether a core-field difference comes from the plugin machinery or predates it.

Both derive their paths like every other profile instead of hardcoding one machine's home directory, and a missing plugin cache fails in milliseconds with the availability matrix, same as a missing Parquet cache.

## Test plan

- [x] `pytest tests/` — 1130 passed, 2 skipped.
- [x] `ruff check` / `ruff format` clean; pre-commit hooks pass.
- [x] New unit coverage: representation-only equivalence (padding, exponent form, `&`-lists, `.`/`""`), the negatives it must **not** absorb (`0` vs `0.000001`, differing token counts, non-numeric), order-only precedence, plugin-profile resolution and its missing-cache failure, and four gate behaviours including that a format-only difference still fails.
- [x] **Re-measured, full chr1–22.** The open question above is now closed with this comparator, not #40's. Results in the section below.

## Added since first review

### `chore(deps)`: pin bio-functions v0.19.0

`datafusion-bio-function-vep` moves off the #217 development head `1345fd5` to `01fa21f`, the commit named by the released **v0.19.0** tag. Both bio-formats dependencies stay on `80f3a6c` — the revision v0.19.0 itself pins; a mismatch would compile the formats crates twice and break type identity across the FFI boundary.

### `fix(e2e)`: only require plugin sources when a chromosome must be built

`run_all_plugin_comparisons.sh` probed the source server and required `bgzip`/`tabix` unconditionally, before the loop and under `set -e`. Those exist solely to slice sources for `build_transient_caches()`. With a complete plugin cache every iteration takes the `CACHE_REUSE` path and never opens a source — so the probe failed runs that needed nothing it was checking for. That is now the normal case, the full chr1–22 five-plugin cache having been built.

The slicing tools and the ClinVar `HEAD` probe are now gated on a `needs_sources` pass over `cache_complete()`, and the 1–22 validation is hoisted above it so a typo reports itself as an invalid chromosome rather than as a missing shard or a source-server error.

## Full-autosome parity results

Run from this branch against the Ensembl VEP 116 five-plugin references, engine `01fa21f`, reusing the complete plugin cache (no rebuilds):

| | |
|---|---|
| chromosomes | 22 (chr1–chr22) |
| VCF records | 4,096,123 |
| CSQ entries | 69,299,753 |
| strict body MD5 | **22/22 `ok`**, 22/22 exit 0 |
| fields at 100% | **124/124 on every chromosome** |

Zero on all 22, in every category: variants present on only one side, CSQ count / set / order mismatches, value mismatches, format-only mismatches, field-order mismatches, and mismatch-ledger rows.

Headers differ as expected (run provenance, absolute source paths, Ensembl's custom INFO declarations); record bodies are byte-identical.

**Scope:** autosomes only. chrX, chrY and chrMT are not covered by these caches or references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

