### PR TITLE
fix(comparison): fall back to the whole-genome plugin reference

### DIFF
--- a/e2e-testing/scripts/comparison/profiles.py
+++ b/e2e-testing/scripts/comparison/profiles.py
@@ -273,7 +273,7 @@ def vep_per_contig_vcf_for(profile_name, release, chrom):
     profile = PROFILES[profile_name]
     if not profile.vep_per_contig:
         return None
-    bare = str(chrom)[3:] if str(chrom).startswith("chr") else str(chrom)
+    bare = str(chrom).removeprefix("chr")
     return _first_existing(
         os.path.join(
             data_dir(),
@@ -294,13 +294,18 @@ def vep_vcf_for(profile_name, release, chrom=None):
     """
     profile = PROFILES[profile_name]
     if profile.vep_per_contig:
+        # Prefer the per-contig file; fall back to a whole-genome reference of
+        # the same basename (a full VEP run with the plugins), which the
+        # comparison restricts to the requested contig like any WGS reference.
         if chrom is not None:
-            return vep_per_contig_vcf_for(profile_name, release, chrom)
-        for candidate_chrom in range(1, 23):
-            found = vep_per_contig_vcf_for(profile_name, release, candidate_chrom)
+            found = vep_per_contig_vcf_for(profile_name, release, chrom)
             if found:
                 return found
-        return None
+        else:
+            for candidate_chrom in range(1, 23):
+                found = vep_per_contig_vcf_for(profile_name, release, candidate_chrom)
+                if found:
+                    return found
     return _first_existing(
         os.path.join(data_dir(), "output", RELEASE_DIRS[release], profile.vep_basename)
     )

--- a/e2e-testing/scripts/comparison/profiles.py
+++ b/e2e-testing/scripts/comparison/profiles.py
@@ -374,14 +374,24 @@ def resolve(
         # but only when a reference is actually needed. Modes that just
         # aggregate stored reports need none, and must not be blocked by the
         # absence of something they never read.
-        if require_reference:
+        # A whole-genome reference of the same basename (a full VEP run with
+        # the plugins) serves a multi-contig run directly when it exists.
+        wgs = _first_existing(
+            os.path.join(
+                data_dir(), "output", RELEASE_DIRS[release], profile.vep_basename
+            )
+        )
+        if wgs:
+            resolved_ref = wgs
+        elif require_reference:
             raise ProfileUnavailable(
                 f"profile {profile_name!r} uses per-contig references "
                 f"({profile.vep_per_contig.format(chrom='N')}.vcf.gz under "
                 f"output/{RELEASE_DIRS[release]}/{profile.vep_subdir}/). "
                 "Request a single contig with --chroms, or pass --vep explicitly."
             )
-        resolved_ref = None
+        else:
+            resolved_ref = None
     else:
         resolved_ref = vep_vcf_for(profile_name, release, chrom)
     resolved_plugin_cache = None

--- a/tests/test_comparison_profiles.py
+++ b/tests/test_comparison_profiles.py
@@ -1,5 +1,4 @@
 import pytest
-
 from comparison import profiles
 
 
@@ -250,13 +249,16 @@ def test_explicit_plugin_cache_override_skips_derivation(tmp_path, monkeypatch):
     assert resolved.annotate_kwargs["plugin_cache_root"] == str(custom)
 
 
-def test_plugin_profile_without_a_contig_explains_the_per_contig_layout():
+def test_plugin_profile_without_a_contig_explains_the_per_contig_layout(
+    monkeypatch, tmp_path
+):
     """Plugin references are one file per contig, so there is nothing to slice.
 
     Previously the profile declared a single WGS basename that the generator
     never writes, so the documented command reported the profile "unavailable"
     even with every generated reference present.
     """
+    monkeypatch.setenv("DATA_VEPYR_DIR", str(tmp_path))
     with pytest.raises(profiles.ProfileUnavailable) as excinfo:
         profiles.resolve("merged_plugins", "116")
 
@@ -295,3 +297,16 @@ def test_plugin_profile_without_a_contig_is_allowed_when_no_reference_is_needed(
     )
 
     assert resolved.vep_vcf is None
+
+
+def test_plugin_profile_without_a_contig_uses_a_whole_genome_reference(
+    monkeypatch, tmp_path
+):
+    """A full VEP run with the plugins serves a multi-contig comparison directly."""
+    monkeypatch.setenv("DATA_VEPYR_DIR", str(tmp_path))
+    out = tmp_path / "output" / "116"
+    out.mkdir(parents=True)
+    wgs = out / (profiles.PROFILES["merged_plugins"].vep_basename + ".vcf.gz")
+    wgs.write_bytes(b"")
+    resolved = profiles.resolve("merged_plugins", "116", require_cache=False)
+    assert resolved.vep_vcf == str(wgs)


### PR DESCRIPTION
Plugin profiles are `vep_per_contig`, so `vep_vcf_for` only looked for `<basename>_chr<N>.vcf[.gz]` and reported the five-plugin whole-genome reference under `output/<release>/` as missing. Now the per-contig file is preferred and the WGS one is returned otherwise; the comparison restricts a WGS reference to the requested contig like any other profile. `tests/test_comparison_profiles.py`: 27 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLfjgNUteh2LdbDTALwQUR