### PR TITLE
feat: record plugin cache source revisions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-function-vep"
 version = "0.17.2"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=58b5650750db246270dd8bd564505fc080eb8796#58b5650750db246270dd8bd564505fc080eb8796"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=e8132dba5bbb321e8f14f235ad8405f24c01d1e3#e8132dba5bbb321e8f14f235ad8405f24c01d1e3"
 dependencies = [
  "ahash",
  "async-trait",
@@ -1264,7 +1264,9 @@ dependencies = [
  "indicatif",
  "libc",
  "log",
+ "md-5",
  "nohash-hasher",
+ "noodles-bgzf 0.49.0",
  "noodles-core 0.16.0",
  "noodles-core 0.20.0",
  "noodles-csi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-function-vep"
 version = "0.17.2"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=e8132dba5bbb321e8f14f235ad8405f24c01d1e3#e8132dba5bbb321e8f14f235ad8405f24c01d1e3"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=dc191d078e2c89a91686527440013954217926e0#dc191d078e2c89a91686527440013954217926e0"
 dependencies = [
  "ahash",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-function-vep"
 version = "0.17.2"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=dc191d078e2c89a91686527440013954217926e0#dc191d078e2c89a91686527440013954217926e0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=27894825a9940370c3f8d4aae24fd2b24014ae7c#27894825a9940370c3f8d4aae24fd2b24014ae7c"
 dependencies = [
  "ahash",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-function-vep"
 version = "0.17.2"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=27894825a9940370c3f8d4aae24fd2b24014ae7c#27894825a9940370c3f8d4aae24fd2b24014ae7c"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=5f1df0840e49bd2c86e1b28ed2c47d5a19e8dd47#5f1df0840e49bd2c86e1b28ed2c47d5a19e8dd47"
 dependencies = [
  "ahash",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,6 @@ serde_json = "1"
 # two different revs are two different sources to cargo, so a mismatch compiles
 # the formats crates twice and `CacheSourceType` / the VCF writer types then fail
 # to cross into `CacheBuilder` (E0308).
-datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "58b5650750db246270dd8bd564505fc080eb8796", features = ["cache-builder"] }
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "e8132dba5bbb321e8f14f235ad8405f24c01d1e3", features = ["cache-builder"] }
 datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "12016a9304d3a14e4d56d9459f3bd6f1cb678d02" }
 datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "12016a9304d3a14e4d56d9459f3bd6f1cb678d02" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,6 @@ serde_json = "1"
 # two different revs are two different sources to cargo, so a mismatch compiles
 # the formats crates twice and `CacheSourceType` / the VCF writer types then fail
 # to cross into `CacheBuilder` (E0308).
-datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "dc191d078e2c89a91686527440013954217926e0", features = ["cache-builder"] }
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "27894825a9940370c3f8d4aae24fd2b24014ae7c", features = ["cache-builder"] }
 datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "12016a9304d3a14e4d56d9459f3bd6f1cb678d02" }
 datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "12016a9304d3a14e4d56d9459f3bd6f1cb678d02" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,6 @@ serde_json = "1"
 # two different revs are two different sources to cargo, so a mismatch compiles
 # the formats crates twice and `CacheSourceType` / the VCF writer types then fail
 # to cross into `CacheBuilder` (E0308).
-datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "27894825a9940370c3f8d4aae24fd2b24014ae7c", features = ["cache-builder"] }
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "5f1df0840e49bd2c86e1b28ed2c47d5a19e8dd47", features = ["cache-builder"] }
 datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "12016a9304d3a14e4d56d9459f3bd6f1cb678d02" }
 datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "12016a9304d3a14e4d56d9459f3bd6f1cb678d02" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,6 @@ serde_json = "1"
 # two different revs are two different sources to cargo, so a mismatch compiles
 # the formats crates twice and `CacheSourceType` / the VCF writer types then fail
 # to cross into `CacheBuilder` (E0308).
-datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "e8132dba5bbb321e8f14f235ad8405f24c01d1e3", features = ["cache-builder"] }
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "dc191d078e2c89a91686527440013954217926e0", features = ["cache-builder"] }
 datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "12016a9304d3a14e4d56d9459f3bd6f1cb678d02" }
 datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "12016a9304d3a14e4d56d9459f3bd6f1cb678d02" }

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -45,7 +45,11 @@ versions (e.g. AlphaMissense `v0.2.0` + ClinVar `v0.3.0`), call
 
 The manifest is resolved from the public vepyr-plugins repo at `version`
 (cloned on demand), or from a local clone via `plugins_repo` for fully offline
-builds. Tiering (warm/cold) is **inherited from the variation cache** at
+builds. The exact resolution is recorded in the cache's `manifest.json` as
+`cache_source_version: "<version>@<commit SHA>"`. An incremental build may add
+or replace chromosomes only when that value matches the existing cache; use a
+full build with `overwrite=True` to move a plugin cache to another revision.
+Tiering (warm/cold) is **inherited from the variation cache** at
 `cache_dir` — plugins declare no tier policy of their own.
 
 ## Annotating with plugins
@@ -524,7 +528,9 @@ A plugin cache is a set of per-chromosome Parquet shards
 (`plugin/<name>/chr*.parquet`) plus a `manifest.json`. The shards use the same
 point-lookup-optimized layout as the Ensembl variation cache, so a lookup reads
 only the handful of pages that could contain the queried positions — never the
-whole file.
+whole file. `manifest.json` records the requested plugin ref and its exact
+resolved commit in `cache_source_version`, making cache provenance immutable and
+auditable even when the requested ref is a branch.
 
 ### Shard schema
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,7 +311,8 @@ fn apply_source_paths(
 }
 
 #[pyfunction]
-#[pyo3(signature = (manifest_path, source_path, variation_cache_dir, plugin_cache_root, chroms=None, overwrite=false))]
+#[pyo3(signature = (manifest_path, source_path, variation_cache_dir, plugin_cache_root, chroms=None, overwrite=false, source_version=None))]
+#[allow(clippy::too_many_arguments)]
 fn build_plugin_cache(
     py: Python<'_>,
     manifest_path: &str,
@@ -320,6 +321,7 @@ fn build_plugin_cache(
     plugin_cache_root: &str,
     chroms: Option<Vec<String>>,
     overwrite: bool,
+    source_version: Option<String>,
 ) -> PyResult<Vec<(String, usize, usize, usize)>> {
     let mut manifest = SourceManifest::load(std::path::Path::new(manifest_path))
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("load manifest: {e}")))?;
@@ -380,6 +382,9 @@ fn build_plugin_cache(
                 plugin_cache_root,
             )
             .with_overwrite(overwrite);
+            if let Some(source_version) = source_version {
+                b = b.with_source_version(source_version);
+            }
             if let Some(cs) = chroms {
                 b = b.with_chrom_filter(cs);
             }

--- a/src/vepyr/__init__.py
+++ b/src/vepyr/__init__.py
@@ -636,6 +636,36 @@ def _resolve_plugin_manifest(
         if created_clone:
             repo = tempfile.mkdtemp(prefix="vepyr-plugins-")
             subprocess.run(["git", "clone", "--quiet", repo_url, repo], check=True)
+        resolved_ref = subprocess.run(
+            [
+                "git",
+                "-C",
+                repo,
+                "rev-parse",
+                "--verify",
+                "--quiet",
+                f"{version}^{{commit}}",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if resolved_ref.returncode != 0:
+            resolved_ref = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    repo,
+                    "rev-parse",
+                    "--verify",
+                    "--quiet",
+                    f"origin/{version}^{{commit}}",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        resolved_commit = resolved_ref.stdout.strip()
         worktree = tempfile.mkdtemp(prefix="vepyr-plugins-wt-")
         subprocess.run(
             [
@@ -647,7 +677,7 @@ def _resolve_plugin_manifest(
                 "--quiet",
                 "--detach",
                 worktree,
-                version,
+                resolved_commit,
             ],
             check=True,
         )
@@ -655,12 +685,6 @@ def _resolve_plugin_manifest(
         manifest = os.path.join(worktree, rel)
         if not os.path.exists(manifest):
             raise FileNotFoundError(f"{rel} not found at {version} in {repo}")
-        resolved_commit = subprocess.run(
-            ["git", "-C", worktree, "rev-parse", "HEAD"],
-            check=True,
-            capture_output=True,
-            text=True,
-        ).stdout.strip()
         yield manifest, resolved_commit
     finally:
         # Remove the worktree (deletes the dir AND its registration in `repo`);

--- a/src/vepyr/__init__.py
+++ b/src/vepyr/__init__.py
@@ -608,16 +608,18 @@ def _resolve_plugin_manifest(
     *,
     plugins_repo: str | None = None,
     repo_url: str = DEFAULT_PLUGINS_REPO_URL,
-) -> Iterator[str]:
+) -> Iterator[tuple[str, str]]:
     """Resolve ``plugins/<plugin>/<plugin>.source.toml`` at git tag ``version``.
 
     Offline: reuse a provided local clone (``plugins_repo``). Online: clone the
     public repo into a temp dir. Either way, materialize the file at ``version``
     via ``git worktree`` (never disturbs the caller's checkout).
 
-    A context manager: the temp clone (online only) and the worktree — including
-    its registration in the source repo's ``.git/worktrees/`` — are removed on
-    exit, so repeated builds don't leak ``/tmp`` clones or stale worktree entries.
+    Yields the manifest path and the immutable commit SHA to which ``version``
+    resolved. A context manager: the temp clone (online only) and the worktree —
+    including its registration in the source repo's ``.git/worktrees/`` — are
+    removed on exit, so repeated builds don't leak ``/tmp`` clones or stale
+    worktree entries.
     """
     import os
     import shutil
@@ -653,7 +655,13 @@ def _resolve_plugin_manifest(
         manifest = os.path.join(worktree, rel)
         if not os.path.exists(manifest):
             raise FileNotFoundError(f"{rel} not found at {version} in {repo}")
-        yield manifest
+        resolved_commit = subprocess.run(
+            ["git", "-C", worktree, "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        yield manifest, resolved_commit
     finally:
         # Remove the worktree (deletes the dir AND its registration in `repo`);
         # `rmtree` is a belt-and-suspenders cleanup if `worktree remove` failed
@@ -702,10 +710,15 @@ def build_plugin_cache(
 
     The sources are registered as ``plugin_<name>_src_<part>`` and combined by the
     manifest's own ``ingest_sql`` -- there is no need to concatenate them first.
+
+    The cache manifest records the source as ``<version>@<commit SHA>``. This
+    keeps mutable refs auditable and prevents an incremental build from mixing
+    chromosomes produced from different manifest revisions.
     """
-    with _resolve_plugin_manifest(
-        plugin, version, plugins_repo=plugins_repo
-    ) as manifest_path:
+    with _resolve_plugin_manifest(plugin, version, plugins_repo=plugins_repo) as (
+        manifest_path,
+        resolved_commit,
+    ):
         return _build_plugin_cache(
             manifest_path,
             source_path,
@@ -713,6 +726,7 @@ def build_plugin_cache(
             plugin_cache_root,
             chroms,
             overwrite,
+            f"{version}@{resolved_commit}",
         )
 
 

--- a/src/vepyr/_core.pyi
+++ b/src/vepyr/_core.pyi
@@ -46,11 +46,13 @@ def build_plugin_cache(
     plugin_cache_root: str,
     chroms: list[str] | None = None,
     overwrite: bool = False,
+    source_version: str | None = None,
 ) -> list[tuple[str, int, int, int]]:
     """Build a plugin cache from a source manifest. Returns (chrom, rows, warm, cold).
 
     ``source_path`` is a path for a single-source manifest, or ``{part: path}``
     for a manifest declaring several ``[[source]]`` entries.
+    ``source_version`` is recorded in ``manifest.json`` when provided.
     """
     ...
 

--- a/tests/test_build_plugin_cache.py
+++ b/tests/test_build_plugin_cache.py
@@ -138,6 +138,66 @@ def test_resolve_manifest_offline_checks_out_tag(tmp_path):
     assert str(worktree) not in listed
 
 
+def test_resolve_manifest_accepts_remote_only_branch(tmp_path):
+    source = _init_plugins_repo(tmp_path)
+    default_branch = subprocess.run(
+        ["git", "-C", str(source), "branch", "--show-current"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    subprocess.run(
+        ["git", "-C", str(source), "switch", "-qc", "feature-manifest"],
+        check=True,
+    )
+    manifest = source / "plugins" / "demo" / "demo.source.toml"
+    manifest.write_text('plugin_name = "feature-demo"\n')
+    subprocess.run(["git", "-C", str(source), "add", str(manifest)], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(source),
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "commit",
+            "-qm",
+            "feature",
+        ],
+        check=True,
+    )
+    expected_commit = subprocess.run(
+        ["git", "-C", str(source), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    subprocess.run(
+        ["git", "-C", str(source), "switch", "-q", default_branch], check=True
+    )
+
+    clone = tmp_path / "fresh-clone"
+    subprocess.run(
+        ["git", "clone", "--quiet", "--no-local", str(source), str(clone)],
+        check=True,
+    )
+    local_branches = subprocess.run(
+        ["git", "-C", str(clone), "branch", "--format=%(refname:short)"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.splitlines()
+    assert "feature-manifest" not in local_branches
+
+    with vepyr._resolve_plugin_manifest(
+        "demo", "feature-manifest", plugins_repo=str(clone)
+    ) as (path, resolved_commit):
+        assert Path(path).read_text() == 'plugin_name = "feature-demo"\n'
+        assert resolved_commit == expected_commit
+
+
 def test_build_records_requested_ref_and_resolved_commit(monkeypatch, tmp_path):
     repo = _init_full_repo(tmp_path)
     expected_commit = subprocess.run(

--- a/tests/test_build_plugin_cache.py
+++ b/tests/test_build_plugin_cache.py
@@ -109,12 +109,20 @@ def _init_plugins_repo(root: Path) -> Path:
 
 def test_resolve_manifest_offline_checks_out_tag(tmp_path):
     repo = _init_plugins_repo(tmp_path)
-    with vepyr._resolve_plugin_manifest(
-        "demo", "v0.1.0", plugins_repo=str(repo)
-    ) as path:
+    expected_commit = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "v0.1.0^{commit}"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    with vepyr._resolve_plugin_manifest("demo", "v0.1.0", plugins_repo=str(repo)) as (
+        path,
+        resolved_commit,
+    ):
         assert (
             Path(path).read_text().strip() == 'plugin_name = "demo"'
         )  # the tagged version
+        assert resolved_commit == expected_commit
         worktree = Path(path).parents[2]  # <worktree>/plugins/demo/demo.source.toml
         assert worktree.exists()
     # On exit the worktree is removed and its registration in the caller's repo
@@ -128,6 +136,34 @@ def test_resolve_manifest_offline_checks_out_tag(tmp_path):
         check=True,
     ).stdout
     assert str(worktree) not in listed
+
+
+def test_build_records_requested_ref_and_resolved_commit(monkeypatch, tmp_path):
+    repo = _init_full_repo(tmp_path)
+    expected_commit = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "v0.1.0^{commit}"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    captured: dict[str, object] = {}
+
+    def fake_build_plugin_cache(*args):
+        captured["args"] = args
+        return []
+
+    monkeypatch.setattr(vepyr, "_build_plugin_cache", fake_build_plugin_cache)
+    result = vepyr.build_plugin_cache(
+        "demo",
+        "v0.1.0",
+        source_path="source.tsv.gz",
+        cache_dir="cache",
+        plugin_cache_root="plugin-cache",
+        plugins_repo=str(repo),
+    )
+
+    assert result == []
+    assert captured["args"][-1] == f"v0.1.0@{expected_commit}"
 
 
 def test_plugin_cache_root_reaches_options(monkeypatch, tmp_path):


### PR DESCRIPTION
Closes #70.

Records each requested plugin ref together with its resolved immutable commit SHA, forwards that provenance through the PyO3 boundary, and refuses mixed-revision incremental cache updates in the upstream builder. Full overwrite rebuilds may advance revisions.

Depends on biodatageeks/datafusion-bio-functions#231.

Validation:
- 1182 pytest tests passed, 2 skipped
- 18 plugin-cache tests passed
- cargo clippy --no-default-features --all-targets -- -D warnings
- cargo fmt --check