### PR TITLE
chore: bump bio-functions to the probe-key shard order fix (#237)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-function-vep"
 version = "0.17.2"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=6476619ed2562bdec5f065ad78b471f3d84d67aa#6476619ed2562bdec5f065ad78b471f3d84d67aa"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=b145bc6e3f4b4e757fe2d1e8fd8a5bd5e8e944ff#b145bc6e3f4b4e757fe2d1e8fd8a5bd5e8e944ff"
 dependencies = [
  "ahash",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,10 @@ log = "0.4"
 env_logger = { version = "0.11", default-features = false }
 serde_json = "1"
 
+# bio-functions b145bc6 (#237): the plugin-cache tier ORDER BY is the probe key
+# (tier, start, allele_string, match cols) instead of every column, which is what let the
+# full-source SpliceAI chr1/chr2 shards build at the default 8 GiB pool (bio-functions#235).
+#
 # bio-formats 12016a9 (v1.12.0 + the exon dedup tie-break, biodatageeks/datafusion-bio-formats#246)
 # and bio-functions 6476619 (v0.19.2 + the translation_core ORDER BY #224, the unread-column
 # drop #225, the bio-formats bump #226, the partial-cache source-type probe #227, which
@@ -69,6 +73,6 @@ serde_json = "1"
 # two different revs are two different sources to cargo, so a mismatch compiles
 # the formats crates twice and `CacheSourceType` / the VCF writer types then fail
 # to cross into `CacheBuilder` (E0308).
-datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "6476619ed2562bdec5f065ad78b471f3d84d67aa", features = ["cache-builder"] }
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "b145bc6e3f4b4e757fe2d1e8fd8a5bd5e8e944ff", features = ["cache-builder"] }
 datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "12016a9304d3a14e4d56d9459f3bd6f1cb678d02" }
 datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "12016a9304d3a14e4d56d9459f3bd6f1cb678d02" }


### PR DESCRIPTION
## Summary

Pins `datafusion-bio-function-vep` at `b145bc6`, engine master after biodatageeks/datafusion-bio-functions#237: the plugin-cache tier join orders shards by the probe key `(tier, start, allele_string, <match columns>)` instead of every normalized column. bio-formats stays at `12016a9`, the rev the engine pins.

## Why

With the 15-column key (#230) the external sort of a 300M-row SpliceAI chromosome starved its own merge reservations under DataFusion's `FairSpillPool` at any pool size (bio-functions#235); DataFusion 55 does not fix it either (the multi-level merge frees the transferred headroom on retry). With the probe key the full-source builds go through the hash-join plan at the default 8 GiB pool with no fallback.

## Built with this pin (default pool, no env overrides, strict source verification)

| plugin | contigs | rows | wall | pool peak |
|---|--:|--:|--:|--:|
| SpliceAI | 25 (chrMT 0 rows) | 3,393,685,728 | 94 min | chr1 5.65 GB |
| CADD (snv + indel) | 25 (chrMT 0 rows) | 8,918,413,601 | 85 min | — |

chr22 SpliceAI rebuilt with this engine is byte-identical (md5 `cc3d4ca1…`) to the published v0.1.1 shard, so the narrow key is order-neutral on valid input. Both caches are published under `biodatageeks/vepyr_116_GRCh38_plugin_{spliceai,cadd}` at tag `v0.1.1`.

## Verification

`uv sync` / `maturin develop --release` against the pin; `tests/test_import.py` and the comparison suite pass. The chr22 merged-plugins parity gate was run earlier today on the same variation cache with the previous pin and should be re-run before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLfjgNUteh2LdbDTALwQUR
