### PR TITLE
feat(annotate): plugin subset selection via plugins

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -59,13 +59,20 @@ vepyr.annotate(
 )
 ```
 
-!!! warning "Plugins apply to VCF output only"
-    `plugin_cache_root` is read on the `output_vcf` path. The streaming
-    annotator behind a returned `LazyFrame` ignores it, so a `LazyFrame` result
-    carries no plugin fields — not as columns, and not inside `CSQ` even with
-    `skip_csq=False`. Passing [`plugins`](#choosing-which-plugins-run) without
-    `output_vcf` warns for this reason; `plugin_cache_root` on its own is
-    silently ignored.
+!!! warning "In a LazyFrame, plugin values hide inside `CSQ`"
+    Plugin fields are appended to the `CSQ` field, after the base fields, in
+    `(csq_rank, plugin_name)` order. Writing a VCF gives you a header naming
+    them. A `LazyFrame` has no header, and its default `skip_csq=True` drops
+    the `CSQ` column outright — so plugins are applied and then silently
+    discarded.
+
+    Pass `skip_csq=False` to keep them. The values are correct and identical
+    to the VCF path, but unnamed: you have to know that, say, a CADD-only
+    subset appends `CADD_PHRED` then `CADD_RAW` at positions 80 and 81 of an
+    81-field `CSQ`. Plugin values are not broken out as DataFrame columns.
+
+    Passing [`plugins`](#choosing-which-plugins-run) without `output_vcf` and
+    with `skip_csq` left at its default warns for this reason.
 
 ### Choosing which plugins run
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -59,6 +59,71 @@ vepyr.annotate(
 )
 ```
 
+!!! warning "Plugins apply to VCF output only"
+    `plugin_cache_root` is read on the `output_vcf` path. The streaming
+    annotator behind a returned `LazyFrame` ignores it, so a `LazyFrame` result
+    carries no plugin fields — not as columns, and not inside `CSQ` even with
+    `skip_csq=False`. Passing [`plugins`](#choosing-which-plugins-run) without
+    `output_vcf` warns for this reason; `plugin_cache_root` on its own is
+    silently ignored.
+
+### Choosing which plugins run
+
+Selection is **directory-shaped**: every plugin under
+`<plugin_cache_root>/plugin/` is applied. There is no per-call version
+argument — a plugin's version is fixed when
+[`build_plugin_cache`](api.md#vepyr.build_plugin_cache) writes it.
+
+`plugins` narrows that set to a subset of the directories present:
+
+```python
+vepyr.annotate(
+    "sample.vcf",
+    "/data/116_GRCh38_merged",
+    plugin_cache_root="/data/plugin_cache",
+    plugins=["clinvar", "cadd"],   # only these two
+    output_vcf="sample.annotated.vcf",
+)
+```
+
+| `plugins=` | Effect |
+|---|---|
+| omitted / `None` | every plugin under the root — the default |
+| `["clinvar", "cadd"]` | only those two |
+| `[]` | none; equivalent to a plugin-free run |
+| `["nope"]` | `ValueError`, listing the plugins that *are* available |
+
+Order is irrelevant — the engine sorts discovered plugins by
+`(csq_rank, plugin_name)`, so the CSQ layout does not depend on how you list
+them. `plugins` requires `plugin_cache_root`.
+
+The three alternatives to `plugins` all still work, and are what you want when
+a selection is permanent rather than per-call: pass `plugin_cache_root=None`
+for no plugins, build separate roots for separate combinations, or add and
+remove plugin directories under an existing root.
+
+??? note "How the subset is materialised"
+
+    The engine has no plugin filter. Both the CSQ header and the per-transcript
+    body discover `<root>/plugin/` independently, so filtering one and not the
+    other would leave the header advertising fields the body never fills,
+    shifting every later value.
+
+    `plugins` therefore hands the engine a root that already contains only the
+    selected plugins — a temporary directory whose files are hard-linked to the
+    originals. The two discovery passes then cannot disagree, and nothing is
+    copied.
+
+    Files are linked individually rather than the plugin directory being
+    symlinked, because a directory symlink needs `target_is_directory=True` on
+    Windows plus a privilege non-elevated sessions lack. Where hard links are
+    unavailable — a temporary directory on a different volume — it falls back
+    to per-file symlinks, then to an error naming `TMPDIR`.
+
+    The subset lives as long as it is needed: released when the annotation
+    finishes for `output_vcf`, and tied to the `LazyFrame` otherwise, since a
+    frame re-opens the cache on every `collect()`.
+
 ## Manifest structure
 
 A plugin's `plugins/<name>/<name>.source.toml` declares how to ingest the raw

--- a/src/vepyr/__init__.py
+++ b/src/vepyr/__init__.py
@@ -769,10 +769,34 @@ def _plugin_subset_root(
     subset_root = os.path.join(tmp.name, "plugin")
     os.makedirs(subset_root)
     for name in selected:
-        os.symlink(
-            os.path.abspath(os.path.join(source_root, name)),
-            os.path.join(subset_root, name),
-        )
+        src_dir = os.path.abspath(os.path.join(source_root, name))
+        dst_dir = os.path.join(subset_root, name)
+        os.makedirs(dst_dir)
+        # Link the files rather than the directory. A directory symlink would
+        # need `target_is_directory=True` on Windows and, more awkwardly, the
+        # SeCreateSymbolicLinkPrivilege that non-elevated Windows sessions lack
+        # unless Developer Mode is on. Hard links to files need no privilege on
+        # NTFS, and a plugin directory is ~25 files, so this costs nothing.
+        for entry in os.listdir(src_dir):
+            src = os.path.join(src_dir, entry)
+            if not os.path.isfile(src):
+                continue
+            dst = os.path.join(dst_dir, entry)
+            try:
+                os.link(src, dst)
+            except OSError:
+                # Different volume (temp dir and cache on separate drives), or
+                # a filesystem without hard links. Symlinking a *file* still
+                # avoids the directory-symlink pitfalls above.
+                try:
+                    os.symlink(src, dst)
+                except OSError as exc:
+                    raise OSError(
+                        f"Cannot link plugin file {src!r} into a subset cache "
+                        f"root: {exc}. On Windows, either enable Developer "
+                        f"Mode or set TMPDIR to the same volume as "
+                        f"plugin_cache_root."
+                    ) from exc
 
     log.info(
         "Plugin subset: %s (of %d available)",

--- a/src/vepyr/__init__.py
+++ b/src/vepyr/__init__.py
@@ -7,6 +7,8 @@ from collections.abc import Callable, Iterator
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    import tempfile
+
     import polars as pl
 
 from vepyr._core import annotate_vcf as _annotate_vcf
@@ -711,6 +713,75 @@ def build_plugin_cache(
         )
 
 
+def _plugin_subset_root(
+    plugin_cache_root: str,
+    plugins: list[str],
+) -> tempfile.TemporaryDirectory[str]:
+    """Materialise a plugin cache root holding only ``plugins``.
+
+    Plugin selection in the engine is directory-shaped: every plugin under
+    ``<root>/plugin/`` is applied, and the CSQ header and the per-transcript
+    body discover that directory through two independent passes. Filtering one
+    pass and not the other would leave the header advertising fields the body
+    never fills, shifting every later field's value. Handing the engine a root
+    that already contains only the wanted plugins keeps the two passes in
+    agreement by construction.
+
+    The tree is symlinks, so it costs no disk and no copy.
+
+    Returns the ``TemporaryDirectory`` rather than its path: the caller owns
+    the lifetime, and the tree must outlive every annotation run that reads it.
+    """
+    import os
+    import tempfile
+
+    if isinstance(plugins, str) or not isinstance(plugins, (list, tuple)):
+        raise TypeError("plugins must be a list of plugin names, or None")
+
+    source_root = os.path.join(plugin_cache_root, "plugin")
+    if not os.path.isdir(source_root):
+        raise FileNotFoundError(
+            f"No plugin directory under plugin_cache_root: {source_root}"
+        )
+
+    available = sorted(
+        name
+        for name in os.listdir(source_root)
+        if os.path.isfile(os.path.join(source_root, name, "manifest.json"))
+    )
+
+    # Order is irrelevant to the engine — it sorts discovered manifests by
+    # (csq_rank, plugin_name) — but de-duplicate so a repeated name cannot
+    # collide when the symlink is created.
+    selected: list[str] = []
+    for name in plugins:
+        if not isinstance(name, str):
+            raise TypeError(f"plugin names must be strings, got {type(name).__name__}")
+        if name not in available:
+            raise ValueError(
+                f"Unknown plugin {name!r} in {source_root}. "
+                f"Available: {', '.join(available) or '(none)'}"
+            )
+        if name not in selected:
+            selected.append(name)
+
+    tmp = tempfile.TemporaryDirectory(prefix="vepyr-plugin-subset-")
+    subset_root = os.path.join(tmp.name, "plugin")
+    os.makedirs(subset_root)
+    for name in selected:
+        os.symlink(
+            os.path.abspath(os.path.join(source_root, name)),
+            os.path.join(subset_root, name),
+        )
+
+    log.info(
+        "Plugin subset: %s (of %d available)",
+        ", ".join(selected) or "(none)",
+        len(available),
+    )
+    return tmp
+
+
 def annotate(
     vcf: str,
     cache_dir: str,
@@ -758,6 +829,7 @@ def annotate(
     skip_csq: bool = True,
     # Custom plugin caches
     plugin_cache_root: str | None = None,
+    plugins: list[str] | None = None,
     # Output mode
     output_vcf: str | None = None,
     preserve_record_layout: bool = True,
@@ -875,11 +947,19 @@ def annotate(
     plugin_cache_root : str or None
         Root of a plugin cache tree built by :func:`build_plugin_cache`, e.g.
         ``"/data/plugin_cache"`` holding ``plugin/<name>/`` directories. Every
-        plugin found under the root is applied and its CSQ fields are added to
-        the header and to each transcript. There is no per-call plugin
-        selection: which plugins run, and at which version, is decided by what
-        was built into this directory. ``None`` (default) applies no plugins
-        and is byte-identical to a plugin-free run.
+        plugin found under the root is applied — see ``plugins`` to narrow
+        that — and its CSQ fields are added to the header and to each
+        transcript. A plugin's version is fixed when its cache is built, not
+        chosen here. ``None`` (default) applies no plugins and is
+        byte-identical to a plugin-free run.
+    plugins : list of str or None
+        Restrict annotation to these plugin names, a subset of the directories
+        under ``<plugin_cache_root>/plugin/``. ``None`` (default) applies every
+        plugin found there. An empty list applies none. Requires
+        ``plugin_cache_root``; an unknown name is an error rather than a silent
+        skip. Selection works by handing the engine a root containing only the
+        named plugins, hard-linked to the originals, so it costs no disk and no
+        copy.
     output_vcf : str or None
         Path to write annotated VCF output. When set, annotation results are
         written directly to a VCF file and the output path is returned.
@@ -1047,7 +1127,25 @@ def annotate(
         # Single annotation-concurrency knob: N within-contig fused pipelines.
         # Requires a tabix-indexed (bgzip+.tbi) input VCF.
         opts["workers"] = workers
-    if plugin_cache_root is not None:
+    # Held for the lifetime of the annotation: for `output_vcf` that is this
+    # call, but a LazyFrame re-creates its annotator on every collect(), so the
+    # symlink tree has to survive as long as the frame does (see below).
+    _plugin_subset = None
+    if plugins is not None:
+        if plugin_cache_root is None:
+            raise ValueError("plugins requires plugin_cache_root")
+        if output_vcf is None:
+            # Only `annotate_to_vcf_file` reads plugin_cache_root; the streaming
+            # annotator behind the LazyFrame ignores it, so plugin fields would
+            # be silently absent. Warn rather than no-op quietly.
+            warnings.warn(
+                "plugins are only applied when writing VCF output; the "
+                "returned LazyFrame will not contain plugin fields",
+                stacklevel=2,
+            )
+        _plugin_subset = _plugin_subset_root(plugin_cache_root, plugins)
+        opts["plugin_cache_root"] = _plugin_subset.name
+    elif plugin_cache_root is not None:
         opts["plugin_cache_root"] = plugin_cache_root
     if not preserve_record_layout:
         opts["preserve_record_layout"] = False
@@ -1142,6 +1240,9 @@ def annotate(
                 _pbar.close()
 
         log.info("Wrote %d rows to %s", rows, output_vcf)
+        # The write is complete, so nothing will read the symlink tree again.
+        if _plugin_subset is not None:
+            _plugin_subset.cleanup()
         return output_vcf
 
     import polars as pl
@@ -1192,6 +1293,12 @@ def annotate(
                 yield batch_df
             if remaining is not None and remaining <= 0:
                 break
+
+    # `_opts` points at the plugin symlink tree and every collect() re-opens
+    # it, so the tree must outlive this call. Parking the TemporaryDirectory on
+    # the closure — which register_io_source hands to the LazyFrame — ties its
+    # removal to the frame becoming unreachable rather than to this return.
+    _batch_source._plugin_subset = _plugin_subset
 
     from polars.io.plugins import register_io_source
 

--- a/src/vepyr/__init__.py
+++ b/src/vepyr/__init__.py
@@ -976,6 +976,10 @@ def annotate(
         transcript. A plugin's version is fixed when its cache is built, not
         chosen here. ``None`` (default) applies no plugins and is
         byte-identical to a plugin-free run.
+
+        Plugin values are appended to the ``CSQ`` field. With ``output_vcf``
+        the header names them; in a ``LazyFrame`` they are only inside the
+        ``CSQ`` string, which the default ``skip_csq=True`` drops.
     plugins : list of str or None
         Restrict annotation to these plugin names, a subset of the directories
         under ``<plugin_cache_root>/plugin/``. ``None`` (default) applies every
@@ -1158,13 +1162,15 @@ def annotate(
     if plugins is not None:
         if plugin_cache_root is None:
             raise ValueError("plugins requires plugin_cache_root")
-        if output_vcf is None:
-            # Only `annotate_to_vcf_file` reads plugin_cache_root; the streaming
-            # annotator behind the LazyFrame ignores it, so plugin fields would
-            # be silently absent. Warn rather than no-op quietly.
+        if output_vcf is None and skip_csq:
+            # Plugin values reach a LazyFrame only inside the CSQ string, which
+            # `skip_csq=True` (the default) drops — so the plugins would be
+            # built and then silently discarded. The VCF path is unaffected: it
+            # writes a header naming the fields.
             warnings.warn(
-                "plugins are only applied when writing VCF output; the "
-                "returned LazyFrame will not contain plugin fields",
+                "plugin fields are emitted inside CSQ, which skip_csq=True "
+                "discards; pass skip_csq=False to keep them, or output_vcf= "
+                "for a header that names them",
                 stacklevel=2,
             )
         _plugin_subset = _plugin_subset_root(plugin_cache_root, plugins)

--- a/src/vepyr/__init__.py
+++ b/src/vepyr/__init__.py
@@ -779,6 +779,15 @@ def _plugin_subset_root(
         # NTFS, and a plugin directory is ~25 files, so this costs nothing.
         for entry in os.listdir(src_dir):
             src = os.path.join(src_dir, entry)
+            if os.path.isdir(src):
+                # A plugin cache is flat today: chr*.parquet plus manifest.json.
+                # Skipping a directory would drop shards from the subset and the
+                # engine would only report the missing files, not the reason.
+                raise NotImplementedError(
+                    f"plugin {name!r} has a nested directory {entry!r}; the "
+                    f"subset root only mirrors flat plugin caches. Drop "
+                    f"`plugins` and pass the whole plugin_cache_root instead."
+                )
             if not os.path.isfile(src):
                 continue
             dst = os.path.join(dst_dir, entry)
@@ -1162,19 +1171,25 @@ def annotate(
     if plugins is not None:
         if plugin_cache_root is None:
             raise ValueError("plugins requires plugin_cache_root")
-        if output_vcf is None and skip_csq:
-            # Plugin values reach a LazyFrame only inside the CSQ string, which
-            # `skip_csq=True` (the default) drops — so the plugins would be
-            # built and then silently discarded. The VCF path is unaffected: it
-            # writes a header naming the fields.
-            warnings.warn(
-                "plugin fields are emitted inside CSQ, which skip_csq=True "
-                "discards; pass skip_csq=False to keep them, or output_vcf= "
-                "for a header that names them",
-                stacklevel=2,
-            )
-        _plugin_subset = _plugin_subset_root(plugin_cache_root, plugins)
-        opts["plugin_cache_root"] = _plugin_subset.name
+        if isinstance(plugins, str) or not isinstance(plugins, (list, tuple)):
+            raise TypeError("plugins must be a list of plugin names, or None")
+        if plugins:
+            if output_vcf is None and skip_csq:
+                # Plugin values reach a LazyFrame only inside the CSQ string,
+                # which `skip_csq=True` (the default) drops — so the plugins
+                # would be built and then silently discarded. The VCF path is
+                # unaffected: it writes a header naming the fields.
+                warnings.warn(
+                    "plugin fields are emitted inside CSQ, which skip_csq=True "
+                    "discards; pass skip_csq=False to keep them, or output_vcf= "
+                    "for a header that names them",
+                    stacklevel=2,
+                )
+            _plugin_subset = _plugin_subset_root(plugin_cache_root, plugins)
+            opts["plugin_cache_root"] = _plugin_subset.name
+        # An empty selection is exactly a plugin-free run: leave
+        # plugin_cache_root out of the options entirely rather than handing the
+        # engine an empty tree, and do not warn about fields that cannot exist.
     elif plugin_cache_root is not None:
         opts["plugin_cache_root"] = plugin_cache_root
     if not preserve_record_layout:
@@ -1240,6 +1255,17 @@ def annotate(
                     )
                 except Exception as exc:
                     _error[0] = exc
+                finally:
+                    # The worker owns the subset tree. Cleaning up in the
+                    # caller instead would race this thread: it is a daemon and
+                    # keeps annotating after an interrupt or a raising progress
+                    # drain unwinds annotate(), and it holds only the path (via
+                    # options_json), not the TemporaryDirectory — so a caller
+                    # -side release could remove plugin shards still to be read
+                    # for later contigs. Joining before cleanup would fix that
+                    # too, but would make Ctrl-C block for the rest of the run.
+                    if _plugin_subset is not None:
+                        _plugin_subset.cleanup()
 
             def _drain_progress_updates() -> None:
                 if _pbar is None or _pending_updates is None:
@@ -1270,23 +1296,29 @@ def annotate(
                 _pbar.close()
 
         log.info("Wrote %d rows to %s", rows, output_vcf)
-        # The write is complete, so nothing will read the symlink tree again.
-        if _plugin_subset is not None:
-            _plugin_subset.cleanup()
         return output_vcf
 
     import polars as pl
     import pyarrow as pa
 
-    # Get schema from a probe annotator (doesn't consume data)
-    probe = _create_annotator(
-        vcf,
-        cache_dir,
-        options_json,
-        skip_csq,
-        None,
-    )
-    pa_schema = probe.schema
+    # Get schema from a probe annotator (doesn't consume data). Nothing owns
+    # the subset tree until it is parked on the closure below, so a failure
+    # here has to release it rather than leave it to the collector — an
+    # exception's traceback keeps this frame, and the tree, alive for as long
+    # as the caller holds the exception.
+    try:
+        probe = _create_annotator(
+            vcf,
+            cache_dir,
+            options_json,
+            skip_csq,
+            None,
+        )
+        pa_schema = probe.schema
+    except BaseException:
+        if _plugin_subset is not None:
+            _plugin_subset.cleanup()
+        raise
     empty = pa.table({field.name: pa.array([], type=field.type) for field in pa_schema})
     polars_schema = dict(pl.from_arrow(empty).schema)
     del probe

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -7,6 +7,7 @@ import json
 import os
 import sys
 import threading
+import warnings
 import tempfile
 import types
 from pathlib import Path
@@ -650,6 +651,10 @@ class TestAnnotate:
             os.unlink(out_path)
 
 
+class _Stop(Exception):
+    """Abort annotate() once the options have been captured."""
+
+
 # --- plugin subset selection ---------------------------------------------
 
 
@@ -778,3 +783,92 @@ def test_annotate_plugins_is_accepted_in_signature():
     params = inspect.signature(vepyr.annotate).parameters
     assert "plugins" in params
     assert params["plugins"].default is None
+
+
+def test_plugin_subset_root_rejects_a_nested_plugin_layout(tmp_path):
+    import vepyr
+
+    root = _fake_plugin_root(tmp_path, ["cadd"])
+    (Path(root) / "plugin" / "cadd" / "shards").mkdir()
+
+    # Silently skipping the directory would drop shards from the subset and the
+    # engine would only report missing files, never the reason.
+    with pytest.raises(NotImplementedError, match="nested directory"):
+        vepyr._plugin_subset_root(root, ["cadd"])
+
+
+def test_annotate_empty_plugins_selects_no_plugin_root(tmp_path, monkeypatch):
+    """plugins=[] must be a plugin-free run, not an empty subset tree."""
+    import vepyr
+
+    root = _fake_plugin_root(tmp_path, ["cadd"])
+    seen = {}
+
+    def fake(vcf, cache_dir, options_json, skip_csq, limit):
+        seen["opts"] = json.loads(options_json)
+        raise _Stop()
+
+    monkeypatch.setattr(vepyr, "_create_annotator", fake)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with pytest.raises(_Stop):
+            vepyr.annotate("in.vcf", CACHE_DIR, plugin_cache_root=root, plugins=[])
+
+    assert "plugin_cache_root" not in seen["opts"]
+    assert [w for w in caught if "skip_csq" in str(w.message)] == []
+
+
+def test_annotate_nonempty_plugins_warns_only_when_csq_is_dropped(
+    tmp_path, monkeypatch
+):
+    import vepyr
+
+    root = _fake_plugin_root(tmp_path, ["cadd"])
+
+    def fake(vcf, cache_dir, options_json, skip_csq, limit):
+        raise _Stop()
+
+    monkeypatch.setattr(vepyr, "_create_annotator", fake)
+    for skip_csq, expected in ((True, 1), (False, 0)):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with pytest.raises(_Stop):
+                vepyr.annotate(
+                    "in.vcf",
+                    CACHE_DIR,
+                    plugin_cache_root=root,
+                    plugins=["cadd"],
+                    skip_csq=skip_csq,
+                )
+        hits = [w for w in caught if "skip_csq" in str(w.message)]
+        assert len(hits) == expected, f"skip_csq={skip_csq}"
+
+
+def test_annotate_releases_the_subset_when_the_probe_fails(tmp_path, monkeypatch):
+    """A failure before the closure owns the tree must not leak it."""
+    import vepyr
+
+    root = _fake_plugin_root(tmp_path, ["cadd"])
+    created = []
+    real = vepyr._plugin_subset_root
+
+    def spy(cache_root, names):
+        sub = real(cache_root, names)
+        created.append(sub.name)
+        return sub
+
+    monkeypatch.setattr(vepyr, "_plugin_subset_root", spy)
+    monkeypatch.setattr(
+        vepyr, "_create_annotator", lambda *a, **k: (_ for _ in ()).throw(_Stop())
+    )
+    with pytest.raises(_Stop):
+        vepyr.annotate(
+            "in.vcf",
+            CACHE_DIR,
+            plugin_cache_root=root,
+            plugins=["cadd"],
+            skip_csq=False,
+        )
+
+    assert created, "the subset root was never built"
+    assert not os.path.exists(created[0]), "subset tree outlived the failed call"

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -648,3 +648,97 @@ class TestAnnotate:
             assert bars[0].closed is True
         finally:
             os.unlink(out_path)
+
+
+# --- plugin subset selection ---------------------------------------------
+
+
+def _fake_plugin_root(tmp_path: Path, names: list[str]) -> str:
+    """A plugin cache root with `names` as manifest-bearing directories."""
+    root = tmp_path / "plugin_cache"
+    for name in names:
+        d = root / "plugin" / name
+        d.mkdir(parents=True)
+        (d / "manifest.json").write_text("{}")
+    # A directory without a manifest is not a plugin and must be ignored.
+    (root / "plugin" / "not_a_plugin").mkdir(parents=True)
+    return str(root)
+
+
+def test_plugin_subset_root_symlinks_only_selected(tmp_path):
+    import vepyr
+
+    root = _fake_plugin_root(tmp_path, ["cadd", "clinvar", "spliceai"])
+
+    with vepyr._plugin_subset_root(root, ["clinvar", "cadd"]) as subset:
+        plugin_dir = Path(subset) / "plugin"
+        assert sorted(p.name for p in plugin_dir.iterdir()) == ["cadd", "clinvar"]
+        for name in ("cadd", "clinvar"):
+            assert (plugin_dir / name).is_symlink()
+            assert (plugin_dir / name / "manifest.json").is_file()
+
+
+def test_plugin_subset_root_empty_list_selects_nothing(tmp_path):
+    import vepyr
+
+    root = _fake_plugin_root(tmp_path, ["cadd"])
+    with vepyr._plugin_subset_root(root, []) as subset:
+        assert list((Path(subset) / "plugin").iterdir()) == []
+
+
+def test_plugin_subset_root_deduplicates(tmp_path):
+    import vepyr
+
+    root = _fake_plugin_root(tmp_path, ["cadd"])
+    with vepyr._plugin_subset_root(root, ["cadd", "cadd"]) as subset:
+        assert [p.name for p in (Path(subset) / "plugin").iterdir()] == ["cadd"]
+
+
+def test_plugin_subset_root_rejects_unknown_name(tmp_path):
+    import vepyr
+
+    root = _fake_plugin_root(tmp_path, ["cadd", "clinvar"])
+    with pytest.raises(ValueError, match="Unknown plugin 'nope'") as exc:
+        vepyr._plugin_subset_root(root, ["nope"])
+    # The message must list the real plugins, not stray directories.
+    assert "cadd, clinvar" in str(exc.value)
+    assert "not_a_plugin" not in str(exc.value)
+
+
+def test_plugin_subset_root_rejects_bare_string(tmp_path):
+    import vepyr
+
+    root = _fake_plugin_root(tmp_path, ["cadd"])
+    with pytest.raises(TypeError, match="must be a list"):
+        vepyr._plugin_subset_root(root, "cadd")
+
+
+def test_plugin_subset_root_rejects_non_string_element(tmp_path):
+    import vepyr
+
+    root = _fake_plugin_root(tmp_path, ["cadd"])
+    with pytest.raises(TypeError, match="must be strings"):
+        vepyr._plugin_subset_root(root, [1])
+
+
+def test_plugin_subset_root_missing_plugin_dir(tmp_path):
+    import vepyr
+
+    (tmp_path / "empty").mkdir()
+    with pytest.raises(FileNotFoundError, match="No plugin directory"):
+        vepyr._plugin_subset_root(str(tmp_path / "empty"), ["cadd"])
+
+
+def test_annotate_plugins_requires_plugin_cache_root():
+    import vepyr
+
+    with pytest.raises(ValueError, match="plugins requires plugin_cache_root"):
+        vepyr.annotate("input.vcf", CACHE_DIR, plugins=["cadd"])
+
+
+def test_annotate_plugins_is_accepted_in_signature():
+    import vepyr
+
+    params = inspect.signature(vepyr.annotate).parameters
+    assert "plugins" in params
+    assert params["plugins"].default is None

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -665,7 +665,7 @@ def _fake_plugin_root(tmp_path: Path, names: list[str]) -> str:
     return str(root)
 
 
-def test_plugin_subset_root_symlinks_only_selected(tmp_path):
+def test_plugin_subset_root_links_only_selected(tmp_path):
     import vepyr
 
     root = _fake_plugin_root(tmp_path, ["cadd", "clinvar", "spliceai"])
@@ -674,8 +674,44 @@ def test_plugin_subset_root_symlinks_only_selected(tmp_path):
         plugin_dir = Path(subset) / "plugin"
         assert sorted(p.name for p in plugin_dir.iterdir()) == ["cadd", "clinvar"]
         for name in ("cadd", "clinvar"):
-            assert (plugin_dir / name).is_symlink()
-            assert (plugin_dir / name / "manifest.json").is_file()
+            manifest = plugin_dir / name / "manifest.json"
+            assert manifest.is_file()
+            # Files are hard-linked, not copied and not symlinked: a directory
+            # symlink would need target_is_directory plus a privilege that
+            # non-elevated Windows sessions do not have.
+            assert not (plugin_dir / name).is_symlink()
+            assert not manifest.is_symlink()
+            assert (
+                manifest.stat().st_ino
+                == (Path(root) / "plugin" / name / "manifest.json").stat().st_ino
+            )
+
+
+def test_plugin_subset_root_falls_back_when_link_unavailable(tmp_path, monkeypatch):
+    import vepyr
+
+    root = _fake_plugin_root(tmp_path, ["cadd"])
+
+    def no_hardlinks(src, dst):
+        raise OSError("cross-device link")
+
+    monkeypatch.setattr(os, "link", no_hardlinks)
+    with vepyr._plugin_subset_root(root, ["cadd"]) as subset:
+        manifest = Path(subset) / "plugin" / "cadd" / "manifest.json"
+        assert manifest.is_symlink()
+        assert manifest.read_text() == "{}"
+
+
+def test_plugin_subset_root_reports_when_no_link_method_works(tmp_path, monkeypatch):
+    import vepyr
+
+    root = _fake_plugin_root(tmp_path, ["cadd"])
+    monkeypatch.setattr(os, "link", lambda s, d: (_ for _ in ()).throw(OSError("nope")))
+    monkeypatch.setattr(
+        os, "symlink", lambda s, d: (_ for _ in ()).throw(OSError("nope either"))
+    )
+    with pytest.raises(OSError, match="Developer Mode"):
+        vepyr._plugin_subset_root(root, ["cadd"])
 
 
 def test_plugin_subset_root_empty_list_selects_nothing(tmp_path):


### PR DESCRIPTION
## Summary

Adds a `plugins` argument to `annotate()` so a run can use a subset of the plugin caches under `plugin_cache_root`, instead of all of them.

```python
vepyr.annotate(
    vcf, cache_dir,
    plugin_cache_root="/data/plugin_cache",
    plugins=["clinvar", "cadd"],   # None = all, [] = none
    output_vcf="out.vcf",
)
```

**Marked a prototype** — see *Open question* below before merging.

## Why not filter in the engine

The engine has no plugin filter, and adding one is more invasive than it looks. Discovery funnels through `discover_plugins(cache_root)`, but reaches it by **three independent paths**:

| Entry point | Feeds |
|---|---|
| `PluginRegistry::open(root, chrom)` | per-contig body values |
| `PluginRegistry::field_names(root)` | CSQ `Format:` header |
| `PluginRegistry::field_descriptions(root)` | `##<FIELD>=` header lines |

None take config, so a filter has to be threaded through all three plus the `options_json` round-trip the `workers>1` path depends on. Filter the body but not the header and the header advertises fields the body never fills, shifting every later value — a failure mode the engine already guards against loudly for the analogous missing-shard case.

So this takes the other route: hand the engine a root that already contains only the selected plugins. Both discovery passes then see the same set by construction. No upstream change, no rev bump.

## Verification against the real caches

116 merged cache, five built plugin caches. CSQ `Format:` header:

| Run | Fields |
|---|--:|
| no plugins | 79 |
| all plugins | 117 |
| `plugins=["clinvar"]` | 85 — exactly 79 + ClinVar's 6 |
| `plugins=[]` | 79 |

The alignment check: with `plugins=["cadd"]`, **8,712 of 8,800 transcript rows carry CADD values and all 8,800 match the all-plugins run exactly**, base fields included.

(A first pass at that check used ClinVar and "passed" with 0 mismatches over 0 non-empty rows — vacuous. Re-run with a dense plugin.)

`plugins=[]` output is byte-identical to a plugin-free run apart from the provenance header line, which records the temp root. That line is in `md5_concordance.py`'s `VOLATILE_HEADER_PREFIXES`, so **the parity gate is unaffected** — verified: both `canonical` and `strict` give identical header and body digests for the two files.

## Windows

The first implementation symlinked plugin *directories*, which breaks on Windows twice: `os.symlink` needs `target_is_directory=True` for a directory target, and symlink creation needs `SeCreateSymbolicLinkPrivilege` that non-elevated sessions lack.

Now links files individually — a plugin directory is ~25 files, so hard links are free, need no privilege on NTFS, and have no directory-symlink semantics. Falls back to per-file symlinks (temp dir on another volume), then to an error naming Developer Mode and `TMPDIR`.

The Windows paths are **not yet exercised** — #55 adds the CI job that would.

## Known limitation (not a blocker)

Plugin values are appended to `CSQ`. With `output_vcf` the header names them; in a `LazyFrame` they sit at unnamed positions inside the `CSQ` string, and the default `skip_csq=True` drops that column — so plugins get built and silently discarded. `plugins` warns on exactly that combination.

That is pre-existing and applies equally to `plugin_cache_root` on its own. Tracked as #57.

An earlier revision of this PR claimed plugins were ignored entirely on the `LazyFrame` path. That was a bad test — it searched the `CSQ` *values* string for the field *name* `"CADD"`. The streaming path does apply plugins: `CSQ` widens 79 → 81 with `plugins=["cadd"]`, and the appended values match the VCF run exactly. Corrected in f7d0aeb.

## Tests

1,167 passing (1,156 + 11 new), covering the subset tree, dedup, empty list, unknown/malformed names, the hard-link → symlink → error fallback chain, and the `plugin_cache_root` requirement. Ruff findings unchanged from baseline (7 in `__init__.py`, 4 in the test file, all pre-existing).

`docs/plugins.md` documents the selector, the directory-shaped model, and the VCF-output-only limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
