### PR TITLE
fix: give the issue form a version recipe that works, and export __version__

### DIFF
--- a/.github/ISSUE_TEMPLATE/data-problem.yml
+++ b/.github/ISSUE_TEMPLATE/data-problem.yml
@@ -104,9 +104,10 @@ body:
     attributes:
       label: vepyr tag or commit SHA
       description: >-
-        A release tag (`v0.4.0`) or the exact commit SHA you built from. Get it with
-        `python -c "import vepyr; print(vepyr.__version__)"`, or `git rev-parse HEAD`
-        for a source build.
+        A release tag (`v0.4.0`) or the exact commit SHA you built from. For an installed
+        wheel run `python -c "import importlib.metadata as m; print(m.version('vepyr'))"`;
+        for a source build run `git rev-parse HEAD` in the checkout. The `tool="vepyr ..."`
+        entry in your output VCF header carries the same version.
       placeholder: "v0.4.0  —  or  306926d4126cbaf75b0ac762a267d2e8b2b157ef"
     validations:
       required: true

--- a/src/vepyr/__init__.py
+++ b/src/vepyr/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import importlib.metadata
 import logging
 import warnings
 from collections.abc import Callable, Iterator
@@ -27,6 +28,8 @@ __all__ = [
     "supported_vep_targets",
     "cache_contig_identity",
 ]
+
+__version__ = importlib.metadata.version("vepyr")
 
 log = logging.getLogger(__name__)
 

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -15,3 +15,12 @@ def test_build_cache_importable():
 def test_annotate_importable():
     """The public vepyr.annotate function is callable."""
     assert callable(annotate)
+
+
+def test_version_matches_installed_metadata():
+    """vepyr.__version__ exists and agrees with the installed distribution."""
+    import importlib.metadata
+
+    import vepyr
+
+    assert vepyr.__version__ == importlib.metadata.version("vepyr")


### PR DESCRIPTION
## Summary

The data-problem issue form's required `vepyr-version` field told reporters to run `python -c "import vepyr; print(vepyr.__version__)"`, but the package never exported `__version__` on any release. Every reporter following the instructions hit an `AttributeError` at the first required field.

- **Issue form**: the field now gives a wheel recipe using `importlib.metadata.version("vepyr")` (works on every released wheel), keeps `git rev-parse HEAD` for source builds, and points at the `tool="vepyr ..."` entry already present in the output VCF header.
- **Package**: `vepyr.__version__` is now exported from the distribution metadata, so the attribute the form originally promised exists from this release on.
- **Test**: `test_version_matches_installed_metadata` asserts the attribute agrees with the installed metadata. It failed before the fix and passes after.

Closes sitekwb/vepyr-porting-tests#608

## Verification

AC-1 from the issue, run on this branch:

```
$ git grep -n -F 'vepyr.__version__' -- .github/ISSUE_TEMPLATE/data-problem.yml; echo "hits_exit=$?"
hits_exit=1
$ git grep -c -F 'importlib.metadata' -- .github/ISSUE_TEMPLATE/data-problem.yml
.github/ISSUE_TEMPLATE/data-problem.yml:1
$ git grep -c -F 'git rev-parse HEAD' -- .github/ISSUE_TEMPLATE/data-problem.yml
.github/ISSUE_TEMPLATE/data-problem.yml:1
```

AC-2: the replacement recipe prints the version with exit 0; `vepyr.__version__` also prints `0.4.0` on this branch. `uv run pytest tests/test_import.py` passes (4 tests), the YAML parses, and the pre-commit ruff hooks passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015TegjzEWLfopRb3zf62VxQ
