### PR TITLE
chore: bump bio-functions to the partial-cache source-type probe fix (#227)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-function-vep"
 version = "0.17.2"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=86f1c0a2a49c9a4f08dbaca42c25308b898b7542#86f1c0a2a49c9a4f08dbaca42c25308b898b7542"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=58b5650750db246270dd8bd564505fc080eb8796#58b5650750db246270dd8bd564505fc080eb8796"
 dependencies = [
  "ahash",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,11 @@ env_logger = { version = "0.11", default-features = false }
 serde_json = "1"
 
 # bio-formats 12016a9 (v1.12.0 + the exon dedup tie-break, biodatageeks/datafusion-bio-formats#246)
-# and bio-functions 86f1c0a (v0.19.2 + the translation_core ORDER BY #224, the unread-column
-# drop #225, and the bio-formats bump #226). Together these make a cache build reproducible:
+# and bio-functions 58b5650 (v0.19.2 + the translation_core ORDER BY #224, the unread-column
+# drop #225, the bio-formats bump #226, and the partial-cache source-type probe #227, which
+# reads bio.vep.cache_source_type from the first variation shard present on disk instead of
+# the manifest's first entry, so a per-contig download with whole-cache manifests annotates).
+# Together these make a cache build reproducible:
 # the exon dedup tie-break is now total, translation_core has a total output ORDER BY instead
 # of relying on CoalescePartitionsExec arrival order, and the four context entities no longer
 # persist raw_object_json / object_hash / _rn, which no reader projects.
@@ -61,6 +64,6 @@ serde_json = "1"
 # two different revs are two different sources to cargo, so a mismatch compiles
 # the formats crates twice and `CacheSourceType` / the VCF writer types then fail
 # to cross into `CacheBuilder` (E0308).
-datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "86f1c0a2a49c9a4f08dbaca42c25308b898b7542", features = ["cache-builder"] }
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "58b5650750db246270dd8bd564505fc080eb8796", features = ["cache-builder"] }
 datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "12016a9304d3a14e4d56d9459f3bd6f1cb678d02" }
 datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "12016a9304d3a14e4d56d9459f3bd6f1cb678d02" }

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import inspect
 import json
 import os
+import shutil
 import sys
 import threading
 import warnings
@@ -44,6 +45,9 @@ def partial_cache_dir(metadata_cache_dir, tmp_path_factory):
     ``chrom_manifest.json`` files describe the whole cache. The entries
     prepended here name contigs that have no shard on disk, and the first of
     them is what a manifest-position probe would try to open.
+
+    Shards are copied, not symlinked: Windows needs Developer Mode or elevated
+    privileges for symlinks, and the suite runs there.
     """
     source = Path(metadata_cache_dir)
     target = tmp_path_factory.mktemp("partial_cache")
@@ -55,7 +59,7 @@ def partial_cache_dir(metadata_cache_dir, tmp_path_factory):
         out = target / entity_dir.name
         out.mkdir()
         for shard in entity_dir.glob("*.parquet"):
-            (out / shard.name).symlink_to(shard)
+            shutil.copy2(shard, out / shard.name)
         entries = json.loads((entity_dir / "chrom_manifest.json").read_text())
         (out / "chrom_manifest.json").write_text(json.dumps(absent + entries, indent=2))
     return str(target)
@@ -108,8 +112,9 @@ class TestPartialCache:
 
         cache = tmp_path / "no_manifest"
         (cache / "variation").mkdir(parents=True)
-        (cache / "variation" / "chr1.parquet").symlink_to(
-            Path(metadata_cache_dir) / "variation" / "chr1.parquet"
+        shutil.copy2(
+            Path(metadata_cache_dir) / "variation" / "chr1.parquet",
+            cache / "variation" / "chr1.parquet",
         )
         with pytest.raises(RuntimeError, match="chrom_manifest.json"):
             vepyr.annotate(

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -35,6 +35,91 @@ def metadata_cache_dir(skip_if_no_cache, tmp_path_factory):
     return str(copy_cache_with_source_metadata(CACHE_DIR, target, "ensembl", "115"))
 
 
+@pytest.fixture(scope="module")
+def partial_cache_dir(metadata_cache_dir, tmp_path_factory):
+    """A per-contig download: every shard on disk, manifests listing more.
+
+    Mirrors ``snapshot_download(allow_patterns=["*/chr1.parquet",
+    "*/chrom_manifest.json"])`` against a published cache, whose
+    ``chrom_manifest.json`` files describe the whole cache. The entries
+    prepended here name contigs that have no shard on disk, and the first of
+    them is what a manifest-position probe would try to open.
+    """
+    source = Path(metadata_cache_dir)
+    target = tmp_path_factory.mktemp("partial_cache")
+    absent = [
+        {"chrom": chrom, "dataset": f"{chrom}.parquet", "rows": 1}
+        for chrom in ("chr21", "chr22")
+    ]
+    for entity_dir in sorted(d for d in source.iterdir() if d.is_dir()):
+        out = target / entity_dir.name
+        out.mkdir()
+        for shard in entity_dir.glob("*.parquet"):
+            (out / shard.name).symlink_to(shard)
+        entries = json.loads((entity_dir / "chrom_manifest.json").read_text())
+        (out / "chrom_manifest.json").write_text(json.dumps(absent + entries, indent=2))
+    return str(target)
+
+
+class TestPartialCache:
+    """A cache whose shards are a subset of its manifests must annotate what it has.
+
+    Regression test for sitekwb/vepyr-porting-tests#607: the engine used to read
+    ``bio.vep.cache_source_type`` off the manifest's first shard unconditionally,
+    so a partial download failed with ``failed to open Parquet cache shard
+    '.../variation/chr21.parquet'`` before touching a requested contig.
+    """
+
+    def test_manifest_lists_more_than_is_on_disk(self, partial_cache_dir):
+        variation = Path(partial_cache_dir) / "variation"
+        entries = json.loads((variation / "chrom_manifest.json").read_text())
+        assert [e["chrom"] for e in entries] == ["chr21", "chr22", "chr1"]
+        assert not (variation / entries[0]["dataset"]).exists()
+        assert (variation / "chr1.parquet").is_file()
+
+    def test_annotates_the_contigs_it_has(self, partial_cache_dir, metadata_cache_dir):
+        import vepyr
+
+        def run(cache_dir):
+            return vepyr.annotate(
+                INPUT_VCF,
+                cache_dir,
+                everything=True,
+                reference_fasta=REFERENCE_FASTA,
+            ).collect()
+
+        partial = run(partial_cache_dir)
+        intact = run(metadata_cache_dir)
+        assert partial.height > 0
+        assert partial.height == intact.height
+        assert partial.select("chrom", "start", "most_severe_consequence").equals(
+            intact.select("chrom", "start", "most_severe_consequence")
+        )
+
+    def test_cache_without_manifest_still_fails_on_the_manifest(
+        self, metadata_cache_dir, tmp_path
+    ):
+        """What the old dataset-card recipe produced: a shard and no manifest.
+
+        Not repaired by the shard-selection fix, and must not be: without a
+        manifest there is no partitioned cache to open.
+        """
+        import vepyr
+
+        cache = tmp_path / "no_manifest"
+        (cache / "variation").mkdir(parents=True)
+        (cache / "variation" / "chr1.parquet").symlink_to(
+            Path(metadata_cache_dir) / "variation" / "chr1.parquet"
+        )
+        with pytest.raises(RuntimeError, match="chrom_manifest.json"):
+            vepyr.annotate(
+                INPUT_VCF,
+                str(cache),
+                everything=True,
+                reference_fasta=REFERENCE_FASTA,
+            ).collect()
+
+
 class TestAnnotate:
     """Test the streaming annotation pipeline."""
 

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -125,6 +125,132 @@ class TestPartialCache:
             ).collect()
 
 
+@pytest.fixture(scope="module")
+def demo_plugin_cache(metadata_cache_dir, tmp_path_factory):
+    """A one-plugin cache built in-process against the golden variation shard.
+
+    Two rows keyed to golden input variants, so the ``DEMO`` field is populated
+    for them and the run is distinguishable from one that ignored the plugin.
+    """
+    from tests.test_build_plugin_cache import _init_full_repo
+
+    import vepyr
+
+    root = tmp_path_factory.mktemp("demo_plugin")
+    repo = _init_full_repo(root)
+    source = root / "demo.tsv"
+    source.write_text("1\t604358\tG\tC\t0.5\n1\t604360\tT\tC\t0.25\n")
+    plugin_root = root / "pc"
+    built = vepyr.build_plugin_cache(
+        "demo",
+        "v0.1.0",
+        source_path=str(source),
+        cache_dir=metadata_cache_dir,
+        plugin_cache_root=str(plugin_root),
+        plugins_repo=str(repo),
+        chroms=["1"],
+    )
+    assert built == [("chr1", 2, 0, 2)]
+    return str(plugin_root)
+
+
+@pytest.fixture(scope="module")
+def partial_plugin_cache(demo_plugin_cache, tmp_path_factory):
+    """The plugin-cache analogue of ``partial_cache_dir``: ``manifest.json``
+    lists contigs whose shards were never downloaded, ahead of the one that was.
+    """
+    source = Path(demo_plugin_cache) / "plugin" / "demo"
+    target = tmp_path_factory.mktemp("partial_plugin") / "plugin" / "demo"
+    target.mkdir(parents=True)
+    shutil.copy2(source / "chr1.parquet", target / "chr1.parquet")
+    manifest = json.loads((source / "manifest.json").read_text())
+    absent = [
+        {"chrom": chrom, "file": f"{chrom}.parquet", "rows": 1, "warm": 0, "cold": 1}
+        for chrom in ("chr21", "chr22")
+    ]
+    manifest["chroms"] = absent + manifest["chroms"]
+    (target / "manifest.json").write_text(json.dumps(manifest, indent=2))
+    return str(target.parents[1])
+
+
+class TestPartialPluginCache:
+    """A plugin cache with a subset of its manifest's shards annotates what it has.
+
+    Companion to ``TestPartialCache``: the plugin registry is opened per contig
+    and reads the CSQ header from ``manifest.json`` without touching a shard, so
+    a per-chromosome plugin download works without trimming the manifest. The
+    one deliberate exception is a requested contig the manifest says has rows
+    but whose shard is absent, which fails loudly rather than emitting nulls
+    under a header that still advertises the plugin's fields.
+    """
+
+    @staticmethod
+    def _records(path: Path) -> tuple[str, list[str]]:
+        lines = path.read_text().splitlines()
+        csq_header = next(line for line in lines if line.startswith("##INFO=<ID=CSQ"))
+        return csq_header, [line for line in lines if not line.startswith("#")]
+
+    def test_plugin_manifest_lists_more_than_is_on_disk(self, partial_plugin_cache):
+        plugin_dir = Path(partial_plugin_cache) / "plugin" / "demo"
+        manifest = json.loads((plugin_dir / "manifest.json").read_text())
+        assert [c["chrom"] for c in manifest["chroms"]] == ["chr21", "chr22", "chr1"]
+        assert not (plugin_dir / manifest["chroms"][0]["file"]).exists()
+        assert (plugin_dir / "chr1.parquet").is_file()
+
+    def test_annotates_the_contigs_it_has(
+        self,
+        partial_cache_dir,
+        partial_plugin_cache,
+        metadata_cache_dir,
+        demo_plugin_cache,
+        tmp_path,
+    ):
+        import vepyr
+
+        def run(cache_dir, plugin_root, name):
+            out = tmp_path / f"{name}.vcf"
+            vepyr.annotate(
+                INPUT_VCF,
+                cache_dir,
+                output_vcf=str(out),
+                reference_fasta=REFERENCE_FASTA,
+                skip_csq=False,
+                plugin_cache_root=plugin_root,
+                plugins=["demo"],
+            )
+            return self._records(out)
+
+        partial_header, partial = run(
+            partial_cache_dir, partial_plugin_cache, "partial"
+        )
+        intact_header, intact = run(metadata_cache_dir, demo_plugin_cache, "intact")
+        assert "DEMO" in partial_header
+        assert partial_header == intact_header
+        assert len(partial) > 0
+        assert partial == intact
+        assert any("604358" in line and "|0.5" in line for line in partial)
+
+    def test_listed_contig_with_missing_shard_fails_loudly(
+        self, demo_plugin_cache, metadata_cache_dir, tmp_path
+    ):
+        import vepyr
+
+        source = Path(demo_plugin_cache) / "plugin" / "demo"
+        broken = tmp_path / "broken" / "plugin" / "demo"
+        broken.mkdir(parents=True)
+        shutil.copy2(source / "manifest.json", broken / "manifest.json")
+        with pytest.raises(RuntimeError, match="shard is missing"):
+            vepyr.annotate(
+                INPUT_VCF,
+                metadata_cache_dir,
+                output_vcf=str(tmp_path / "out.vcf"),
+                reference_fasta=REFERENCE_FASTA,
+                skip_csq=False,
+                plugin_cache_root=str(tmp_path / "broken"),
+                plugins=["demo"],
+            )
+
+
 class TestAnnotate:
     """Test the streaming annotation pipeline."""
 


### PR DESCRIPTION
Bumps `datafusion-bio-function-vep` from 86f1c0a to 58b5650, which is master after biodatageeks/datafusion-bio-functions#227. The bio-formats pin (12016a9) is unchanged; the engine at 58b5650 pins the same rev, so the two stay on one source.

## What the bump fixes

sitekwb/vepyr-porting-tests#607: a per-contig download of a published cache keeps the whole-cache `chrom_manifest.json` (463 contigs, `chr1` first) next to only the fetched shards. The engine read `bio.vep.cache_source_type` off the manifest's first shard unconditionally, so every `annotate()` failed with `failed to open Parquet cache shard '<cache>/variation/chr1.parquet'` before touching a requested contig. #227 reads it from the first listed shard that is present on disk. A cache with no manifest still fails on the manifest, as before.

The three HF dataset cards were corrected on 2026-09-03 to repeat `--include` per pattern and fetch `*/chrom_manifest.json`; `docs/downloads.md` already documented the correct form.

## Verification

Against a symlink tree of the local 116 ensembl cache holding chr21+chr22 shards for all seven entities and the untrimmed 463-entry manifests, with the issue's `probe_arms.py` and `input.vcf` (132 chr21 records):

| check | result |
|---|---|
| five option sets (`{}`, `check_existing`, `expected_cache_version="116"`, both, `skip_csq`) | all `OK records=132` |
| records vs the issue's trimmed-manifest control `vepyr-output-OK.trimmed.vcf` | identical, header excluded |
| no-manifest layout (single `variation/chr21.parquet`, what the old card recipe produced) | still fails: `failed to read .../variation/chrom_manifest.json` |
| `uv run pytest` | 1175 passed, 2 skipped |

Same tree, same probe against the previous pin (86f1c0a): all five arms fail with the `chr1.parquet` open error, verbatim as reported.

## Regression test

`tests/test_annotate.py::TestPartialCache` builds a partial cache from the golden fixture (chr1 shards symlinked, `chr21`/`chr22` prepended to every manifest with no shard on disk) and asserts it annotates the same rows as the intact cache; a control asserts a shard-without-manifest cache still fails on the manifest. Verified both ways by rebuilding the extension: on 86f1c0a the annotation test fails with `failed to open Parquet cache shard '.../variation/chr21.parquet'`, on 58b5650 it passes. Full suite: 1178 passed, 2 skipped.

## Partial plugin cache

`tests/test_annotate.py::TestPartialPluginCache` covers the plugin-cache analogue. The engine's `PluginRegistry` is opened per contig and reads the CSQ header from `manifest.json` without opening a shard, so a per-chromosome plugin download already works; this is coverage, not a fix. The fixture builds the demo plugin in-process against the golden variation shard, then derives a plugin cache whose `manifest.json` lists `chr21`/`chr22` ahead of the on-disk `chr1` shard, and asserts byte-identical output to the intact plugin cache. A control asserts the registry's deliberate failure (manifest lists rows for a requested contig, shard absent) still raises. Verified the same way against the real ClinVar and AlphaMissense caches with only their `chr21` shards: identical records to the full caches at workers=1 and workers=2. Full suite: 1181 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvnLNnNN9myYRaBoTrTNUY
