### PR TITLE
chore: qualify the release-116 cache-build determinism fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,8 +1150,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-bed"
-version = "1.11.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=80f3a6c043899f8ded44eaab204b42735f805272#80f3a6c043899f8ded44eaab204b42735f805272"
+version = "1.12.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=c992f69e0b94201c4d9056b7450f2b2ec2922d5e#c992f69e0b94201c4d9056b7450f2b2ec2922d5e"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1173,8 +1173,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-core"
-version = "1.11.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=80f3a6c043899f8ded44eaab204b42735f805272#80f3a6c043899f8ded44eaab204b42735f805272"
+version = "1.12.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=c992f69e0b94201c4d9056b7450f2b2ec2922d5e#c992f69e0b94201c4d9056b7450f2b2ec2922d5e"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1196,8 +1196,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-ensembl-cache"
-version = "1.11.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=80f3a6c043899f8ded44eaab204b42735f805272#80f3a6c043899f8ded44eaab204b42735f805272"
+version = "1.12.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=c992f69e0b94201c4d9056b7450f2b2ec2922d5e#c992f69e0b94201c4d9056b7450f2b2ec2922d5e"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1214,8 +1214,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-format-vcf"
-version = "1.11.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=80f3a6c043899f8ded44eaab204b42735f805272#80f3a6c043899f8ded44eaab204b42735f805272"
+version = "1.12.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=c992f69e0b94201c4d9056b7450f2b2ec2922d5e#c992f69e0b94201c4d9056b7450f2b2ec2922d5e"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1246,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-function-vep"
 version = "0.17.2"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=3a3fca3f423c3290dea80b2ee20fbebc7a5f3fe0#3a3fca3f423c3290dea80b2ee20fbebc7a5f3fe0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=93ba78ebaae262a0d0fbed78baab8879a87ec52b#93ba78ebaae262a0d0fbed78baab8879a87ec52b"
 dependencies = [
  "ahash",
  "async-trait",
@@ -5450,7 +5450,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vepyr"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "arrow",
  "datafusion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,7 +1151,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-bed"
 version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=c992f69e0b94201c4d9056b7450f2b2ec2922d5e#c992f69e0b94201c4d9056b7450f2b2ec2922d5e"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=12016a9304d3a14e4d56d9459f3bd6f1cb678d02#12016a9304d3a14e4d56d9459f3bd6f1cb678d02"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1174,7 +1174,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-core"
 version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=c992f69e0b94201c4d9056b7450f2b2ec2922d5e#c992f69e0b94201c4d9056b7450f2b2ec2922d5e"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=12016a9304d3a14e4d56d9459f3bd6f1cb678d02#12016a9304d3a14e4d56d9459f3bd6f1cb678d02"
 dependencies = [
  "async-compression",
  "bytes",
@@ -1197,7 +1197,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-ensembl-cache"
 version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=c992f69e0b94201c4d9056b7450f2b2ec2922d5e#c992f69e0b94201c4d9056b7450f2b2ec2922d5e"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=12016a9304d3a14e4d56d9459f3bd6f1cb678d02#12016a9304d3a14e4d56d9459f3bd6f1cb678d02"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1215,7 +1215,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-format-vcf"
 version = "1.12.0"
-source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=c992f69e0b94201c4d9056b7450f2b2ec2922d5e#c992f69e0b94201c4d9056b7450f2b2ec2922d5e"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?rev=12016a9304d3a14e4d56d9459f3bd6f1cb678d02#12016a9304d3a14e4d56d9459f3bd6f1cb678d02"
 dependencies = [
  "async-compression",
  "async-stream",
@@ -1246,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-function-vep"
 version = "0.17.2"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=93ba78ebaae262a0d0fbed78baab8879a87ec52b#93ba78ebaae262a0d0fbed78baab8879a87ec52b"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=86f1c0a2a49c9a4f08dbaca42c25308b898b7542#86f1c0a2a49c9a4f08dbaca42c25308b898b7542"
 dependencies = [
  "ahash",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,13 @@ log = "0.4"
 env_logger = { version = "0.11", default-features = false }
 serde_json = "1"
 
-# Released bio-formats v1.11.0 and bio-functions v0.19.2, pinned by the commit
+# QUALIFICATION PINS (not release tags). bio-formats is
+# c992f69 = v1.12.0 + the exon dedup tie-break (biodatageeks/datafusion-bio-formats#246);
+# bio-functions is 93ba78e = v0.19.2 + the translation_core ORDER BY (#224) and the
+# unread-column drop (#225), merged for local qualification and itself re-pinned to
+# c992f69. Re-pin both to the merged master SHAs once those three PRs land.
+#
+# Previously: released bio-formats v1.11.0 and bio-functions v0.19.2, pinned by the commit
 # each tag names. v1.11.0 carries each record's INFO and FORMAT key order through
 # a read/write round trip; v0.18.0 turned that on for annotation output and
 # stopped stripping field metadata from the annotation schema, without which the
@@ -55,6 +61,6 @@ serde_json = "1"
 # two different revs are two different sources to cargo, so a mismatch compiles
 # the formats crates twice and `CacheSourceType` / the VCF writer types then fail
 # to cross into `CacheBuilder` (E0308).
-datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "3a3fca3f423c3290dea80b2ee20fbebc7a5f3fe0", features = ["cache-builder"] }
-datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "80f3a6c043899f8ded44eaab204b42735f805272" }
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "80f3a6c043899f8ded44eaab204b42735f805272" }
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "93ba78ebaae262a0d0fbed78baab8879a87ec52b", features = ["cache-builder"] }
+datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "c992f69e0b94201c4d9056b7450f2b2ec2922d5e" }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "c992f69e0b94201c4d9056b7450f2b2ec2922d5e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,14 +42,14 @@ log = "0.4"
 env_logger = { version = "0.11", default-features = false }
 serde_json = "1"
 
-# QUALIFICATION PINS (not release tags). bio-formats is
-# c992f69 = v1.12.0 + the exon dedup tie-break (biodatageeks/datafusion-bio-formats#246);
-# bio-functions is 93ba78e = v0.19.2 + the translation_core ORDER BY (#224) and the
-# unread-column drop (#225), merged for local qualification and itself re-pinned to
-# c992f69. Re-pin both to the merged master SHAs once those three PRs land.
+# bio-formats 12016a9 (v1.12.0 + the exon dedup tie-break, biodatageeks/datafusion-bio-formats#246)
+# and bio-functions 86f1c0a (v0.19.2 + the translation_core ORDER BY #224, the unread-column
+# drop #225, and the bio-formats bump #226). Together these make a cache build reproducible:
+# the exon dedup tie-break is now total, translation_core has a total output ORDER BY instead
+# of relying on CoalescePartitionsExec arrival order, and the four context entities no longer
+# persist raw_object_json / object_hash / _rn, which no reader projects.
 #
-# Previously: released bio-formats v1.11.0 and bio-functions v0.19.2, pinned by the commit
-# each tag names. v1.11.0 carries each record's INFO and FORMAT key order through
+# bio-formats v1.11.0 carried each record's INFO and FORMAT key order through
 # a read/write round trip; v0.18.0 turned that on for annotation output and
 # stopped stripping field metadata from the annotation schema, without which the
 # carry reaches the writer unrecognised. v0.19.0 adds the plugin cache-builder
@@ -61,6 +61,6 @@ serde_json = "1"
 # two different revs are two different sources to cargo, so a mismatch compiles
 # the formats crates twice and `CacheSourceType` / the VCF writer types then fail
 # to cross into `CacheBuilder` (E0308).
-datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "93ba78ebaae262a0d0fbed78baab8879a87ec52b", features = ["cache-builder"] }
-datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "c992f69e0b94201c4d9056b7450f2b2ec2922d5e" }
-datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "c992f69e0b94201c4d9056b7450f2b2ec2922d5e" }
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "86f1c0a2a49c9a4f08dbaca42c25308b898b7542", features = ["cache-builder"] }
+datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "12016a9304d3a14e4d56d9459f3bd6f1cb678d02" }
+datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "12016a9304d3a14e4d56d9459f3bd6f1cb678d02" }

--- a/docs/caches.md
+++ b/docs/caches.md
@@ -107,12 +107,12 @@ Column counts (merged cache, release 116):
 | Entity | Columns | of which provenance | Cross-type delta |
 |---|--:|--:|---|
 | `variation` | 25 | 0 | — |
-| `transcript` | 79 | 20 | `source_refseq` |
-| `exon` | 36 | 20 | `source_refseq` |
+| `transcript` | 77 | 20 | `source_refseq` |
+| `exon` | 33 | 20 | `source_refseq` |
 | `translation_core` | 10 | 0 | — |
 | `translation_sift` | 3 | 0 | — |
-| `regulatory` | 32 | 20 | `source_refseq` |
-| `motif` | 37 | 20 | `source_refseq` |
+| `regulatory` | 30 | 20 | `source_refseq` |
+| `motif` | 35 | 20 | `source_refseq` |
 
 ### The provenance block
 

--- a/docs/caches.md
+++ b/docs/caches.md
@@ -169,7 +169,7 @@ cache, leaving 19.
     | `af_gnomadg_alleles` | `list<item: string>` |
     | `af_gnomadg_freqs` | `list<item: float>` |
 
-??? note "`transcript` — 59 columns (+ 20 provenance)"
+??? note "`transcript` — 57 columns (+ 20 provenance)"
 
     The transcript models, including sequences and the nested `exons` / `cdna_mapper_segments` / `refseq_edits` structures. No provenance block shown — see above.
 
@@ -231,11 +231,9 @@ cache, leaving 19.
     | `has_non_polya_rna_edit` | `bool` |
     | `spliced_seq` | `string` |
     | `flags_str` | `string` |
-    | `raw_object_json` | `string` |
-    | `object_hash` | `string` |
     | `transcript_uid` | `uint32` |
 
-??? note "`exon` — 16 columns (+ 20 provenance)"
+??? note "`exon` — 13 columns (+ 20 provenance)"
 
     Exon/intron structure, one row per exon of a transcript. No provenance block shown — see above.
 
@@ -254,9 +252,6 @@ cache, leaving 19.
     | `transcript_id` | `string` |
     | `gene_stable_id` | `string` |
     | `exon_number` | `int32` |
-    | `raw_object_json` | `string` |
-    | `object_hash` | `string` |
-    | `_rn` | `uint64` |
 
 ??? note "`translation_core` — 10 columns"
 
@@ -285,7 +280,7 @@ cache, leaving 19.
     | `sift` | `binary` |
     | `poly` | `binary` |
 
-??? note "`regulatory` — 12 columns (+ 20 provenance)"
+??? note "`regulatory` — 10 columns (+ 20 provenance)"
 
     Regulatory features. No provenance block shown — see above.
 
@@ -301,10 +296,8 @@ cache, leaving 19.
     | `epigenome_count` | `int32` |
     | `regulatory_build_id` | `int64` |
     | `cell_types` | `string` |
-    | `raw_object_json` | `string` |
-    | `object_hash` | `string` |
 
-??? note "`motif` — 17 columns (+ 20 provenance)"
+??? note "`motif` — 15 columns (+ 20 provenance)"
 
     TF-binding motif features (release 116 only). No provenance block shown — see above.
 
@@ -325,8 +318,6 @@ cache, leaving 19.
     | `cell_types` | `string` |
     | `overlapping_regulatory_feature` | `string` |
     | `transcription_factors` | `string` |
-    | `raw_object_json` | `string` |
-    | `object_hash` | `string` |
 
 ## CSQ output fields
 

--- a/docs/testing-vep.md
+++ b/docs/testing-vep.md
@@ -465,9 +465,29 @@ rather than a full scan.
 ## Checking byte-level agreement
 
 The field-by-field comparison above answers whether the annotation *content* matches.
-`md5_concordance.py` answers the stricter question of whether the *bytes* match, which
+The byte-level check answers the stricter question of whether the *bytes* match, which
 is what makes vepyr's output a drop-in replacement for VEP's rather than an equivalent
-one. It hashes each file's header and record body separately and compares the digests.
+one. Both hash each file's header and record body separately and compare the digests.
+
+For the usual case, ask `run_comparison.py` for it directly — it slices the input and
+the reference, annotates, hashes both, and exits non-zero on any mismatch:
+
+```bash
+cd e2e-testing/scripts
+
+# One command, any contig subset
+uv run python run_comparison.py --release 116 --chroms 1 4 7 22 \
+    --comparison-mode md5 --bgzf
+```
+
+`--comparison-mode` picks *how* to compare (`field`, the default, or `md5`);
+`--skip-compare` picks *whether* to compare at all and skips the reference slice with
+it. The two cannot be combined. `--md5-mode` defaults to `both`, reporting `strict` and
+`canonical` side by side.
+
+Reach for `md5_concordance.py` when you need what that flag does not do: compare two
+arbitrary files, re-hash existing output without re-annotating, or classify *how*
+records differ with `--explain`.
 
 ```bash
 cd e2e-testing/scripts
@@ -481,7 +501,8 @@ uv run python md5_concordance.py \
 uv run python md5_concordance.py --results-dir ../results/116 --mode strict
 ```
 
-`--mode canonical` (the default) normalizes the differences that are known to be
+`--mode canonical` (the standalone tool's default; `run_comparison.py --md5-mode`
+defaults to `both`) normalizes the differences that are known to be
 cosmetic before hashing — QUAL rendered numerically, INFO and FORMAT keys sorted,
 FORMAT keys missing in every sample dropped — so a matching canonical digest means the
 two files carry identical annotation content and differ only in how they were written.

--- a/e2e-testing/README.md
+++ b/e2e-testing/README.md
@@ -96,8 +96,18 @@ uv run python run_comparison.py --release 115 --chroms 22 --workers 4
 # One subprocess per contig, so a native crash loses only that contig
 uv run python run_comparison.py --release 115 --isolate
 
-# Annotate only, no comparison -- useful for annotation timing
+# Annotate only, no comparison and no reference slice -- annotation timing
 uv run python run_comparison.py --release 115 --chroms 22 --skip-compare
+
+# Byte-level comparison instead of the field-by-field one, for a contig subset.
+# Slices the input and the VEP reference, annotates, hashes both, exits non-zero
+# on any mismatch -- the whole e2e check in one command.
+uv run python run_comparison.py --release 116 --chroms 1 4 7 22 \
+    --comparison-mode md5 --bgzf
+
+# Narrow the digest to one mode (default reports strict and canonical)
+uv run python run_comparison.py --release 116 --chroms 22 \
+    --comparison-mode md5 --md5-mode strict
 
 # Regenerate the summary from existing per-contig JSONs (instant)
 uv run python run_comparison.py --release 115 --skip-annotate
@@ -109,6 +119,23 @@ uv run python run_comparison.py --release 115 --chroms 22 \
     --cache-dir /path/to/cache \
     --fasta /path/to/reference.fa
 ```
+
+**Comparison modes.** `--comparison-mode` selects *how* the output is checked
+against the VEP reference; `--skip-compare` selects *whether* it is checked at
+all. The two cannot be combined -- doing so is an error rather than a silently
+resolved contradiction.
+
+| flags | annotate | reference slice | check |
+|---|---|---|---|
+| *(default)* | yes | yes | `field` -- CSQ fields per record, writes the aggregate summary |
+| `--comparison-mode md5` | yes | yes | `md5` -- byte digests per contig |
+| `--skip-compare` | yes | no | none |
+
+`--md5-mode` defaults to `both`, reporting `strict` (record bytes as-is, the
+parity target) and `canonical` (cosmetic serialization normalised first)
+side by side. Hashing twice is cheap and the pair is diagnostic: a strict
+failure with a canonical pass isolates serialization drift from a change in
+annotation content, which either digest alone leaves ambiguous.
 
 **Defaults:** `--profile merged`, always regenerate annotation output, reuse
 only source-identified normalized/input/reference slices (`--force` to recreate

--- a/e2e-testing/scripts/comparison/cli.py
+++ b/e2e-testing/scripts/comparison/cli.py
@@ -277,13 +277,18 @@ def md5_summary(report_dir, chroms, suffix, release, requested):
     print(header)
     print("  " + "-" * (len(header) - 2))
     differing = []
+    incomplete = []
     for chrom, payload in rows:
         first = payload.get(modes[0], {})
         cells = []
         for mode in modes:
             entry = payload.get(mode)
             if entry is None:
+                # A requested mode with no stored digest is unevaluated, not
+                # passing -- happens when the report was written by a run with
+                # a narrower --md5-mode.
                 cells.append(f"{'-':<9}")
+                incomplete.append(chrom)
                 continue
             cells.append(f"{'ok' if entry['body_match'] else 'DIFFER':<9}")
             if not entry["body_match"]:
@@ -293,17 +298,25 @@ def md5_summary(report_dir, chroms, suffix, release, requested):
         print(f"  {chrom:<8} {shown:>12}  " + "  ".join(cells))
 
     differing = sorted(set(differing))
+    incomplete = sorted(set(incomplete) - set(differing))
     total = sum(
         payload.get(modes[0], {}).get("vep_records") or 0 for _, payload in rows
     )
     if missing:
         print(f"  no md5 evidence for: {', '.join(missing)}")
+    if incomplete:
+        print(
+            f"  no digest for every requested mode on: {', '.join(incomplete)}"
+            " -- re-run without --skip-annotate, or narrow --md5-mode"
+        )
     if differing:
         print(f"\n  FAIL: body digest differs on {', '.join(differing)}")
+    elif missing or incomplete:
+        print("\n  FAIL: incomplete md5 evidence -- nothing was verified above")
     else:
         print(f"\n  PASS: {len(rows)} contig(s) concord ({total:,} records)")
     print("=" * 60)
-    return differing + missing
+    return differing + missing + incomplete
 
 
 def md5_for_contig(chrom, vep_slice, vepyr_vcf, requested):
@@ -654,7 +667,11 @@ def main(argv=None):
                 failures.append(chrom)
 
     md5_failures = []
-    if args.comparison_mode == "md5" and not args.skip_annotate:
+    # No `not args.skip_annotate` guard: md5_summary reads the per-contig report
+    # JSONs back off disk, exactly as load_reports does for field mode, so
+    # --skip-annotate re-summarises existing evidence instead of silently
+    # printing nothing and exiting 0.
+    if args.comparison_mode == "md5":
         md5_failures = md5_summary(
             report_dir,
             [chrom for chrom in chroms if chrom not in failures],

--- a/e2e-testing/scripts/comparison/cli.py
+++ b/e2e-testing/scripts/comparison/cli.py
@@ -87,7 +87,32 @@ def parse_args(argv=None):
         "--skip-comparison",
         dest="skip_compare",
         action="store_true",
-        help="Annotate only, no comparison against the VEP reference",
+        help="Annotate only: no comparison, and no reference slice. To "
+        "compare, drop this and use --comparison-mode.",
+    )
+    p.add_argument(
+        "--comparison-mode",
+        choices=("field", "md5"),
+        default=None,
+        dest="comparison_mode",
+        help="How to compare vepyr's output against the VEP reference "
+        "(default: field). Both modes annotate and cut the reference slice if "
+        "it is missing; only the check differs. 'field' compares the CSQ "
+        "fields per record and writes the aggregate summary. 'md5' hashes the "
+        "files and reports byte concordance per contig. Use --skip-compare to "
+        "annotate with no comparison at all.",
+    )
+    p.add_argument(
+        "--md5-mode",
+        choices=("strict", "canonical", "both"),
+        default="both",
+        dest="md5_mode",
+        help="Digest mode for --comparison-mode md5 (default: both). "
+        "'strict' hashes record bytes as-is -- the parity target. 'canonical' "
+        "normalises cosmetic serialization first. 'both' is the default "
+        "because hashing twice is cheap and the pair is diagnostic: a strict "
+        "failure with a canonical pass isolates serialization drift from a "
+        "content change, which one digest alone cannot tell you.",
     )
     p.add_argument(
         "--no-normalize",
@@ -221,6 +246,103 @@ def resolve_contigs(args, resolved, input_vcf):
     return args.chroms
 
 
+def md5_summary(report_dir, chroms, suffix, release, requested):
+    """Print the per-contig md5 verdicts and return the contigs that differ.
+
+    Read back from the per-contig report JSONs rather than kept in memory, so
+    the summary is identical whether the contigs ran in-process or under
+    --isolate (where each one is a separate subprocess).
+    """
+    modes = ("strict", "canonical") if requested == "both" else (requested,)
+    rows = []
+    missing = []
+    for chrom in chroms:
+        path = report.report_json_path(report_dir, chrom, suffix, release)
+        try:
+            with open(path) as f:
+                payload = json.load(f).get("md5")
+        except (OSError, ValueError):
+            payload = None
+        if not payload:
+            missing.append(chrom)
+            continue
+        rows.append((chrom, payload))
+
+    print(f"\n{'=' * 60}")
+    print(f"  MD5 concordance vs the VEP reference ({', '.join(modes)})")
+    print(f"{'=' * 60}")
+    header = f"  {'CONTIG':<8} {'RECORDS':>12}  " + "  ".join(
+        f"{m.upper():<9}" for m in modes
+    )
+    print(header)
+    print("  " + "-" * (len(header) - 2))
+    differing = []
+    for chrom, payload in rows:
+        first = payload.get(modes[0], {})
+        cells = []
+        for mode in modes:
+            entry = payload.get(mode)
+            if entry is None:
+                cells.append(f"{'-':<9}")
+                continue
+            cells.append(f"{'ok' if entry['body_match'] else 'DIFFER':<9}")
+            if not entry["body_match"]:
+                differing.append(chrom)
+        records = first.get("vep_records")
+        shown = f"{records:,}" if isinstance(records, int) else "?"
+        print(f"  {chrom:<8} {shown:>12}  " + "  ".join(cells))
+
+    differing = sorted(set(differing))
+    total = sum(
+        payload.get(modes[0], {}).get("vep_records") or 0 for _, payload in rows
+    )
+    if missing:
+        print(f"  no md5 evidence for: {', '.join(missing)}")
+    if differing:
+        print(f"\n  FAIL: body digest differs on {', '.join(differing)}")
+    else:
+        print(f"\n  PASS: {len(rows)} contig(s) concord ({total:,} records)")
+    print("=" * 60)
+    return differing + missing
+
+
+def md5_for_contig(chrom, vep_slice, vepyr_vcf, requested):
+    """Hash one contig's vepyr output against its VEP reference slice.
+
+    Delegates to `md5_concordance` rather than re-implementing the digest, so
+    the verdict here and the verdict from `md5_concordance.py --results-dir`
+    cannot drift. Returns `{mode: {...}}`, printing one line per mode.
+    """
+    import md5_concordance
+
+    modes = ("strict", "canonical") if requested == "both" else (requested,)
+    pair = md5_concordance.Pair(label=chrom, vep=vep_slice, vepyr=vepyr_vcf)
+    out = {}
+    for mode in modes:
+        outcome = md5_concordance.compare(pair, mode)
+        out[mode] = {
+            "body_match": outcome.body_match,
+            "header_match": outcome.header_match,
+            "count_match": outcome.count_match,
+            "vep_body_md5": outcome.vep.body,
+            "vepyr_body_md5": outcome.vepyr.body,
+            "vep_records": outcome.vep.records,
+            "vepyr_records": outcome.vepyr.records,
+            "notes": list(outcome.notes),
+        }
+        verdict = "MATCH" if outcome.body_match else "DIFFER"
+        counts = (
+            f"{outcome.vep.records:,}"
+            if outcome.count_match
+            else f"{outcome.vep.records:,} vs {outcome.vepyr.records:,}"
+        )
+        print(f"  md5 {mode}: body {verdict} ({counts} records)")
+        if not outcome.body_match:
+            for note in outcome.notes:
+                print(f"    - {note}")
+    return out
+
+
 def run_contig(
     chrom,
     args,
@@ -271,11 +393,17 @@ def run_contig(
         bgzf=args.bgzf,
     )
 
-    comparison = None
+    # The reference slice feeds the field comparison and the md5 check alike, so
+    # it must be cut whenever either is wanted -- `--skip-compare --md5` used to
+    # leave md5 with nothing to compare against.
+    vep_slice = None
     if not args.skip_compare:
         vep_slice = vcfio.slice_vep(
             resolved.vep_vcf, chrom, work_dir, resolved.suffix, force=args.force
         )
+
+    comparison = None
+    if not args.skip_compare and args.comparison_mode == "field":
         comparison = compare.compare_vcfs(
             output_vcf,
             vep_slice,
@@ -289,6 +417,10 @@ def run_contig(
                 resolved.release,
             ),
         )
+
+    md5_result = None
+    if not args.skip_compare and args.comparison_mode == "md5":
+        md5_result = md5_for_contig(chrom, vep_slice, output_vcf, args.md5_mode)
 
     result = {
         "chrom": chrom,
@@ -309,6 +441,8 @@ def run_contig(
         },
         "comparison": comparison,
     }
+    if md5_result is not None:
+        result["md5"] = md5_result
     if reference_identity is not None:
         result["reference_identity"] = reference_identity
     # Only for plugin profiles, so a non-plugin report keeps its exact shape.
@@ -350,6 +484,10 @@ def _run_contig_isolated(chrom, args):
         cmd.append("--bgzf")
     if args.skip_compare:
         cmd.append("--skip-compare")
+    if args.comparison_mode:
+        cmd += ["--comparison-mode", args.comparison_mode]
+    if args.md5_mode:
+        cmd += ["--md5-mode", args.md5_mode]
     if args.no_normalize:
         cmd.append("--no-normalize")
     if args.vep:
@@ -363,6 +501,19 @@ def _run_contig_isolated(chrom, args):
 
 def main(argv=None):
     args = parse_args(argv)
+
+    # --skip-compare means "no comparison at all"; --comparison-mode selects
+    # which comparison to run. Asking for both is contradictory, so say so
+    # rather than silently honouring one of them.
+    if args.skip_compare and args.comparison_mode is not None:
+        print(
+            "Error: --skip-compare runs no comparison, so it cannot be "
+            f"combined with --comparison-mode {args.comparison_mode}. "
+            "Drop one.",
+            file=sys.stderr,
+        )
+        return 2
+    args.comparison_mode = args.comparison_mode or "field"
 
     try:
         # Per-contig plugin references resolve one file at a time, so hand the
@@ -502,9 +653,26 @@ def main(argv=None):
                 print(f"  ERROR: {chrom} failed: {exc}", file=sys.stderr)
                 failures.append(chrom)
 
+    md5_failures = []
+    if args.comparison_mode == "md5" and not args.skip_annotate:
+        md5_failures = md5_summary(
+            report_dir,
+            [chrom for chrom in chroms if chrom not in failures],
+            resolved.suffix,
+            resolved.release,
+            args.md5_mode,
+        )
+
     if args.skip_compare:
         print("\nSkipping aggregate summary (--skip-compare)")
         return 1 if failures else 0
+
+    if args.comparison_mode == "md5":
+        # The field-level aggregate summarises per-field mismatch counts, which
+        # md5 mode never produces. The md5 table above is this mode's summary.
+        if failures:
+            print(f"  FAILED contigs: {', '.join(failures)}")
+        return 1 if failures or md5_failures else 0
 
     successful_chroms = [chrom for chrom in chroms if chrom not in failures]
     if not args.skip_annotate:
@@ -585,5 +753,7 @@ def main(argv=None):
     print(f"  Total mismatches: {sum(agg['field_mm'].values()):,}")
     if failures:
         print(f"  FAILED contigs: {', '.join(failures)}")
+    if md5_failures:
+        print(f"  MD5 mismatched contigs: {', '.join(md5_failures)}")
     print("=" * 60)
-    return 1 if failures else 0
+    return 1 if failures or md5_failures else 0

--- a/e2e-testing/scripts/comparison/cli.py
+++ b/e2e-testing/scripts/comparison/cli.py
@@ -453,6 +453,7 @@ def run_contig(
             "output_variants": n_out,
         },
         "comparison": comparison,
+        "comparison_mode": None if args.skip_compare else args.comparison_mode,
     }
     if md5_result is not None:
         result["md5"] = md5_result
@@ -496,10 +497,12 @@ def _run_contig_isolated(chrom, args):
     if args.bgzf:
         cmd.append("--bgzf")
     if args.skip_compare:
+        # main() has already defaulted comparison_mode to "field", so forwarding
+        # it here would hand the child both flags and trip its own conflict
+        # check -- failing every contig of an annotate-only isolated sweep.
         cmd.append("--skip-compare")
-    if args.comparison_mode:
+    else:
         cmd += ["--comparison-mode", args.comparison_mode]
-    if args.md5_mode:
         cmd += ["--md5-mode", args.md5_mode]
     if args.no_normalize:
         cmd.append("--no-normalize")
@@ -692,6 +695,43 @@ def main(argv=None):
         return 1 if failures or md5_failures else 0
 
     successful_chroms = [chrom for chrom in chroms if chrom not in failures]
+
+    # An md5 run writes `comparison: null` to the same mode-agnostic report
+    # path a field run uses. Left unchecked, a later field-mode
+    # --skip-annotate would load those reports, aggregate_mismatches() would
+    # skip every null, and the run would print a 0/0 field summary and exit 0
+    # on evidence that contains no field comparison at all. Only reused
+    # evidence can be stale this way -- a fresh field run always populates
+    # `comparison` -- so the check is scoped to --skip-annotate.
+    field_evidence_missing = []
+    for chrom in successful_chroms if args.skip_annotate else ():
+        path = report.report_json_path(
+            report_dir, chrom, resolved.suffix, resolved.release
+        )
+        if not os.path.isfile(path):
+            continue
+        try:
+            with open(path) as f:
+                payload = json.load(f)
+        except (OSError, ValueError):
+            continue
+        if payload.get("comparison") is None:
+            field_evidence_missing.append(chrom)
+    if field_evidence_missing:
+        print(
+            "  ERROR: no field-comparison evidence for "
+            + ", ".join(field_evidence_missing)
+            + " -- those reports were written by a run in another mode "
+            "(--comparison-mode md5, or --skip-compare).\n"
+            "         Re-run in field mode, or pass --comparison-mode md5 to "
+            "read the md5 evidence instead.",
+            file=sys.stderr,
+        )
+        failures.extend(field_evidence_missing)
+        successful_chroms = [
+            chrom for chrom in successful_chroms if chrom not in field_evidence_missing
+        ]
+
     if not args.skip_annotate:
         missing_evidence = [
             chrom

--- a/tests/test_build_cache.py
+++ b/tests/test_build_cache.py
@@ -632,7 +632,16 @@ class TestBuildCacheIntegration:
 
     def test_transcript_column_count(self, built_cache):
         _, _, _, tables = built_cache
-        assert tables["transcript"].num_columns == 78
+        assert tables["transcript"].num_columns == 76
+
+    def test_transcript_omits_unpersisted_columns(self, built_cache):
+        # The cache build stops at the columns something reads. The raw
+        # Storable payload and its hash are projected by no reader, and `_rn`
+        # is the dedup helper; see biodatageeks/datafusion-bio-functions#225.
+        _, _, _, tables = built_cache
+        cols = tables["transcript"].column_names
+        for c in ("raw_object_json", "object_hash"):
+            assert c not in cols, f"{c} must not be persisted in transcript"
 
     def test_transcript_required_columns(self, built_cache):
         _, _, _, tables = built_cache
@@ -729,7 +738,16 @@ class TestBuildCacheIntegration:
 
     def test_exon_column_count(self, built_cache):
         _, _, _, tables = built_cache
-        assert tables["exon"].num_columns == 35
+        assert tables["exon"].num_columns == 32
+
+    def test_exon_omits_unpersisted_columns(self, built_cache):
+        # The cache build stops at the columns something reads. The raw
+        # Storable payload and its hash are projected by no reader, and `_rn`
+        # is the dedup helper; see biodatageeks/datafusion-bio-functions#225.
+        _, _, _, tables = built_cache
+        cols = tables["exon"].column_names
+        for c in ("raw_object_json", "object_hash", "_rn"):
+            assert c not in cols, f"{c} must not be persisted in exon"
 
     def test_exon_required_columns(self, built_cache):
         _, _, _, tables = built_cache
@@ -889,7 +907,16 @@ class TestBuildCacheIntegration:
 
     def test_regulatory_column_count(self, built_cache):
         _, _, _, tables = built_cache
-        assert tables["regulatory"].num_columns == 31
+        assert tables["regulatory"].num_columns == 29
+
+    def test_regulatory_omits_unpersisted_columns(self, built_cache):
+        # The cache build stops at the columns something reads. The raw
+        # Storable payload and its hash are projected by no reader, and `_rn`
+        # is the dedup helper; see biodatageeks/datafusion-bio-functions#225.
+        _, _, _, tables = built_cache
+        cols = tables["regulatory"].column_names
+        for c in ("raw_object_json", "object_hash"):
+            assert c not in cols, f"{c} must not be persisted in regulatory"
 
     def test_regulatory_required_columns(self, built_cache):
         _, _, _, tables = built_cache

--- a/uv.lock
+++ b/uv.lock
@@ -1983,7 +1983,7 @@ wheels = [
 
 [[package]]
 name = "vepyr"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "polars" },


### PR DESCRIPTION
Pins the three upstream fixes for the cache-build non-determinism reported in [sitekwb/vepyr-porting-tests#387](https://github.com/sitekwb/vepyr-porting-tests/issues/387), and updates the schema docs and tests that the column change invalidates.

All upstream work is **merged**; this PR carries the merged master SHAs.

## The defects

Building the same Parquet cache twice, from the same raw cache with the same command, did not give the same bytes. Two independent causes:

- **`translation_core` was reordered** — its export query was the only one in the cache builder without an outer `ORDER BY`. `execute_stream` wraps a multi-partition plan in `CoalescePartitionsExec`, an *arrival-ordered* merge, so the shard was N internally-sorted runs concatenated in whatever order the threads finished. Measured at `partitions=8`: chr21 88% of positions moved, chr22 100% — a pure permutation (same multiset, equal once sorted).
- **`exon` picked a different source copy** — the dedup ordered only by `stable_id`, which is *identical* in the two cross-region copies of an exon whose transcript straddles a 1 Mb cache-region boundary. A complete tie, so the winner was whichever row reached the window operator first. Not merely non-deterministic: transcript and translation both break this tie explicitly, citing VEP's `merge_features` "lowest region wins". Exon was never given that rule, making it a latent correctness bug, not just a reproducibility one.

While tracing which columns the exon race could touch, it turned out `raw_object_json`/`object_hash` are read by nobody — they appear in none of the `*_CONTEXT_COLUMNS` projections and are never read by name. The exon shard was additionally leaking `_rn`, the dedup helper.

## Pins

| rev | contents |
|---|---|
| bio-formats `12016a9` | v1.12.0 + biodatageeks/datafusion-bio-formats#246 (exon dedup tie-break) |
| bio-functions `86f1c0a` | v0.19.2 + #224 (translation_core `ORDER BY` + CI step) + #225 (drop unread columns) + #226 (bio-formats pin bump) |

Both crates carry the same bio-formats rev, which is required and not incidental: `bio-function-vep` pins its own, and two revs are two distinct sources to cargo, so a mismatch compiles the formats crates twice and `CacheSourceType` fails to cross into `CacheBuilder` (E0308). `Cargo.lock` resolves to `12016a9` x4 and `86f1c0a` x1.

## Qualification

Rebuilt all three release-116 caches (ensembl, merged, refseq). Only **5 of 7 entities** needed it — `variation` (29.2 GB) and `translation_sift` (4.4 GB) use different write paths, which cut the rebuild from ~5.5 h to ~2 h. That scoping was verified, not assumed: `variation/chr22` rebuilt under the new code is **byte-identical** to the pre-change shard (388,756,098 bytes, `cmp` clean), and `translation_sift` came back byte-identical on 40/40 sampled shards.

**Cache size**, per cache (ensembl shown; refseq/merged comparable):

| entity | before | after | |
|---|---:|---:|---:|
| transcript | 659.6 M | 276.6 M | -58.1% |
| exon | 218.2 M | 128.4 M | -41.2% |
| regulatory | 74.1 M | 7.6 M | -89.7% |
| motif | 92.8 M | 28.5 M | -69.3% |
| translation_core | 272.5 M | 219.1 M | -19.6% |
| translation_sift | 4359.4 M | 4359.4 M | byte-identical |
| variation | 29171.3 M | 29171.3 M | untouched |
| **total** | **34.85 G** | **34.19 G** | **-660 MB** |

`translation_core` shrinking 19.6% was not predicted — that is the `ORDER BY` improving dictionary encoding. The determinism fix pays for itself in size.

**Determinism**: an independent rebuild of exon chr21+chr22 at `partitions=8` is **byte-identical** to the cache shard. Pre-fix, chr22 varied in roughly 1 of 8 builds (measured: 8 builds produced 2 distinct shards). Re-confirmed after re-pinning to the merged SHAs.

**Annotation parity** — HG002 WGS re-annotated against all three rebuilt caches, md5 vs the Ensembl VEP 116 references:

| profile | contigs | strict | canonical | records |
|---|---|---|---|---:|
| ensembl | 24 | PASS 24/24 | PASS 24/24 | 4,317,549 |
| refseq | 24 | PASS 24/24 | PASS 24/24 | 4,317,549 |
| merged | 22 | PASS 22/22 | PASS 22/22 | 4,096,123 |

**140/140 body digests match, zero failures.** `HEADER` shows `DIFF` on every row by design — VEP stamps run-specific provenance (`##VEP=` timestamp), which the tool hashes separately.

Two limits stated plainly rather than glossed:
- **merged is 22 contigs** because its VEP reference has no chrX/chrY records, not a partial run.
- **`merged_plugins` was not exercised** — no plugin cache is present locally for ClinVar/SpliceAI/CADD/AlphaMissense/dbNSFP — so it is excluded rather than counted as passing.

## Squash-merge verification

All three upstream PRs were squash-merged, so the revs the caches were qualified against are **not** ancestors of master and ancestry proves nothing. Content compared instead:

```
bio-formats   export_query.rs   c992f69 vs 12016a9  ->  identical
bio-functions cache/build.rs    93ba78e vs 86f1c0a  ->  identical
```

So the qualification above carries over unchanged, with no repeat of the 2-hour rebuild.

## Docs and tests

Four entity tables in `docs/caches.md` lose `raw_object_json`/`object_hash` (exon also `_rn`); column counts corrected (transcript 59 to 57, exon 16 to 13, regulatory 12 to 10, motif 17 to 15), each verified against its actual row count.

Three `*_column_count` tests failed on the new schema — real signal, asserting 78/35/31 against the actual 76/32/29. Updated, plus a new `*_omits_unpersisted_columns` test per entity that names the removed columns rather than trusting a bare count to catch a regression.

`uv run pytest`: **1174 passed, 2 skipped**.

## Merge path (complete)

1. bio-formats #246 — merged `12016a9`
2. bio-functions #224 — merged `ca3ef85`
3. bio-functions #225 — merged `213f6ff` (rebased onto #224; both add tests at the same anchor)
4. bio-functions #226 — merged `86f1c0a` (bio-formats pin bump)
5. **this PR** — re-pinned to the merged SHAs
6. `integration/387-cache-build-fixes` — deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)
