### PR TITLE
feat: add plugin-only core field annotation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-function-vep"
 version = "0.17.2"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=90ed9b0371b7bdac02b8a1c46bb82d593b1424c4#90ed9b0371b7bdac02b8a1c46bb82d593b1424c4"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=afff39e0aaae293d2a1b6c6005e279e6e54bcca6#afff39e0aaae293d2a1b6c6005e279e6e54bcca6"
 dependencies = [
  "ahash",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-function-vep"
 version = "0.17.2"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=9157c950ce8191dacbb6982679c405cc2aa5bc8c#9157c950ce8191dacbb6982679c405cc2aa5bc8c"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=a0298dd122cb98310b2da3294fba700e8238ed91#a0298dd122cb98310b2da3294fba700e8238ed91"
 dependencies = [
  "ahash",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-function-vep"
 version = "0.17.2"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=a0298dd122cb98310b2da3294fba700e8238ed91#a0298dd122cb98310b2da3294fba700e8238ed91"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=90ed9b0371b7bdac02b8a1c46bb82d593b1424c4#90ed9b0371b7bdac02b8a1c46bb82d593b1424c4"
 dependencies = [
  "ahash",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,6 @@ serde_json = "1"
 # two different revs are two different sources to cargo, so a mismatch compiles
 # the formats crates twice and `CacheSourceType` / the VCF writer types then fail
 # to cross into `CacheBuilder` (E0308).
-datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "9157c950ce8191dacbb6982679c405cc2aa5bc8c", features = ["cache-builder"] }
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "a0298dd122cb98310b2da3294fba700e8238ed91", features = ["cache-builder"] }
 datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "12016a9304d3a14e4d56d9459f3bd6f1cb678d02" }
 datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "12016a9304d3a14e4d56d9459f3bd6f1cb678d02" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,6 @@ serde_json = "1"
 # two different revs are two different sources to cargo, so a mismatch compiles
 # the formats crates twice and `CacheSourceType` / the VCF writer types then fail
 # to cross into `CacheBuilder` (E0308).
-datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "90ed9b0371b7bdac02b8a1c46bb82d593b1424c4", features = ["cache-builder"] }
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "afff39e0aaae293d2a1b6c6005e279e6e54bcca6", features = ["cache-builder"] }
 datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "12016a9304d3a14e4d56d9459f3bd6f1cb678d02" }
 datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "12016a9304d3a14e4d56d9459f3bd6f1cb678d02" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,6 @@ serde_json = "1"
 # two different revs are two different sources to cargo, so a mismatch compiles
 # the formats crates twice and `CacheSourceType` / the VCF writer types then fail
 # to cross into `CacheBuilder` (E0308).
-datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "a0298dd122cb98310b2da3294fba700e8238ed91", features = ["cache-builder"] }
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "90ed9b0371b7bdac02b8a1c46bb82d593b1424c4", features = ["cache-builder"] }
 datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "12016a9304d3a14e4d56d9459f3bd6f1cb678d02" }
 datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "12016a9304d3a14e4d56d9459f3bd6f1cb678d02" }

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -82,9 +82,10 @@ result = vepyr.annotate(
 
 VCF output records the exact ordered layout in the `CSQ` `Format:` header. On
 the DataFrame path, the selected base fields retain their existing named
-columns and each plugin field (for example `CADD_PHRED` and `CADD_RAW`) is a
-named `List(String)` column. The raw `CSQ` string is still available with
-`skip_csq=False`, but is not required to access plugin values.
+columns, unselected annotation columns are omitted, and each plugin field (for
+example `CADD_PHRED` and `CADD_RAW`) is a named `List(String)` column. The raw
+`CSQ` string is still available with `skip_csq=False`, but is not required to
+access plugin values.
 
 An explicit list or tuple may be used instead of `"core"`; its order is
 preserved. Fields needed by plugin match templates are still computed even

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -65,24 +65,31 @@ vepyr.annotate(
 )
 ```
 
-!!! warning "In a LazyFrame, plugin values hide inside `CSQ`"
-    Plugin fields are appended to the `CSQ` field, after the base fields, in
-    caller-supplied `plugins` order, or alphabetical plugin-name order when
-    `plugins=None`. Writing a VCF gives you a header naming
-    them. A `LazyFrame` has no header, and its default `skip_csq=True` drops
-    the `CSQ` column outright — so plugins are applied and then silently
-    discarded.
+### Plugin-only annotation
 
-    Pass `skip_csq=False` to keep them. The values are correct and identical
-    to the VCF path, but unnamed — you have to count positions yourself, and
-    the base field count varies (74–86, by cache type and `everything`), so
-    the offsets are not fixed. A CADD-only subset on a **merged** cache at
-    default flags appends `CADD_PHRED` then `CADD_RAW` at positions 80 and 81
-    of an 81-field `CSQ`; with `everything=True` the same two land at 87 and
-    88. Plugin values are not broken out as DataFrame columns.
+Pass `fields="core"` to emit VEP's eleven VCF-side default fields followed by
+the selected plugin blocks:
 
-    Passing [`plugins`](#choosing-which-plugins-run) without `output_vcf` and
-    with `skip_csq` left at its default warns for this reason.
+```python
+result = vepyr.annotate(
+    "sample.vcf",
+    "/data/116_GRCh38_merged",
+    fields="core",
+    plugin_cache_root="/data/plugin_cache",
+    plugins=["cadd"],
+)
+```
+
+VCF output records the exact ordered layout in the `CSQ` `Format:` header. On
+the DataFrame path, the selected base fields retain their existing named
+columns and each plugin field (for example `CADD_PHRED` and `CADD_RAW`) is a
+named `List(String)` column. The raw `CSQ` string is still available with
+`skip_csq=False`, but is not required to access plugin values.
+
+An explicit list or tuple may be used instead of `"core"`; its order is
+preserved. Fields needed by plugin match templates are still computed even
+when they are not emitted. With `fields=None` the full legacy CSQ layout and
+DataFrame schema remain unchanged.
 
 ### Choosing which plugins run
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -198,6 +198,20 @@ df = vepyr.annotate(
 ).collect()
 ```
 
+To use vepyr as a lightweight plugin annotator, select VEP's core VCF fields.
+Plugin outputs become named DataFrame columns, so keeping the raw `CSQ` string
+is optional:
+
+```python
+df = vepyr.annotate(
+    "input.vcf.gz",
+    "/data/vepyr_cache/parquet/116_GRCh38_ensembl",
+    fields="core",
+    plugin_cache_root="/data/plugin_cache",
+    plugins=["cadd", "spliceai"],
+).collect()
+```
+
 ### Writing annotated VCF output
 
 Write results directly to a VCF file instead of returning a LazyFrame:

--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -315,6 +315,26 @@ pub fn annotate_to_vcf_file(
             ));
         }
     };
+    config.fields = match opts.get("fields") {
+        None => None,
+        Some(Value::Array(values)) => Some(
+            values
+                .iter()
+                .map(|value| {
+                    value.as_str().map(String::from).ok_or_else(|| {
+                        pyo3::exceptions::PyValueError::new_err(
+                            "fields must be an array of strings",
+                        )
+                    })
+                })
+                .collect::<PyResult<Vec<_>>>()?,
+        ),
+        Some(_) => {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "fields must be an array of strings",
+            ));
+        }
+    };
     // Recorded as a `tool` attribute in the output header's provenance
     // lines. The header key itself is fixed by the engine.
     config.provenance_tool_name = Some(env!("CARGO_PKG_NAME").to_string());

--- a/src/vepyr/__init__.py
+++ b/src/vepyr/__init__.py
@@ -895,7 +895,8 @@ def annotate(
         Ordered base CSQ fields to emit, mirroring VEP ``--fields``. ``"core"``
         selects VEP's eleven VCF-side default output fields. A list or tuple
         preserves its supplied order. Plugin fields are always appended after
-        the selected base block. ``None`` (default) keeps the full layout.
+        the selected base block. On the DataFrame path, unselected annotation
+        columns are omitted. ``None`` (default) keeps the full layout.
     plugin_cache_root : str or None
         Root of a plugin cache tree built by :func:`build_plugin_cache`, e.g.
         ``"/data/plugin_cache"`` holding ``plugin/<name>/`` directories. Every
@@ -1290,6 +1291,32 @@ def annotate(
     pa_schema = probe.schema
     empty = pa.table({field.name: pa.array([], type=field.type) for field in pa_schema})
     polars_schema = dict(pl.from_arrow(empty).schema)
+    selected_dataframe_columns: list[str] | None = None
+    if selected_fields is not None:
+        schema_names = list(polars_schema)
+        try:
+            annotation_start = schema_names.index("most_severe_consequence")
+        except ValueError as exc:
+            raise RuntimeError(
+                "annotation schema is missing most_severe_consequence"
+            ) from exc
+        missing_columns = [
+            name for name in selected_fields if name not in polars_schema
+        ]
+        if missing_columns:
+            raise ValueError(
+                "selected CSQ fields have no named DataFrame column: "
+                + ", ".join(missing_columns)
+            )
+        selected_dataframe_columns = [
+            name
+            for name in schema_names[: annotation_start + 1]
+            if not (skip_csq and name == "CSQ")
+        ]
+        selected_dataframe_columns.extend(selected_fields)
+        polars_schema = {
+            name: polars_schema[name] for name in selected_dataframe_columns
+        }
     if plugin_field_names:
         for name in plugin_field_names:
             if name in polars_schema:
@@ -1298,7 +1325,7 @@ def annotate(
                 )
             polars_schema[name] = pl.List(pl.String)
         if skip_csq:
-            del polars_schema["CSQ"]
+            polars_schema.pop("CSQ", None)
     del probe
 
     # Each collect() creates a fresh streaming annotator so the LazyFrame
@@ -1338,6 +1365,10 @@ def annotate(
                 )
                 if skip_csq:
                     batch_df = batch_df.drop("CSQ")
+            if selected_dataframe_columns is not None:
+                batch_df = batch_df.select(
+                    [*selected_dataframe_columns, *plugin_field_names]
+                )
             if predicate is not None:
                 batch_df = batch_df.filter(predicate)
             if with_columns is not None:

--- a/src/vepyr/__init__.py
+++ b/src/vepyr/__init__.py
@@ -1253,6 +1253,10 @@ def annotate(
         import os
 
         plugin_root = os.path.join(plugin_cache_root, "plugin")
+        if not os.path.isdir(plugin_root):
+            raise FileNotFoundError(
+                f"No plugin directory under plugin_cache_root: {plugin_root}"
+            )
         manifests = []
         for directory_name in sorted(os.listdir(plugin_root)):
             manifest_path = os.path.join(plugin_root, directory_name, "manifest.json")
@@ -1300,8 +1304,9 @@ def annotate(
             raise RuntimeError(
                 "annotation schema is missing most_severe_consequence"
             ) from exc
+        annotation_schema_names = set(schema_names[annotation_start + 1 :])
         missing_columns = [
-            name for name in selected_fields if name not in polars_schema
+            name for name in selected_fields if name not in annotation_schema_names
         ]
         if missing_columns:
             raise ValueError(
@@ -1363,8 +1368,6 @@ def annotate(
                     .alias(name)
                     for index, name in enumerate(plugin_field_names)
                 )
-                if skip_csq:
-                    batch_df = batch_df.drop("CSQ")
             if selected_dataframe_columns is not None:
                 batch_df = batch_df.select(
                     [*selected_dataframe_columns, *plugin_field_names]

--- a/src/vepyr/__init__.py
+++ b/src/vepyr/__init__.py
@@ -31,6 +31,20 @@ __version__ = importlib.metadata.version("vepyr")
 
 log = logging.getLogger(__name__)
 
+_CORE_CSQ_FIELDS = (
+    "Allele",
+    "Gene",
+    "Feature",
+    "Feature_type",
+    "Consequence",
+    "cDNA_position",
+    "CDS_position",
+    "Protein_position",
+    "Amino_acids",
+    "Codons",
+    "Existing_variation",
+)
+
 # Ensembl FTP URL templates for VEP cache tarballs.
 # {method_infix} is "" for Ensembl, "_merged" for merged, "_refseq" for RefSeq.
 # Release >=115 uses indexed_vep_cache/, older releases use vep/.
@@ -759,6 +773,7 @@ def annotate(
     cache_size_mb: int = 1024,
     workers: int = 1,
     skip_csq: bool = True,
+    fields: str | list[str] | tuple[str, ...] | None = None,
     # Custom plugin caches
     plugin_cache_root: str | None = None,
     plugins: list[str] | tuple[str, ...] | None = None,
@@ -876,6 +891,11 @@ def annotate(
     skip_csq : bool
         Exclude the raw CSQ column from the output (default: True).
         When True, only the parsed annotation columns are returned.
+    fields : {"core"}, list or tuple of str, or None
+        Ordered base CSQ fields to emit, mirroring VEP ``--fields``. ``"core"``
+        selects VEP's eleven VCF-side default output fields. A list or tuple
+        preserves its supplied order. Plugin fields are always appended after
+        the selected base block. ``None`` (default) keeps the full layout.
     plugin_cache_root : str or None
         Root of a plugin cache tree built by :func:`build_plugin_cache`, e.g.
         ``"/data/plugin_cache"`` holding ``plugin/<name>/`` directories. Every
@@ -885,9 +905,9 @@ def annotate(
         chosen here. ``None`` (default) applies no plugins and is
         byte-identical to a plugin-free run.
 
-        Plugin values are appended to the ``CSQ`` field. With ``output_vcf``
-        the header names them; in a ``LazyFrame`` they are only inside the
-        ``CSQ`` string, which the default ``skip_csq=True`` drops.
+        Plugin values are appended to the ``CSQ`` field. With ``fields`` set,
+        a ``LazyFrame`` also exposes each plugin field as a named list column,
+        including when ``skip_csq=True``.
     plugins : list or tuple of str, or None
         Restrict annotation to these plugin names, a subset of the directories
         under ``<plugin_cache_root>/plugin/``. ``None`` (default) applies every
@@ -965,6 +985,26 @@ def annotate(
     ... )
     """
     import json
+
+    if fields == "core":
+        selected_fields = list(_CORE_CSQ_FIELDS)
+    elif isinstance(fields, str):
+        raise ValueError("fields must be 'core', an ordered list or tuple, or None")
+    elif fields is None:
+        selected_fields = None
+    elif not isinstance(fields, (list, tuple)):
+        raise TypeError("fields must be 'core', an ordered list or tuple, or None")
+    else:
+        if not fields:
+            raise ValueError("fields must contain at least one base CSQ field")
+        for name in fields:
+            if not isinstance(name, str):
+                raise TypeError(
+                    f"field names must be strings, got {type(name).__name__}"
+                )
+        if len(set(fields)) != len(fields):
+            raise ValueError("fields must not contain duplicate names")
+        selected_fields = list(fields)
 
     # Validate reference_fasta requirement
     if (everything or hgvs or hgvsc or hgvsp) and not reference_fasta:
@@ -1061,6 +1101,8 @@ def annotate(
         # Single annotation-concurrency knob: N within-contig fused pipelines.
         # Requires a tabix-indexed (bgzip+.tbi) input VCF.
         opts["workers"] = workers
+    if selected_fields is not None:
+        opts["fields"] = selected_fields
     if plugins is not None:
         if plugin_cache_root is None:
             raise ValueError("plugins requires plugin_cache_root")
@@ -1092,7 +1134,7 @@ def annotate(
                     f"Unknown plugin {unknown[0]!r} in {source_root}. "
                     f"Available: {', '.join(available) or '(none)'}"
                 )
-            if output_vcf is None and skip_csq:
+            if output_vcf is None and skip_csq and selected_fields is None:
                 # Plugin values reach a LazyFrame only inside the CSQ string,
                 # which `skip_csq=True` (the default) drops — so the plugins
                 # would be built and then silently discarded. The VCF path is
@@ -1205,26 +1247,67 @@ def annotate(
     import polars as pl
     import pyarrow as pa
 
+    plugin_field_names: list[str] = []
+    if selected_fields is not None and plugin_cache_root is not None and plugins != []:
+        import os
+
+        plugin_root = os.path.join(plugin_cache_root, "plugin")
+        manifests = []
+        for directory_name in sorted(os.listdir(plugin_root)):
+            manifest_path = os.path.join(plugin_root, directory_name, "manifest.json")
+            if not os.path.isfile(manifest_path):
+                continue
+            with open(manifest_path, encoding="utf-8") as handle:
+                manifest = json.load(handle)
+            plugin_name = manifest.get("plugin_name", directory_name)
+            manifests.append((plugin_name, manifest))
+        manifests.sort(key=lambda item: item[0])
+        by_name = {name: manifest for name, manifest in manifests}
+        ordered_names = list(plugins) if plugins is not None else sorted(by_name)
+        for plugin_name in ordered_names:
+            manifest = by_name[plugin_name]
+            value_columns = manifest.get("value_columns", [])
+            if manifest.get("field_order", "declared") == "alphabetical":
+                value_columns = sorted(
+                    value_columns, key=lambda column: column["csq_field"]
+                )
+            plugin_field_names.extend(column["csq_field"] for column in value_columns)
+        if len(set(plugin_field_names)) != len(plugin_field_names):
+            raise ValueError(
+                "selected plugins expose duplicate CSQ field names, which cannot be "
+                "represented as distinct DataFrame columns"
+            )
+
     # Get schema from a probe annotator (doesn't consume data).
+    engine_skip_csq = skip_csq and not plugin_field_names
     probe = _create_annotator(
         vcf,
         cache_dir,
         options_json,
-        skip_csq,
+        engine_skip_csq,
         None,
     )
     pa_schema = probe.schema
     empty = pa.table({field.name: pa.array([], type=field.type) for field in pa_schema})
     polars_schema = dict(pl.from_arrow(empty).schema)
+    if plugin_field_names:
+        for name in plugin_field_names:
+            if name in polars_schema:
+                raise ValueError(
+                    f"plugin CSQ field {name!r} conflicts with an existing DataFrame column"
+                )
+            polars_schema[name] = pl.List(pl.String)
+        if skip_csq:
+            del polars_schema["CSQ"]
     del probe
 
     # Each collect() creates a fresh streaming annotator so the LazyFrame
     # is re-runnable (not single-use). Captures vcf/cache_dir/options by value.
-    _vcf, _cache_dir, _opts, _skip = (
+    _vcf, _cache_dir, _opts, _engine_skip = (
         vcf,
         cache_dir,
         options_json,
-        skip_csq,
+        engine_skip_csq,
     )
 
     def _batch_source(with_columns, predicate, n_rows, batch_size):
@@ -1233,12 +1316,28 @@ def annotate(
             _vcf,
             _cache_dir,
             _opts,
-            _skip,
+            _engine_skip,
             n_rows,
         )
         remaining = n_rows
         for py_batch in annotator:
             batch_df = pl.from_arrow(py_batch)
+            if plugin_field_names:
+                first_plugin_index = len(selected_fields)
+                batch_df = batch_df.with_columns(
+                    pl.col("CSQ")
+                    .str.split(",")
+                    .list.eval(
+                        pl.element()
+                        .str.split("|")
+                        .list.get(first_plugin_index + index, null_on_oob=True)
+                        .replace("", None)
+                    )
+                    .alias(name)
+                    for index, name in enumerate(plugin_field_names)
+                )
+                if skip_csq:
+                    batch_df = batch_df.drop("CSQ")
             if predicate is not None:
                 batch_df = batch_df.filter(predicate)
             if with_columns is not None:

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -1045,6 +1045,36 @@ def test_annotate_rejects_invalid_field_selections(fields, error, message):
         vepyr.annotate("in.vcf", CACHE_DIR, fields=fields)
 
 
+def test_selected_fields_must_be_annotation_columns(monkeypatch):
+    import pyarrow as pa
+    import vepyr
+
+    class FakeAnnotator:
+        schema = pa.schema(
+            [
+                pa.field("chrom", pa.string()),
+                pa.field("most_severe_consequence", pa.string()),
+                pa.field("Allele", pa.string()),
+            ]
+        )
+
+    monkeypatch.setattr(vepyr, "_create_annotator", lambda *args: FakeAnnotator())
+    with pytest.raises(ValueError, match="no named DataFrame column"):
+        vepyr.annotate("in.vcf", CACHE_DIR, fields=["most_severe_consequence"])
+
+
+def test_selected_fields_with_plugin_root_require_plugin_directory(tmp_path):
+    import vepyr
+
+    with pytest.raises(FileNotFoundError, match="No plugin directory"):
+        vepyr.annotate(
+            "in.vcf",
+            CACHE_DIR,
+            fields="core",
+            plugin_cache_root=str(tmp_path / "not-built-yet"),
+        )
+
+
 def test_selected_plugin_fields_are_named_dataframe_columns(tmp_path, monkeypatch):
     import pyarrow as pa
     import vepyr

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -942,9 +942,7 @@ def test_annotate_plugins_rejects_unknown_name_with_available_plugins(tmp_path):
 
     root = _fake_plugin_root(tmp_path, ["cadd", "clinvar"])
     with pytest.raises(ValueError, match="Unknown plugin 'nope'") as exc:
-        vepyr.annotate(
-            "in.vcf", CACHE_DIR, plugin_cache_root=root, plugins=["nope"]
-        )
+        vepyr.annotate("in.vcf", CACHE_DIR, plugin_cache_root=root, plugins=["nope"])
     assert "Available: cadd, clinvar" in str(exc.value)
 
 
@@ -961,6 +959,126 @@ def test_annotate_plugins_is_accepted_in_signature():
     params = inspect.signature(vepyr.annotate).parameters
     assert "plugins" in params
     assert params["plugins"].default is None
+
+
+def test_annotate_core_fields_expand_in_vep_order(monkeypatch):
+    import vepyr
+
+    seen = {}
+
+    def fake(vcf, cache_dir, options_json, skip_csq, limit):
+        seen["opts"] = json.loads(options_json)
+        raise _Stop()
+
+    monkeypatch.setattr(vepyr, "_create_annotator", fake)
+    with pytest.raises(_Stop):
+        vepyr.annotate("in.vcf", CACHE_DIR, fields="core")
+
+    assert seen["opts"]["fields"] == [
+        "Allele",
+        "Gene",
+        "Feature",
+        "Feature_type",
+        "Consequence",
+        "cDNA_position",
+        "CDS_position",
+        "Protein_position",
+        "Amino_acids",
+        "Codons",
+        "Existing_variation",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("fields", "error", "message"),
+    [
+        ("all", ValueError, "must be 'core'"),
+        ({"Gene"}, TypeError, "ordered list or tuple"),
+        ([], ValueError, "at least one"),
+        (["Gene", "Gene"], ValueError, "duplicate"),
+        (["Gene", 1], TypeError, "must be strings"),
+    ],
+)
+def test_annotate_rejects_invalid_field_selections(fields, error, message):
+    import vepyr
+
+    with pytest.raises(error, match=message):
+        vepyr.annotate("in.vcf", CACHE_DIR, fields=fields)
+
+
+def test_selected_plugin_fields_are_named_dataframe_columns(tmp_path, monkeypatch):
+    import pyarrow as pa
+    import vepyr
+
+    root = Path(_fake_plugin_root(tmp_path, ["cadd"]))
+    (root / "plugin" / "cadd" / "manifest.json").write_text(
+        json.dumps(
+            {
+                "plugin_name": "cadd",
+                "field_order": "declared",
+                "value_columns": [
+                    {"column": "phred", "csq_field": "CADD_PHRED"},
+                    {"column": "raw", "csq_field": "CADD_RAW"},
+                ],
+            }
+        )
+    )
+    core_values = [
+        "G",
+        "ENSG1",
+        "ENST1",
+        "Transcript",
+        "missense_variant",
+        "10",
+        "7",
+        "3",
+        "A/T",
+        "Gcc/Acc",
+        "rs1",
+    ]
+    schema = pa.schema(
+        [
+            pa.field("chrom", pa.string()),
+            pa.field("CSQ", pa.string()),
+            pa.field("Allele", pa.string()),
+        ]
+    )
+
+    class FakeAnnotator:
+        def __init__(self):
+            self.schema = schema
+
+        def __iter__(self):
+            yield pa.record_batch(
+                [
+                    pa.array(["1"]),
+                    pa.array(["|".join([*core_values, "24.5", "0.12"])]),
+                    pa.array(["G"]),
+                ],
+                schema=schema,
+            )
+
+    calls = []
+
+    def fake(vcf, cache_dir, options_json, skip_csq, limit):
+        calls.append((json.loads(options_json), skip_csq, limit))
+        return FakeAnnotator()
+
+    monkeypatch.setattr(vepyr, "_create_annotator", fake)
+    result = vepyr.annotate(
+        "in.vcf",
+        CACHE_DIR,
+        fields="core",
+        plugin_cache_root=str(root),
+        plugins=["cadd"],
+        skip_csq=True,
+    ).collect()
+
+    assert calls[0][0]["fields"] == list(vepyr._CORE_CSQ_FIELDS)
+    assert calls[0][1] is False, "CSQ is retained internally for plugin projection"
+    assert "CSQ" not in result.columns
+    assert result["CADD_PHRED"].to_list() == [["24.5"]]
+    assert result["CADD_RAW"].to_list() == [["0.12"]]
 
 
 def test_annotate_empty_plugins_is_plugin_free_without_cache_validation(

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -197,6 +197,45 @@ class TestPartialPluginCache:
         assert not (plugin_dir / manifest["chroms"][0]["file"]).exists()
         assert (plugin_dir / "chr1.parquet").is_file()
 
+    def test_core_fields_align_vcf_and_named_dataframe_plugin_output(
+        self, demo_plugin_cache, metadata_cache_dir, tmp_path
+    ):
+        import vepyr
+
+        output = tmp_path / "core-plugin.vcf"
+        vepyr.annotate(
+            INPUT_VCF,
+            metadata_cache_dir,
+            fields="core",
+            plugin_cache_root=demo_plugin_cache,
+            plugins=["demo"],
+            output_vcf=str(output),
+            show_progress=False,
+        )
+        header = next(
+            line
+            for line in output.read_text().splitlines()
+            if line.startswith("##INFO=<ID=CSQ")
+        )
+        assert header.endswith(
+            "Format: Allele|Gene|Feature|Feature_type|Consequence|cDNA_position|"
+            "CDS_position|Protein_position|Amino_acids|Codons|Existing_variation|"
+            'DEMO">'
+        )
+
+        frame = vepyr.annotate(
+            INPUT_VCF,
+            metadata_cache_dir,
+            fields="core",
+            plugin_cache_root=demo_plugin_cache,
+            plugins=["demo"],
+        ).collect()
+        assert "DEMO" in frame.columns
+        assert "DISTANCE" not in frame.columns
+        assert any(
+            value is not None for values in frame["DEMO"].to_list() for value in values
+        )
+
     def test_annotates_the_contigs_it_has(
         self,
         partial_cache_dir,
@@ -1040,7 +1079,9 @@ def test_selected_plugin_fields_are_named_dataframe_columns(tmp_path, monkeypatc
         [
             pa.field("chrom", pa.string()),
             pa.field("CSQ", pa.string()),
-            pa.field("Allele", pa.string()),
+            pa.field("most_severe_consequence", pa.string()),
+            *(pa.field(name, pa.string()) for name in vepyr._CORE_CSQ_FIELDS),
+            pa.field("DISTANCE", pa.string()),
         ]
     )
 
@@ -1053,7 +1094,9 @@ def test_selected_plugin_fields_are_named_dataframe_columns(tmp_path, monkeypatc
                 [
                     pa.array(["1"]),
                     pa.array(["|".join([*core_values, "24.5", "0.12"])]),
-                    pa.array(["G"]),
+                    pa.array(["missense_variant"]),
+                    *(pa.array([value]) for value in core_values),
+                    pa.array(["100"]),
                 ],
                 schema=schema,
             )
@@ -1077,6 +1120,12 @@ def test_selected_plugin_fields_are_named_dataframe_columns(tmp_path, monkeypatc
     assert calls[0][0]["fields"] == list(vepyr._CORE_CSQ_FIELDS)
     assert calls[0][1] is False, "CSQ is retained internally for plugin projection"
     assert "CSQ" not in result.columns
+    assert "DISTANCE" not in result.columns
+    assert result.columns[-13:] == [
+        *vepyr._CORE_CSQ_FIELDS,
+        "CADD_PHRED",
+        "CADD_RAW",
+    ]
     assert result["CADD_PHRED"].to_list() == [["24.5"]]
     assert result["CADD_RAW"].to_list() == [["0.12"]]
 


### PR DESCRIPTION
Closes #72.

Depends on biodatageeks/datafusion-bio-functions#233 and #74.

Adds `fields="core"` and ordered explicit field selections to both VCF and DataFrame annotation. The VCF header/body share the selected layout, plugin fields remain a trailing ordered block, and DataFrames expose only the selected named annotation columns plus named plugin list columns. The engine keeps match-template dependencies available while skipping unselected expensive work and writes the core layout directly.

Validation:
- 1,186 pytest tests passed (2 skipped)
- full engine suite: 1,040 unit tests passed (1 ignored), plus 3 plugin and 4 VCF integration tests
- Rust clippy/fmt and Python Ruff pass
- actual golden VCF/plugin integration verifies the exact header/body layout and named DataFrame plugin output

Release benchmark (Apple arm64, 10,000 repeated golden variants, one demo plugin, 8 alternating runs after warm-up): default median 0.9683 s vs core 0.7464 s (22.9% faster); plain VCF 175,345,115 vs 83,997,833 bytes (52.1% smaller); retained DataFrame size 288,396,304 vs 67,240,550 bytes (76.7% smaller).