### PR TITLE
docs: enable Google Analytics on the MkDocs site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,3 +87,8 @@ markdown_extensions:
       custom_checkbox: true
   - toc:
       permalink: true
+
+extra:
+  analytics:
+    provider: google
+    property: G-X2YYYSXDCD


### PR DESCRIPTION
## What

Adds the mkdocs-material `extra.analytics` block to `mkdocs.yml` so the published docs site at https://biodatageeks.org/vepyr/ reports pageviews to GA4 (property `G-X2YYYSXDCD`).

```yaml
extra:
  analytics:
    provider: google
    property: G-X2YYYSXDCD
```

## Why the ID is in plain text

GA4 measurement IDs are not secrets — mkdocs-material inlines them into the `gtag` snippet on every rendered page, so they are public by construction. Hardcoding keeps local `mkdocs serve` output identical to production and avoids a repo secret that would silently no-op if unset.

## Verification

`mkdocs build` succeeds (only the pre-existing broken-link warnings from `docs/superpowers/**`), and the rendered `site/index.html` now loads:

```
https://www.googletagmanager.com/gtag/js?id=G-X2YYYSXDCD
```

## Note on rollout

`.github/workflows/publish_documentation.yml` deploys only on tag pushes and `workflow_dispatch`, so tracking starts at the next release tag or a manual run of that workflow.

Feedback widget ("Was this page helpful?") deliberately not included — analytics only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZFNNS95bo9kNhGbWCBdra