### PR TITLE
docs(plugins): correct five claims that disagree with the engine

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -150,52 +150,85 @@ source and map it to CSQ fields.
     MUST precede any `[[table]]` header, or TOML absorbs them into the preceding
     table.
 
-- **`plugin_name`** — plugin identifier (also the cache dir name).
-- **`coordinate_system`** — `"1-based"` or `"0-based-half-open"` (drives the
-  build-time coordinate shift to the variation cache's 1-based convention).
-- **`ingest_sql`** — a `SELECT` over the raw source view `plugin_<name>_src`
-  that MUST project the fixed key columns `chrom`, `start`, `end`,
-  `allele_string` (`ref/alt`), plus any discriminator column(s) and the value
-  column(s).
-- **`[[source]]`** — the raw source file(s). `provider` is one of the recognized
-  raw-source types `csv`, `tsv`, `parquet`, `vcf`, `bed` (see
-  [Table providers](#build-pipeline-table-providers-tables-views) for which are
-  wired today — `csv`/`tsv`/`parquet` are implemented; `vcf`/`bed` are recognized
-  but not yet wired). `path` is overridden at build time by `source_path`. A
-  `[source.csv]` block (for `csv`/`tsv`) declares `delimiter`, `has_header`,
-  `comment`, `compression`, and an ordered `schema` of `{name, type}`.
-  A manifest may declare several `[[source]]` blocks, each with its own `part`.
-  They are registered as `plugin_<name>_src_<part>` and combined by the
-  manifest's own `ingest_sql`, so there is no need to concatenate the files
-  first — CADD's separate SNV and indel sources are the worked example.
-  `build_plugin_cache()` takes a plain path for a single-source manifest, and a
-  `{part: path}` mapping for a multi-source one:
+### Top level
 
-  ```python
-  vepyr.build_plugin_cache(
-      "cadd", version,
-      source_path={
-          "snv": ".../whole_genome_SNVs.tsv.gz",
-          "indel": ".../gnomad.genomes.r4.0.indel.tsv.gz",
-      },
-      ...
-  )
-  ```
+| Key | Type | Required | Description |
+|---|---|---|---|
+| `plugin_name` | string | yes | Plugin identifier; also the cache directory name. |
+| `coordinate_system` | `1-based` \| `0-based-half-open` | yes | How `ingest_sql` reads positions. Drives the build-time shift to the variation cache's 1-based convention, and for `vcf`/`bed` sources it also sets the provider's own flag so both agree. |
+| `ingest_sql` | string | yes | `SELECT` over the raw source table(s). MUST project `chrom`, `start`, `end`, `allele_string` (`ref/alt`), plus any discriminator and value columns. |
+| `[[source]]` | table array | yes, 1+ | The raw file(s) — see below. |
+| `[[value_columns]]` | table array | yes, 1+ | The emitted CSQ fields — see below. |
+| `[[match_column]]` | table array | no (default none) | Per-transcript discriminator(s) — see below. Omit for per-variant plugins. |
+| `allele_match` | `exact` \| `minimised` | no (default `exact`) | Which comparison the plugin's own Ensembl implementation uses. See [Allele matching](#allele-matching-exact-vs-minimised) — it is a statement about upstream, not a tuning knob. |
+| `field_order` | `declared` \| `alphabetical` | no (default `declared`) | Order of this plugin's fields in CSQ. `declared` mirrors Ensembl `--custom`, `alphabetical` mirrors `--plugin`. |
+| `csq_rank` | integer | no (default `4294967295`) | Where this plugin's block sits relative to other plugins. Plugins are emitted sorted by `(csq_rank, plugin_name)`, so an unset rank sorts last, by name. |
+| `assume_unique` | bool | no (default `false`) | Declare that the source never repeats a probe key, skipping the dedup pass. The build **samples the data to check the claim** rather than trusting it. |
 
-  The mapping must cover every declared part and name no unknown one. A bare
-  path against a multi-source manifest is rejected — one path cannot address two
-  sources, and the unmapped ones would silently read their placeholders. A
-  mapping is likewise rejected when a `[[source]]` declares no `part`, since
-  there is then no key to address it by.
-- **`[[match_column]]`** *(optional, 0+)* — a per-transcript discriminator:
-  `column` (the stored discriminator column) + `template` (built at runtime from
-  the engine-attribute namespace, see below). Omit entirely for per-variant
-  plugins (the value is emitted on every transcript line).
-- **`[[value_columns]]`** *(1+)* — `column`, `csq_field` (output field name),
-  `type` (`Utf8` / `Float32` / `Int32`). **Declaration order = CSQ output order.**
-- **`allele_match`** *(optional)* — `"exact"` (default) or `"minimised"`. Which
-  one is correct is decided by the plugin's own Ensembl implementation, not by
-  preference; see [Allele matching](#allele-matching-exact-vs-minimised).
+### `[[source]]`
+
+| Key | Type | Required | Description |
+|---|---|---|---|
+| `provider` | `csv` \| `tsv` \| `parquet` \| `vcf` \| `bed` | yes | Reader for this file. All five work — see [Table providers](#build-pipeline-table-providers-tables-views). |
+| `path` | string | yes | Placeholder; **always** overridden at build time by `source_path`. |
+| `part` | string | no | Names this source when a manifest declares several. Registers as `plugin_<name>_src_<part>`, and makes `source_path` take a `{part: path}` mapping. |
+| `index` | `tabix` | no | Random-access index. Explicit rather than inferred from a `.gz` suffix, because ordinary gzip is not seekable. On `csv`/`tsv` it **requires** `compression = "gzip"` (i.e. BGZF) — a plain gzip source with `index = "tabix"` is rejected at parse time. |
+| `record_layout` | bool | no (default `false`) | `vcf` sources only: carry the raw record layout through the provider. |
+| `[source.csv]` | table | for `csv`/`tsv` | Parsing options — see below. Not used by `parquet`/`vcf`/`bed`. |
+
+### `[source.csv]`
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `delimiter` | string | `"\t"` | Field separator. |
+| `has_header` | bool | `false` | Whether row 1 is a header. |
+| `comment` | string | none | Lines starting with this are skipped (e.g. `"#"`). |
+| `compression` | string | none | `"gzip"` is the recognised value. gzip inputs are decompressed to a temp file first, since DataFusion is built without the `compression` feature. |
+| `schema` | array of `{name, type}` | empty | Ordered column list for headerless or explicitly typed input. `type` is `Utf8`, `Float32` or `Int32` — declaring everything `Utf8` and casting in `ingest_sql` is the common pattern. |
+
+### `[[match_column]]`
+
+| Key | Type | Required | Description |
+|---|---|---|---|
+| `column` | string | yes | The discriminator column stored in the shard. |
+| `template` | string | yes | Built at runtime from the [engine-attribute namespace](#engine-attribute-namespace), e.g. `{ref_aa}{Protein_position}{alt_aa}`. If any attribute it references is absent for a consequence, the discriminator is empty and the plugin emits nothing on that line. |
+
+### `[[value_columns]]`
+
+| Key | Type | Required | Description |
+|---|---|---|---|
+| `column` | string | yes | Column produced by `ingest_sql`. |
+| `csq_field` | string | yes | Output CSQ field name. |
+| `type` | `Utf8` \| `Float32` \| `Int32` | yes | Stored Arrow type. |
+| `description` | string | no | Emitted as the `##<FIELD>=<description>` header line, matching what Ensembl writes for plugin fields. |
+
+Declaration order is **not** necessarily output order — `field_order` decides
+that, and it is `alphabetical` for four of the five shipped plugins. See
+[the note on emitted order](#supported-plugins).
+
+### Multi-part sources
+
+A manifest may declare several `[[source]]` blocks, each with its own `part`.
+They register as `plugin_<name>_src_<part>` and are combined by the manifest's
+own `ingest_sql`, so the files need not be concatenated first — CADD's separate
+SNV and indel sources are the worked example:
+
+```python
+vepyr.build_plugin_cache(
+    "cadd", version,
+    source_path={
+        "snv": ".../whole_genome_SNVs.tsv.gz",
+        "indel": ".../gnomad.genomes.r4.0.indel.tsv.gz",
+    },
+    ...
+)
+```
+
+The mapping must cover every declared part and name no unknown one. A bare path
+against a multi-source manifest is rejected — one path cannot address two
+sources, and the unmapped ones would silently read their placeholders. A mapping
+is likewise rejected when a `[[source]]` declares no `part`, since there is then
+no key to address it by.
 
 There is **no `[tier]` block** — tiering is inherited from the variation cache.
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -30,8 +30,14 @@ vepyr.build_plugin_cache(
     plugin_cache_root="/data/plugin_cache",   # output: plugin/<name>/chr*.parquet + manifest.json
     chroms=None,                     # None = all chroms present under <cache_dir>/variation/
     plugins_repo=None,               # optional local clone of vepyr-plugins for OFFLINE builds
+    overwrite=False,                 # True replaces an existing plugin/<name>/ tree
 )
 ```
+
+`source_path` also accepts a `dict[str, str]` for a manifest whose `[[source]]`
+entries are split across several files, keyed by part name — those register as
+`plugin_<name>_src_<part>`. The call returns one
+`(chrom, rows, warm, cold)` tuple per chromosome written.
 
 One call builds one plugin at one version. To combine plugins at different
 versions (e.g. AlphaMissense `v0.2.0` + ClinVar `v0.3.0`), call
@@ -67,9 +73,12 @@ vepyr.annotate(
     discarded.
 
     Pass `skip_csq=False` to keep them. The values are correct and identical
-    to the VCF path, but unnamed: you have to know that, say, a CADD-only
-    subset appends `CADD_PHRED` then `CADD_RAW` at positions 80 and 81 of an
-    81-field `CSQ`. Plugin values are not broken out as DataFrame columns.
+    to the VCF path, but unnamed — you have to count positions yourself, and
+    the base field count varies (74–86, by cache type and `everything`), so
+    the offsets are not fixed. A CADD-only subset on a **merged** cache at
+    default flags appends `CADD_PHRED` then `CADD_RAW` at positions 80 and 81
+    of an 81-field `CSQ`; with `everything=True` the same two land at 87 and
+    88. Plugin values are not broken out as DataFrame columns.
 
     Passing [`plugins`](#choosing-which-plugins-run) without `output_vcf` and
     with `skip_csq` left at its default warns for this reason.
@@ -447,6 +456,7 @@ missense-only gating works (a non-missense consequence has no amino-acid change)
 |---|---|
 | `Consequence` | Consequence type(s) for the transcript (e.g. `missense_variant`). |
 | `Gene` | Ensembl gene stable ID. |
+| `SYMBOL` | Gene symbol (e.g. `APP`) — SpliceAI's discriminator. |
 | `Feature_type` | Feature type (e.g. `Transcript`). |
 | `Feature` | Transcript stable ID — the transcript-id discriminator (e.g. dbNSFP). |
 | `BIOTYPE` | Transcript biotype (e.g. `protein_coding`). |
@@ -528,13 +538,17 @@ a short chain of SQL objects:
 
 **Table providers** (`[[source]].provider`):
 
-| Provider | Status | Notes |
-|---|---|---|
-| `csv` | ✅ implemented | Built-in DataFusion CSV reader. |
-| `tsv` | ✅ implemented | CSV reader with tab delimiter. gzip inputs are decompressed to a temp file first (DataFusion is built without the `compression` feature, so `register_csv` can't read `.gz` directly). |
-| `parquet` | ✅ implemented | Built-in DataFusion Parquet reader. |
-| `vcf` | ⛔ not implemented | Reserved for a future bio-formats-backed provider. |
-| `bed` | ⛔ not implemented | Reserved for a future bio-formats-backed provider. |
+| Provider | Notes |
+|---|---|
+| `csv` | Built-in DataFusion CSV reader. |
+| `tsv` | CSV reader with tab delimiter. gzip inputs are decompressed to a temp file first (DataFusion is built without the `compression` feature, so `register_csv` can't read `.gz` directly). |
+| `parquet` | Built-in DataFusion Parquet reader. |
+| `vcf` | `VcfTableProvider` from bio-formats. Every INFO field the header declares is exposed and `ingest_sql` projects down to what it needs; set `record_layout` on the source to carry the raw record through. |
+| `bed` | `BedTableProvider` from bio-formats, BED4 only — `chrom`, `start`, `end`, `name`, whatever the file's variant. |
+
+All five are implemented. `vcf` and `bed` take their zero/one-based
+interpretation from the manifest's `coordinate_system` rather than the file's
+own convention, so `ingest_sql` always sees the system the manifest declares.
 
 ## Supported plugins
 
@@ -550,15 +564,30 @@ see [Plugin caches](downloads.md#plugin-caches) for the download commands.
 | **ClinVar** | 6 | — (per variant) | `minimised` | [`…plugin_clinvar`](downloads.md#plugin-caches) | [ncbi.nlm.nih.gov/clinvar](https://www.ncbi.nlm.nih.gov/clinvar/) |
 | **dbNSFP** | 19 | `{ref_aa}/{alt_aa}` | `exact` | **not published** — build locally | [dbNSFP](https://www.dbnsfp.org/) |
 
-The CSQ fields each plugin emits, in output order:
+The CSQ fields each plugin emits, **in emitted order**:
 
 | Plugin | Fields |
 |---|---|
-| CADD | `CADD_RAW`, `CADD_PHRED` |
-| SpliceAI | `SpliceAI_pred_SYMBOL`, `SpliceAI_pred_DS_AG`, `SpliceAI_pred_DS_AL`, `SpliceAI_pred_DS_DG`, `SpliceAI_pred_DS_DL`, `SpliceAI_pred_DP_AG`, `SpliceAI_pred_DP_AL`, `SpliceAI_pred_DP_DG`, `SpliceAI_pred_DP_DL` |
+| CADD | `CADD_PHRED`, `CADD_RAW` |
+| SpliceAI | `SpliceAI_pred_DP_AG`, `SpliceAI_pred_DP_AL`, `SpliceAI_pred_DP_DG`, `SpliceAI_pred_DP_DL`, `SpliceAI_pred_DS_AG`, `SpliceAI_pred_DS_AL`, `SpliceAI_pred_DS_DG`, `SpliceAI_pred_DS_DL`, `SpliceAI_pred_SYMBOL` |
 | AlphaMissense | `am_class`, `am_pathogenicity` |
 | ClinVar | `ClinVar`, `ClinVar_CLNSIG`, `ClinVar_CLNREVSTAT`, `ClinVar_CLNDN`, `ClinVar_CLNVC`, `ClinVar_CLNVI` |
-| dbNSFP | 19 predictor score/prediction pairs (`SIFT4G_*`, `Polyphen2_HDIV_*`, `Polyphen2_HVAR_*`, `MutationTaster_*`, …) |
+| dbNSFP | `CADD_phred`, `CADD_raw`, `GERP++_RS`, `MetaLR_pred`, `MetaLR_score`, `MetaSVM_pred`, `MetaSVM_score`, `MutationTaster_pred`, `MutationTaster_score`, `PROVEAN_pred`, `PROVEAN_score`, `Polyphen2_HDIV_score`, `Polyphen2_HVAR_score`, `REVEL_score`, `SIFT4G_pred`, `SIFT4G_score`, `VEST4_score`, `phastCons100way_vertebrate`, `phyloP100way_vertebrate` |
+
+!!! note "Emitted order is not manifest order"
+    A manifest's `field_order` decides this, and it is not the order the
+    `[[value_columns]]` happen to be written in:
+
+    | `field_order` | Emits | Mirrors |
+    |---|---|---|
+    | `declared` (default) | manifest declaration order | Ensembl `--custom` |
+    | `alphabetical` | sorted by CSQ field name | Ensembl `--plugin` |
+
+    Four of the five are `alphabetical`, because Ensembl loads them with
+    `--plugin`. ClinVar is `declared`, because it is loaded with `--custom` —
+    which is why it is the one plugin whose emitted order matches how its
+    manifest reads. `dbNSFP` carries its own `CADD_phred`/`CADD_raw`, distinct
+    from the CADD plugin's upper-case `CADD_PHRED`/`CADD_RAW`.
 
 !!! note "dbNSFP is supported but cannot be mirrored"
     The dbNSFP licence permits academic use of the data but not redistribution


### PR DESCRIPTION
## Summary

Audited every factual claim on `docs/plugins.md` against the upstream source, the built plugin manifests and a real annotation run. Five were wrong. Documentation only.

## 1. `vcf` and `bed` were marked "not implemented" — both work

The provider table said *"⛔ not implemented — Reserved for a future bio-formats-backed provider"*. `provider.rs` constructs both:

```rust
ProviderKind::Vcf => { ... VcfTableProvider::new(spec.path, None, None, None, zero_based) ... }
ProviderKind::Bed => { ... BedTableProvider::new(spec.path, BEDFields::BED4, None, zero_based) ... }
```

Both honour the manifest's `coordinate_system`; the VCF arm also supports `record_layout`. This is the costliest of the five — it tells a manifest author a working capability does not exist.

## 2. "in output order" was manifest order, not emitted order

Emitted order comes from `field_order`, which is **`alphabetical` for four of the five plugins**:

| Plugin | page said | actually emitted |
|---|---|---|
| CADD | `CADD_RAW`, `CADD_PHRED` | `CADD_PHRED`, `CADD_RAW` |
| SpliceAI | `SYMBOL` first | `SYMBOL` last, `DP_*` then `DS_*` |
| dbNSFP | "19 score/prediction pairs" | 19 named fields, fully sorted |

Verified against a real CSQ header: emitted == `sorted(declared)` for every plugin except ClinVar.

The page also contradicted itself — its LazyFrame warning already said CADD appends `CADD_PHRED` then `CADD_RAW`.

Added a note on why: `declared` (the default) mirrors Ensembl `--custom`, `alphabetical` mirrors `--plugin`. ClinVar is loaded with `--custom`, which is exactly why it is the one plugin whose emitted order matches how its manifest reads. Also flags that dbNSFP carries its own lower-case `CADD_phred`/`CADD_raw`, distinct from the CADD plugin's.

## 3. `SYMBOL` missing from the engine-attribute table

`ATTR_NAMES` has 17 entries; the table listed 16. The same page uses `{SYMBOL}` as SpliceAI's discriminator — documenting a template referencing an undocumented attribute.

## 4. `build_plugin_cache` example was incomplete

It comments every argument as if exhaustive but omitted `overwrite`, never mentioned that `source_path` takes a `{part: path}` mapping for multi-part manifests (CADD's SNV + indel sources), and did not say what the call returns.

## 5. CSQ positions quoted without their flags

The LazyFrame warning gave positions 80 and 81 with no mention that they hold only for a merged cache at default flags — the base count varies 74–86 by cache type and `everything`, in a warning that tells people to count positions by hand. Both figures now stated with flags, and measured:

```
default flags     81 fields; CADD_PHRED at 80, CADD_RAW at 81
everything=True   88 fields; CADD_PHRED at 87, CADD_RAW at 88
```

## 6. The manifest section was prose, and incomplete

Second commit. Six keys the parser accepts appeared nowhere on the page, so a manifest author could not discover them:

| Key | Block | Allowed values / default |
|---|---|---|
| `csq_rank` | top level | integer, default `u32::MAX` — plugins emit sorted by `(csq_rank, plugin_name)` |
| `field_order` | top level | `declared` (default) \| `alphabetical` |
| `assume_unique` | top level | bool, default `false` — build samples the data to check the claim |
| `index` | `[[source]]` | `tabix`; on csv/tsv **requires** `compression = "gzip"` |
| `record_layout` | `[[source]]` | bool, default `false`, vcf only |
| `description` | `[[value_columns]]` | string — becomes the `##<FIELD>=` header line |

`csq_rank` and `field_order` are the awkward pair: both are cited elsewhere on this page as explanations while never being listed as settable keys.

Two more wrong statements surfaced there too:

- **"Declaration order = CSQ output order"** — holds only for `field_order = declared`, which is the minority case among the shipped plugins.
- The provider bullet **repeated** the "vcf/bed recognized but not yet wired" claim. The first commit fixed that in the provider table and missed this second occurrence.

Now five tables — top level, `[[source]]`, `[source.csv]`, `[[match_column]]`, `[[value_columns]]` — each with type, required/default and allowed values. Multi-part source rules stay prose, since they are constraints rather than fields. Defaults read off the serde attributes.

## What checked out

Recorded because several were doubted during the audit: the four HF plugin repos exist, `downloads.md#plugin-caches` resolves, per-plugin field counts (2/9/2/6/19), `allele_match` and `csq_rank` values, the shard schema including `tier` as `Int8`, and the tier constants `WARM_AF_THRESHOLD = 0.01` / `WARM_POSITION_RADIUS = 1`.

## Notes

Rebased on current `origin/master`. Touches different sections of `plugins.md` than #58, and a trial merge of the two produces no conflicts. `mkdocs build` passes with no warnings from the page. No code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
