### PR TITLE
feat(annotate): let a LazyFrame select() decide the annotation flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-function-vep"
 version = "0.17.2"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=4e1446b34fb6bf456b8f5c8190fb678141cc2433#4e1446b34fb6bf456b8f5c8190fb678141cc2433"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=44f5954be973075402f2a6080cb228acb6ce262c#44f5954be973075402f2a6080cb228acb6ce262c"
 dependencies = [
  "ahash",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-function-vep"
 version = "0.17.2"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=b145bc6e3f4b4e757fe2d1e8fd8a5bd5e8e944ff#b145bc6e3f4b4e757fe2d1e8fd8a5bd5e8e944ff"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=4e1446b34fb6bf456b8f5c8190fb678141cc2433#4e1446b34fb6bf456b8f5c8190fb678141cc2433"
 dependencies = [
  "ahash",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ log = "0.4"
 env_logger = { version = "0.11", default-features = false }
 serde_json = "1"
 
+# bio-functions 4e1446b (#238): typed motif columns are per-consequence lists and
+# SWISSPROT/TREMBL typed values use `&` like the CSQ string; supersedes
 # bio-functions b145bc6 (#237): the plugin-cache tier ORDER BY is the probe key
 # (tier, start, allele_string, match cols) instead of every column, which is what let the
 # full-source SpliceAI chr1/chr2 shards build at the default 8 GiB pool (bio-functions#235).
@@ -73,6 +75,6 @@ serde_json = "1"
 # two different revs are two different sources to cargo, so a mismatch compiles
 # the formats crates twice and `CacheSourceType` / the VCF writer types then fail
 # to cross into `CacheBuilder` (E0308).
-datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "b145bc6e3f4b4e757fe2d1e8fd8a5bd5e8e944ff", features = ["cache-builder"] }
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "4e1446b34fb6bf456b8f5c8190fb678141cc2433", features = ["cache-builder"] }
 datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "12016a9304d3a14e4d56d9459f3bd6f1cb678d02" }
 datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "12016a9304d3a14e4d56d9459f3bd6f1cb678d02" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ log = "0.4"
 env_logger = { version = "0.11", default-features = false }
 serde_json = "1"
 
-# bio-functions 4e1446b (#238): typed motif columns are per-consequence lists and
+# bio-functions 44f5954 (#238): typed motif columns are per-consequence lists and
 # SWISSPROT/TREMBL typed values use `&` like the CSQ string; supersedes
 # bio-functions b145bc6 (#237): the plugin-cache tier ORDER BY is the probe key
 # (tier, start, allele_string, match cols) instead of every column, which is what let the
@@ -75,6 +75,6 @@ serde_json = "1"
 # two different revs are two different sources to cargo, so a mismatch compiles
 # the formats crates twice and `CacheSourceType` / the VCF writer types then fail
 # to cross into `CacheBuilder` (E0308).
-datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "4e1446b34fb6bf456b8f5c8190fb678141cc2433", features = ["cache-builder"] }
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "44f5954be973075402f2a6080cb228acb6ce262c", features = ["cache-builder"] }
 datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "12016a9304d3a14e4d56d9459f3bd6f1cb678d02" }
 datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", rev = "12016a9304d3a14e4d56d9459f3bd6f1cb678d02" }

--- a/docs/dataframes.md
+++ b/docs/dataframes.md
@@ -344,6 +344,102 @@ any_stream = df.filter(
 any_high = df.filter(pl.col("IMPACT").list.contains("HIGH"))
 ```
 
+## Plugins
+
+Point the frame at a plugin cache and the plugin fields are columns like any
+other; see [Plugin columns](#plugin-columns) for how their shape and type are
+decided. All examples below use the four published caches:
+
+```python
+lf = vepyr.annotate(
+    "input.vcf.gz", cache, reference_fasta="GRCh38.fa",
+    plugin_cache_root="/data/plugin_cache",
+    plugins=["cadd", "clinvar", "spliceai", "alphamissense"],
+)
+```
+
+**CADD** is per variant, and its scores are strings so the VCF keeps the
+source digits. Cast, then filter:
+
+```python
+high_cadd = (
+    lf.select("chrom", "start", "ref", "alt", "SYMBOL", "CADD_PHRED")
+      .with_columns(pl.col("CADD_PHRED").cast(pl.Float32))
+      .filter(pl.col("CADD_PHRED") >= 20)
+      .collect()
+)
+```
+
+**ClinVar** is per variant too, so its fields are plain string columns.
+`ClinVar` holds the variation id, and the assertion fields keep VEP's `&`
+joins, so match with a pattern:
+
+```python
+clinvar = (
+    lf.select("chrom", "start", "ref", "alt", "ClinVar", "ClinVar_CLNSIG", "ClinVar_CLNREVSTAT")
+      .filter(pl.col("ClinVar_CLNSIG").str.contains("(?i)pathogenic"))
+      .collect()
+)
+```
+
+**SpliceAI** is matched by gene symbol, so every field is a list aligned with
+`Consequence`. The delta scores are strings in the cache; cast the lists and
+take the largest score across the variant's entries:
+
+```python
+DS = ["SpliceAI_pred_DS_AG", "SpliceAI_pred_DS_AL", "SpliceAI_pred_DS_DG", "SpliceAI_pred_DS_DL"]
+
+splice = (
+    lf.select("chrom", "start", "ref", "alt", "SpliceAI_pred_SYMBOL", *DS)
+      .with_columns(pl.col(DS).cast(pl.List(pl.Float32)))
+      .with_columns(pl.max_horizontal(pl.col(DS).list.max()).alias("spliceai_max_ds"))
+      .filter(pl.col("spliceai_max_ds") >= 0.5)
+      .collect()
+)
+```
+
+**AlphaMissense** is matched by protein change, so `am_class` and
+`am_pathogenicity` (already `List(Float32)`) belong to the consequence entry
+that produced the change. Explode them together with the transcript columns
+to see which transcript each score refers to:
+
+```python
+am = (
+    lf.select("chrom", "start", "ref", "alt", "Feature", "Protein_position",
+              "Amino_acids", "am_class", "am_pathogenicity")
+      .filter(pl.col("am_class").list.contains("likely_pathogenic"))
+      .explode(["Feature", "Protein_position", "Amino_acids", "am_class", "am_pathogenicity"])
+      .filter(pl.col("am_class") == "likely_pathogenic")
+      .collect()
+)
+```
+
+Plugin columns combine freely with the base annotation, and the projection
+still decides what runs. This query runs the co-located lookup for
+`gnomADg_AF` and the CADD lookup, and nothing else:
+
+```python
+candidates = (
+    lf.select("chrom", "start", "ref", "alt", "SYMBOL", "Consequence", "gnomADg_AF", "CADD_PHRED")
+      .with_columns(pl.col("CADD_PHRED").cast(pl.Float32))
+      .filter(
+          pl.any_horizontal(pl.col("gnomADg_AF").is_null(), pl.col("gnomADg_AF") < 0.001)
+          & (pl.col("CADD_PHRED") >= 25)
+      )
+      .collect()
+)
+```
+
+The [`consequence_rows`](#one-row-per-consequence) helper works unchanged on
+a frame with plugins: per-feature plugin lists explode alongside the
+transcript columns, per-variant scalars such as `CADD_PHRED` repeat on each
+row, like the frequencies do.
+
+A query that reads no plugin column skips the plugin lookup entirely. On
+chr22 with the four caches, `select(chrom, start, SYMBOL)` takes 1.2 s and
+`select(chrom, start, CADD_PHRED)` 8.4 s, so keep plugin columns out of
+queries that do not need them.
+
 ## Writing results to disk
 
 `collect()` holds the whole result in memory. On chromosome 1 of a

--- a/docs/dataframes.md
+++ b/docs/dataframes.md
@@ -162,6 +162,10 @@ type come from the plugin's manifest, not from the CSQ text it travels in:
   exactly, which is why `CADD_PHRED` is a string; cast it when you need a
   number.
 
+See [String scores and numeric casts in the vepyr-plugins README](https://github.com/biodatageeks/vepyr-plugins/blob/master/README.md#string-scores-and-numeric-casts)
+for per-field numeric types and Polars examples covering scalar columns,
+consequence-aligned lists and multiple scores inside a dbNSFP element.
+
 The engine only runs the plugin lookup, and only builds the CSQ string the
 values are carried in, when a query reads one of those columns:
 

--- a/docs/dataframes.md
+++ b/docs/dataframes.md
@@ -249,7 +249,7 @@ some rows cannot break the alignment.
 
 ```python
 UNALIGNED = {"Existing_variation", "CLIN_SIG", "PUBMED",
-             "clin_sig_allele", "clinvar_ids", "dbsnp_ids"}
+             "clin_sig_allele", "clinvar_ids", "cosmic_ids", "dbsnp_ids"}
 
 
 def consequence_rows(df: pl.DataFrame) -> pl.DataFrame:

--- a/docs/dataframes.md
+++ b/docs/dataframes.md
@@ -118,7 +118,7 @@ Schema({
     'SOMATIC': String,
     'PHENO': String,
     'PUBMED': List(String),              # distinct values per variant
-    'MOTIF_NAME': List(String),          # per entry; null outside MotifFeature entries
+    'MOTIF_NAME': List(String),          # per entry, MotifFeature entries only; everything only
     'MOTIF_POS': List(Int64),
     'HIGH_INF_POS': List(String),
     'MOTIF_SCORE_CHANGE': List(Float32),
@@ -190,8 +190,8 @@ native annotator. Two things reach the engine:
   columns (`Existing_variation`, `CLIN_SIG`, `SOMATIC`, `PHENO`, `PUBMED`, the
   `AF` family and the cache-only columns) on `check_existing` and the `af`
   flags; and the `everything`-only extras (`MANE`, `APPRIS`, `SIFT`,
-  `PolyPhen`, `DOMAINS`, `miRNA`, `HGVS_OFFSET` and the gnomAD
-  sub-populations) on `everything`. A group nobody selected is switched off
+  `PolyPhen`, `DOMAINS`, `miRNA`, `HGVS_OFFSET`, the five motif columns and
+  the gnomAD sub-populations) on `everything`. A group nobody selected is switched off
   for the run. A group a column needs is switched on when you gave no flags;
   flags you did set are kept exactly as configured. HGVS and the `everything`
   extras need `reference_fasta`, and selecting them without one raises rather

--- a/docs/dataframes.md
+++ b/docs/dataframes.md
@@ -201,9 +201,10 @@ native annotator. Two things reach the engine:
 `filter()` itself is applied to each batch after annotation. It bounds memory,
 because a batch is dropped as soon as it has been reduced, but it does not
 reduce the engine's work; filtering by region is cheaper done on the input VCF
-with `bcftools view -r`. Adding `skip_csq=False` and selecting `CSQ` disables
-pruning, since the string needs every flag. Plugin lookups run only when the
-query reads a plugin column or `CSQ`.
+with `bcftools view -r`. The raw `CSQ` string (`skip_csq=False`) needs every
+flag, so a query that reads it runs like a plain `collect()`: with the flags
+you gave, or the flagless default. Plugin lookups run only when the query
+reads a plugin column or `CSQ`.
 
 ```python
 preview = lf.head(20).collect()              # LIMIT 20 in the engine

--- a/docs/dataframes.md
+++ b/docs/dataframes.md
@@ -141,6 +141,12 @@ entry, such as the frequencies, are stored once as scalars. The input's other
 `INFO` fields and its sample columns are not in the frame; use `output_vcf`
 for those. Add `skip_csq=False` to get the raw `CSQ` string as a column.
 
+To narrow the frame, `select()` the columns you need, see
+[below](#what-is-pushed-into-the-engine); the engine then only computes what
+those columns require.
+
+### Plugin columns
+
 With a plugin cache configured, every plugin CSQ field is a named
 `List(String)` column appended after the block above, `CADD_PHRED` and
 `CADD_RAW` for example; see [Plugins](plugins.md). The engine only runs the
@@ -158,8 +164,7 @@ lf.select("chrom", "start", "SYMBOL")                     # neither
 
 Selecting a plugin column on a frame without a plugin cache fails when the
 plan is built, with Polars' `ColumnNotFoundError` listing the columns the
-frame has. To narrow the frame, `select()` the columns you need (next
-section); the engine then only computes what those columns require.
+frame has.
 
 ## What is pushed into the engine
 

--- a/docs/dataframes.md
+++ b/docs/dataframes.md
@@ -11,17 +11,23 @@ import vepyr
 lf = vepyr.annotate(
     "input.vcf.gz",
     "/data/vepyr_cache/116_GRCh38_merged",
-    everything=True,
     reference_fasta="GRCh38.fa",
 )
 df = lf.collect()
 ```
 
+No annotation flags are needed on this path. A frame created without flags
+fills everything the inputs allow: with a `reference_fasta` that is the full
+`--everything` result, without one the HGVS and `everything`-only columns
+stay null because the engine cannot compute them. Flags you pass explicitly
+are honoured as given, and a `select()` decides what actually runs, see
+[below](#what-is-pushed-into-the-engine).
+
 ## Schema
 
 `collect_schema()` is free: it comes from a probe that opens the cache but
-annotates nothing. This is the schema for chr22 of HG002 with
-`everything=True` on the release-116 Ensembl cache:
+annotates nothing. This is the schema for chr22 of HG002 on the release-116
+Ensembl cache:
 
 ```python
 >>> lf.collect_schema()
@@ -151,12 +157,11 @@ native annotator. Two things reach the engine:
   flags; and the `everything`-only extras (`MANE`, `APPRIS`, `SIFT`,
   `PolyPhen`, `DOMAINS`, `miRNA`, `HGVS_OFFSET` and the gnomAD
   sub-populations) on `everything`. A group nobody selected is switched off
-  for the run. A group a column needs is switched on when you gave no flags,
-  so `annotate(vcf, cache, reference_fasta=fasta)` followed by a `select()`
-  is enough; flags you did set are kept exactly as configured. HGVS and the
-  `everything` extras need `reference_fasta`, and selecting them without one
-  raises rather than returning nulls. The selected columns are value-identical
-  to a run with the flags spelled out.
+  for the run. A group a column needs is switched on when you gave no flags;
+  flags you did set are kept exactly as configured. HGVS and the `everything`
+  extras need `reference_fasta`, and selecting them without one raises rather
+  than returning nulls. The selected columns are value-identical to a run
+  with the flags spelled out.
 
 `filter()` itself is applied to each batch after annotation. It bounds memory,
 because a batch is dropped as soon as it has been reduced, but it does not
@@ -173,17 +178,18 @@ high = (
       .collect()
 )                                            # runs without HGVS or the co-located lookup
 
-bare = vepyr.annotate("input.vcf.gz", cache, reference_fasta="GRCh38.fa")   # no flags
-bare.select("chrom", "start", "HGVSc").collect()           # turns on hgvs
-bare.select("chrom", "start", "AF", "CLIN_SIG").collect()  # turns on the co-located lookup
-bare.select("chrom", "start", "SIFT").collect()            # turns on everything
-bare.collect()                                             # no projection: base columns only
+lf.select("chrom", "start", "SYMBOL", "Consequence").collect()   # no flags at all
+lf.select("chrom", "start", "HGVSc").collect()                    # hgvs only
+lf.select("chrom", "start", "AF", "CLIN_SIG").collect()           # the co-located lookup only
+lf.select("chrom", "start", "SIFT").collect()                     # everything
+lf.collect()                                                      # no projection: everything
 ```
 
-Without a projection the flags you passed are what runs: a plain `collect()`
-on a frame created without flags fills only the flag-independent columns.
+Without a projection there is nothing to infer from, so the flags you passed
+are what runs, and a frame created without flags runs `everything` when it
+has a FASTA and the co-located lookup when it does not.
 
-With `everything=True` on the release-116 Ensembl cache and `workers=1`:
+On the release-116 Ensembl cache with a FASTA and `workers=1`:
 
 | Input | Query | Wall time |
 |---|---|---|

--- a/docs/dataframes.md
+++ b/docs/dataframes.md
@@ -141,9 +141,25 @@ entry, such as the frequencies, are stored once as scalars. The input's other
 `INFO` fields and its sample columns are not in the frame; use `output_vcf`
 for those. Add `skip_csq=False` to get the raw `CSQ` string as a column.
 
-Plugin values become named list columns; see [Plugins](plugins.md). To
-narrow the frame, `select()` the columns you need (next section); the engine
-then only computes what those columns require.
+With a plugin cache configured, every plugin CSQ field is a named
+`List(String)` column appended after the block above, `CADD_PHRED` and
+`CADD_RAW` for example; see [Plugins](plugins.md). The engine only runs the
+plugin lookup, and only builds the CSQ string the values are carried in, when
+a query reads one of those columns:
+
+```python
+lf = vepyr.annotate(
+    "input.vcf.gz", cache, reference_fasta="GRCh38.fa",
+    plugin_cache_root="/data/plugin_cache", plugins=["cadd"],
+)
+lf.select("chrom", "start", "ref", "alt", "CADD_PHRED")   # plugin lookup, no HGVS
+lf.select("chrom", "start", "SYMBOL")                     # neither
+```
+
+Selecting a plugin column on a frame without a plugin cache fails when the
+plan is built, with Polars' `ColumnNotFoundError` listing the columns the
+frame has. To narrow the frame, `select()` the columns you need (next
+section); the engine then only computes what those columns require.
 
 ## What is pushed into the engine
 
@@ -169,7 +185,8 @@ native annotator. Two things reach the engine:
 because a batch is dropped as soon as it has been reduced, but it does not
 reduce the engine's work; filtering by region is cheaper done on the input VCF
 with `bcftools view -r`. Adding `skip_csq=False` and selecting `CSQ` disables
-pruning, since the string needs every flag.
+pruning, since the string needs every flag. Plugin lookups run only when the
+query reads a plugin column or `CSQ`.
 
 ```python
 preview = lf.head(20).collect()              # LIMIT 20 in the engine

--- a/docs/dataframes.md
+++ b/docs/dataframes.md
@@ -147,11 +147,23 @@ those columns require.
 
 ### Plugin columns
 
-With a plugin cache configured, every plugin CSQ field is a named
-`List(String)` column appended after the block above, `CADD_PHRED` and
-`CADD_RAW` for example; see [Plugins](plugins.md). The engine only runs the
-plugin lookup, and only builds the CSQ string the values are carried in, when
-a query reads one of those columns:
+With a plugin cache configured, every plugin CSQ field is a named column
+appended after the block above; see [Plugins](plugins.md). Its shape and
+type come from the plugin's manifest, not from the CSQ text it travels in:
+
+- A plugin keyed on the variant alone, such as CADD or ClinVar, gives one
+  value per row: `CADD_PHRED: String`, `ClinVar_CLNSIG: String`.
+- A plugin keyed on a transcript feature, such as SpliceAI (by gene symbol)
+  or AlphaMissense (by protein change), gives one value per consequence
+  entry, aligned with `Consequence`: `SpliceAI_pred_DP_AG: List(Int32)`,
+  `am_pathogenicity: List(Float32)`.
+- The element type is the manifest's `type`: `Utf8`, `Int32` or `Float32`.
+  CADD's scores are declared `Utf8` so the VCF reproduces the source digits
+  exactly, which is why `CADD_PHRED` is a string; cast it when you need a
+  number.
+
+The engine only runs the plugin lookup, and only builds the CSQ string the
+values are carried in, when a query reads one of those columns:
 
 ```python
 lf = vepyr.annotate(

--- a/docs/dataframes.md
+++ b/docs/dataframes.md
@@ -16,12 +16,14 @@ lf = vepyr.annotate(
 df = lf.collect()
 ```
 
-No annotation flags are needed on this path. A frame created without flags
-fills everything the inputs allow: with a `reference_fasta` that is the full
-`--everything` result, without one the HGVS and `everything`-only columns
-stay null because the engine cannot compute them. Flags you pass explicitly
-are honoured as given, and a `select()` decides what actually runs, see
-[below](#what-is-pushed-into-the-engine).
+!!! tip "No columns selected means `everything`"
+    A frame created without annotation flags and collected without a
+    `select()` is the full VEP `--everything` result, provided a
+    `reference_fasta` is given. Without a FASTA the HGVS and
+    `everything`-only columns stay null, because the engine cannot compute
+    them. Add a `select()` and only the flags its columns need are run, see
+    [below](#what-is-pushed-into-the-engine). Flags you pass explicitly are
+    honoured as given.
 
 ## Schema
 

--- a/docs/dataframes.md
+++ b/docs/dataframes.md
@@ -133,35 +133,14 @@ entry, such as the frequencies, are stored once as scalars. The input's other
 `INFO` fields and its sample columns are not in the frame; use `output_vcf`
 for those. Add `skip_csq=False` to get the raw `CSQ` string as a column.
 
-`fields="core"` narrows the frame to VEP's default fields:
-
-```python
->>> vepyr.annotate("input.vcf.gz", cache, fields="core").collect_schema()
-Schema({
-    'chrom': String, 'start': UInt32, 'end': UInt32, 'id': String,
-    'ref': String, 'alt': String, 'qual': Float64, 'filter': String,
-    'most_severe_consequence': String,
-    'Allele': String,
-    'Gene': List(String),
-    'Feature': List(String),
-    'Feature_type': List(String),
-    'Consequence': List(String),
-    'cDNA_position': List(String),
-    'CDS_position': List(String),
-    'Protein_position': List(String),
-    'Amino_acids': List(String),
-    'Codons': List(String),
-    'Existing_variation': List(String),
-})
-```
-
-A list keeps exactly those fields in that order. Plugin fields become named
-list columns after the selected block; see [Plugins](plugins.md).
+Plugin values become named list columns; see [Plugins](plugins.md). To
+narrow the frame, `select()` the columns you need (next section); the engine
+then only computes what those columns require.
 
 ## What is pushed into the engine
 
 The frame is backed by a Polars IO plugin that pulls Arrow batches from the
-native annotator. Three things reach the engine:
+native annotator. Two things reach the engine:
 
 - **`head(n)` and `limit(n)`** become a SQL `LIMIT`, so previewing is fast.
 - **A narrowing `select()`**, together with the columns a pushed-down
@@ -178,9 +157,6 @@ native annotator. Three things reach the engine:
   `everything` extras need `reference_fasta`, and selecting them without one
   raises rather than returning nulls. The selected columns are value-identical
   to a run with the flags spelled out.
-- **`fields=`** fixes the layout up front. It cannot be combined with a
-  narrowing `select()`: collecting such a query raises an error, because the
-  two would disagree about which columns exist.
 
 `filter()` itself is applied to each batch after annotation. It bounds memory,
 because a batch is dropped as soon as it has been reduced, but it does not

--- a/docs/dataframes.md
+++ b/docs/dataframes.md
@@ -19,9 +19,9 @@ df = lf.collect()
 !!! tip "No columns selected means `everything`"
     A frame created without annotation flags and collected without a
     `select()` is the full VEP `--everything` result, provided a
-    `reference_fasta` is given. Without a FASTA the HGVS and
-    `everything`-only columns stay null, because the engine cannot compute
-    them. Add a `select()` and only the flags its columns need are run, see
+    `reference_fasta` is given. Without a FASTA the engine cannot compute
+    the HGVS and `everything`-only columns: they stay null and a warning
+    names them. Add a `select()` and only the flags its columns need are run, see
     [below](#what-is-pushed-into-the-engine). Flags you pass explicitly are
     honoured as given.
 

--- a/docs/dataframes.md
+++ b/docs/dataframes.md
@@ -1,0 +1,407 @@
+# Polars DataFrames
+
+`vepyr.annotate()` without `output_vcf` returns a `polars.LazyFrame`. Nothing
+runs until you `collect()` or `sink_*()` it, and every collect starts a fresh
+annotation stream, so the same LazyFrame can be evaluated more than once.
+
+```python
+import polars as pl
+import vepyr
+
+lf = vepyr.annotate(
+    "input.vcf.gz",
+    "/data/vepyr_cache/116_GRCh38_merged",
+    everything=True,
+    reference_fasta="GRCh38.fa",
+)
+df = lf.collect()
+```
+
+## Schema
+
+`collect_schema()` is free: it comes from a probe that opens the cache but
+annotates nothing. This is the schema for chr22 of HG002 with
+`everything=True` on the release-116 Ensembl cache:
+
+```python
+>>> lf.collect_schema()
+Schema({
+    'chrom': String,
+    'start': UInt32,                     # VCF POS, 1-based
+    'end': UInt32,                       # POS + len(REF) - 1
+    'id': String,                        # '' when the VCF has '.'
+    'ref': String,
+    'alt': String,
+    'qual': Float64,
+    'filter': String,
+    'most_severe_consequence': String,
+    'Allele': String,
+    'Consequence': List(String),         # one element per CSQ entry, in CSQ order ...
+    'IMPACT': List(String),
+    'SYMBOL': List(String),
+    'Gene': List(String),
+    'Feature_type': List(String),
+    'Feature': List(String),
+    'BIOTYPE': List(String),
+    'EXON': List(String),
+    'INTRON': List(String),
+    'HGVSc': List(String),
+    'HGVSp': List(String),
+    'cDNA_position': List(String),
+    'CDS_position': List(String),
+    'Protein_position': List(String),
+    'Amino_acids': List(String),
+    'Codons': List(String),
+    'Existing_variation': List(String),  # distinct values per variant, not per entry
+    'DISTANCE': List(Int64),
+    'STRAND': List(Int8),
+    'FLAGS': List(String),
+    'VARIANT_CLASS': String,
+    'SYMBOL_SOURCE': List(String),
+    'HGNC_ID': List(String),
+    'CANONICAL': List(String),
+    'MANE': List(String),
+    'MANE_SELECT': List(String),
+    'MANE_PLUS_CLINICAL': List(String),
+    'TSL': List(Int8),
+    'APPRIS': List(String),
+    'CCDS': List(String),
+    'ENSP': List(String),
+    'SWISSPROT': List(String),
+    'TREMBL': List(String),
+    'UNIPARC': List(String),
+    'UNIPROT_ISOFORM': List(String),
+    'GENE_PHENO': List(String),
+    'SIFT': List(String),
+    'PolyPhen': List(String),
+    'DOMAINS': List(String),
+    'miRNA': List(String),
+    'HGVS_OFFSET': List(Int64),
+    'AF': Float32,                       # frequencies are per variant ...
+    'AFR_AF': Float32,
+    'AMR_AF': Float32,
+    'EAS_AF': Float32,
+    'EUR_AF': Float32,
+    'SAS_AF': Float32,
+    'gnomADe_AF': Float32,
+    'gnomADe_AFR_AF': Float32,
+    'gnomADe_AMR_AF': Float32,
+    'gnomADe_ASJ_AF': Float32,
+    'gnomADe_EAS_AF': Float32,
+    'gnomADe_FIN_AF': Float32,
+    'gnomADe_MID_AF': Float32,
+    'gnomADe_NFE_AF': Float32,
+    'gnomADe_REMAINING_AF': Float32,
+    'gnomADe_SAS_AF': Float32,
+    'gnomADg_AF': Float32,
+    'gnomADg_AFR_AF': Float32,
+    'gnomADg_AMI_AF': Float32,
+    'gnomADg_AMR_AF': Float32,
+    'gnomADg_ASJ_AF': Float32,
+    'gnomADg_EAS_AF': Float32,
+    'gnomADg_FIN_AF': Float32,
+    'gnomADg_MID_AF': Float32,
+    'gnomADg_NFE_AF': Float32,
+    'gnomADg_REMAINING_AF': Float32,
+    'gnomADg_SAS_AF': Float32,
+    'MAX_AF': Float32,
+    'MAX_AF_POPS': String,
+    'CLIN_SIG': List(String),            # distinct values per variant
+    'SOMATIC': String,
+    'PHENO': String,
+    'PUBMED': List(String),              # distinct values per variant
+    'MOTIF_NAME': List(String),          # per entry; null outside MotifFeature entries
+    'MOTIF_POS': List(Int64),
+    'HIGH_INF_POS': List(String),
+    'MOTIF_SCORE_CHANGE': List(Float32),
+    'TRANSCRIPTION_FACTORS': List(String),
+    'clin_sig_allele': List(String),     # cache-only columns, no CSQ counterpart
+    'clinical_impact': String,
+    'minor_allele': String,
+    'minor_allele_freq': Float32,
+    'clinvar_ids': List(String),
+    'cosmic_ids': List(String),
+    'dbsnp_ids': List(String),
+})
+```
+
+The 80 columns from `Allele` to `TRANSCRIPTION_FACTORS` are the CSQ fields in
+VCF header order. A `List` column that is aligned with `Consequence` has one
+element per CSQ entry; `Existing_variation`, `CLIN_SIG` and `PUBMED` hold the
+distinct values for the variant instead. Values that VEP repeats on every
+entry, such as the frequencies, are stored once as scalars. The input's other
+`INFO` fields and its sample columns are not in the frame; use `output_vcf`
+for those. Add `skip_csq=False` to get the raw `CSQ` string as a column.
+
+`fields="core"` narrows the frame to VEP's default fields:
+
+```python
+>>> vepyr.annotate("input.vcf.gz", cache, fields="core").collect_schema()
+Schema({
+    'chrom': String, 'start': UInt32, 'end': UInt32, 'id': String,
+    'ref': String, 'alt': String, 'qual': Float64, 'filter': String,
+    'most_severe_consequence': String,
+    'Allele': String,
+    'Gene': List(String),
+    'Feature': List(String),
+    'Feature_type': List(String),
+    'Consequence': List(String),
+    'cDNA_position': List(String),
+    'CDS_position': List(String),
+    'Protein_position': List(String),
+    'Amino_acids': List(String),
+    'Codons': List(String),
+    'Existing_variation': List(String),
+})
+```
+
+A list keeps exactly those fields in that order. Plugin fields become named
+list columns after the selected block; see [Plugins](plugins.md).
+
+## What is pushed into the engine
+
+The frame is backed by a Polars IO plugin that pulls Arrow batches from the
+native annotator. Three things reach the engine:
+
+- **`head(n)` and `limit(n)`** become a SQL `LIMIT`, so previewing is fast.
+- **A narrowing `select()`**, together with the columns a pushed-down
+  `filter()` reads, decides the annotation flags. Only three groups of columns
+  depend on flags at all: `HGVSc` and `HGVSp` on `hgvs`; the co-located
+  columns (`Existing_variation`, `CLIN_SIG`, `SOMATIC`, `PHENO`, `PUBMED`, the
+  `AF` family and the cache-only columns) on `check_existing` and the `af`
+  flags; and the `everything`-only extras (`MANE`, `APPRIS`, `SIFT`,
+  `PolyPhen`, `DOMAINS`, `miRNA`, `HGVS_OFFSET` and the gnomAD
+  sub-populations) on `everything`. A group nobody selected is switched off
+  for the run. A group a column needs is switched on when you gave no flags,
+  so `annotate(vcf, cache, reference_fasta=fasta)` followed by a `select()`
+  is enough; flags you did set are kept exactly as configured. HGVS and the
+  `everything` extras need `reference_fasta`, and selecting them without one
+  raises rather than returning nulls. The selected columns are value-identical
+  to a run with the flags spelled out.
+- **`fields=`** fixes the layout up front. It cannot be combined with a
+  narrowing `select()`: collecting such a query raises an error, because the
+  two would disagree about which columns exist.
+
+`filter()` itself is applied to each batch after annotation. It bounds memory,
+because a batch is dropped as soon as it has been reduced, but it does not
+reduce the engine's work; filtering by region is cheaper done on the input VCF
+with `bcftools view -r`. Adding `skip_csq=False` and selecting `CSQ` disables
+pruning, since the string needs every flag.
+
+```python
+preview = lf.head(20).collect()              # LIMIT 20 in the engine
+
+high = (
+    lf.filter(pl.col("IMPACT").list.contains("HIGH"))
+      .select("chrom", "start", "ref", "alt", "SYMBOL", "Consequence")
+      .collect()
+)                                            # runs without HGVS or the co-located lookup
+
+bare = vepyr.annotate("input.vcf.gz", cache, reference_fasta="GRCh38.fa")   # no flags
+bare.select("chrom", "start", "HGVSc").collect()           # turns on hgvs
+bare.select("chrom", "start", "AF", "CLIN_SIG").collect()  # turns on the co-located lookup
+bare.select("chrom", "start", "SIFT").collect()            # turns on everything
+bare.collect()                                             # no projection: base columns only
+```
+
+Without a projection the flags you passed are what runs: a plain `collect()`
+on a frame created without flags fills only the flag-independent columns.
+
+With `everything=True` on the release-116 Ensembl cache and `workers=1`:
+
+| Input | Query | Wall time |
+|---|---|---|
+| chr22, 50,861 variants | `collect()` | 2.3 s |
+| | `select(chrom, start, ref, alt, SYMBOL, Consequence, IMPACT)` | 1.2 s |
+| | `select(chrom, start, HGVSc, HGVSp)` | 1.4 s |
+| | `select(chrom, start, Existing_variation, AF, MAX_AF, CLIN_SIG, PUBMED)` | 1.9 s |
+| chr1, 323,430 variants | `collect()` | 15.2 s |
+| | `select(chrom, start, ref, alt, SYMBOL, Consequence, IMPACT)` | 5.8 s |
+| | `select(chrom, start, HGVSc, HGVSp)` | 9.0 s |
+| | `select(chrom, start, Existing_variation, AF, MAX_AF, CLIN_SIG, PUBMED)` | 14.2 s |
+
+## One row per consequence
+
+Most downstream work, and every `filter_vep` expression, is about one CSQ
+entry: a variant paired with one transcript, regulatory or motif feature.
+Explode the aligned list columns together to get that long format. The helper
+pads a null list to the row's entry count first, so a column that is null on
+some rows cannot break the alignment.
+
+```python
+UNALIGNED = {"Existing_variation", "CLIN_SIG", "PUBMED",
+             "clin_sig_allele", "clinvar_ids", "dbsnp_ids"}
+
+
+def consequence_rows(df: pl.DataFrame) -> pl.DataFrame:
+    """One row per CSQ entry. Keeps every scalar and per-variant column as is."""
+    cols = [
+        c for c, t in df.schema.items()
+        if isinstance(t, pl.List) and c not in UNALIGNED
+    ]
+    padded = [
+        pl.when(pl.col(c).is_null())
+        .then(pl.col("Consequence").list.eval(pl.lit(None)).cast(df.schema[c]))
+        .otherwise(pl.col(c))
+        .alias(c)
+        for c in cols
+    ]
+    return (
+        df.filter(pl.col("Consequence").is_not_null())
+          .with_columns(padded)
+          .explode(cols)
+    )
+
+
+long = consequence_rows(df)
+```
+
+Rows whose `ALT` is `*` have no consequences and are dropped by the filter.
+On chr22 of HG002 the 50,861 variants become 943,901 consequence rows.
+
+## `filter_vep` expressions in Polars
+
+Ensembl's [`filter_vep`](https://jun2026.archive.ensembl.org/info/docs/tools/vep/script/vep_filter.html)
+evaluates an expression per CSQ entry and keeps the variant when any entry
+matches; with `--only_matched` it also drops the entries that did not. Both
+map onto the frame:
+
+- On the **long frame** (`long` above), `filter()` keeps matching entries only.
+  This is `filter_vep --only_matched`.
+- On the **wide frame** (`df`), wrap the per-entry test in
+  `list.eval(...).list.any()` to keep the whole variant when any entry
+  matches. This is plain `filter_vep`.
+
+The table uses the long frame. Fields that `filter_vep` treats as numbers
+after stripping text, such as `SIFT`'s score in parentheses or the exon
+number in `2/10`, need the same extraction here.
+
+| `filter_vep` expression | Polars expression on `long` |
+|---|---|
+| `Feature is ENST00000307301` | `pl.col("Feature") == "ENST00000307301"` |
+| `Feature_type is Transcript` | `pl.col("Feature_type") == "Transcript"` |
+| `Consequence is missense_variant` | `pl.col("Consequence").str.split("&").list.contains("missense_variant")` |
+| `Consequence matches stream` | `pl.col("Consequence").str.contains("stream")` |
+| `Consequence match stop` | `pl.col("Consequence").str.contains("stop")` |
+| `SIFT != tolerated` | `pl.col("SIFT").str.replace(r"\(.*\)$", "") != "tolerated"` |
+| `SIFT match tolerated` | `pl.col("SIFT").str.contains("tolerated")` |
+| `SIFT < 0.1` | `pl.col("SIFT").str.extract(r"\(([\d.]+)\)").cast(pl.Float64) < 0.1` |
+| `Protein_position < 10` | `pl.col("Protein_position").str.extract(r"^(\d+)").cast(pl.Int64) < 10` |
+| `Exon > 1` | `pl.col("EXON").str.extract(r"^(\d+)").cast(pl.Int64) > 1` |
+| `MANE` (field exists) | `pl.col("MANE").is_not_null()` |
+| `SYMBOL` | `pl.col("SYMBOL").is_not_null()` |
+| `not Existing_variation` | `pl.col("Existing_variation").is_null()` |
+| `AF < 0.01 or not AF` | `pl.any_horizontal(pl.col("AF") < 0.01, pl.col("AF").is_null())` |
+| `AFR_AF > 0.1 or EUR_AF > 0.1` | `pl.any_horizontal(pl.col("AFR_AF") > 0.1, pl.col("EUR_AF") > 0.1)` |
+| `AFR_AF > #EUR_AF` | `pl.col("AFR_AF") > pl.col("EUR_AF")` |
+| `(AFR_AF > 0.1 or EUR_AF > 0.1) and (EAS_AF < 0.1 and SAS_AF < 0.1)` | `pl.any_horizontal(pl.col("AFR_AF") > 0.1, pl.col("EUR_AF") > 0.1) & pl.all_horizontal(pl.col("EAS_AF") < 0.1, pl.col("SAS_AF") < 0.1)` |
+| `Consequence is missense_variant and CCDS and DOMAINS` | `pl.col("Consequence").str.split("&").list.contains("missense_variant") & pl.col("CCDS").is_not_null() & pl.col("DOMAINS").is_not_null()` |
+| `SYMBOL in BRCA1,BRCA2` | `pl.col("SYMBOL").is_in(["BRCA1", "BRCA2"])` |
+| `Feature in /data/files/motifs_list.txt` | `pl.col("Feature").is_in(Path("/data/files/motifs_list.txt").read_text().split())` |
+| `Consequence is coding_sequence_variant` with `--ontology` | No ontology expansion; list the child terms: `pl.col("Consequence").str.split("&").list.eval(pl.element().is_in(CHILD_TERMS)).list.any()` |
+
+Operator by operator:
+
+| `filter_vep` | Polars |
+|---|---|
+| `is`, `=`, `eq` | `==`; on `&`-joined fields `str.split("&").list.contains(...)` |
+| `!=`, `ne` | `!=` |
+| `match`, `matches`, `re`, `regex` | `str.contains(pattern)` |
+| `<`, `>`, `<=`, `>=` | the same, after `cast()` from the string form where needed |
+| `exists`, `ex`, `defined`, bare field | `is_not_null()` |
+| `not` | `~` or `is_null()` |
+| `and`, `or`, parentheses | `&` and the pipe operator, each side in its own parentheses; or `pl.all_horizontal()` / `pl.any_horizontal()` |
+| `in a,b,c` / `in file` | `is_in([...])` |
+
+Where a value in the frame is null, the `filter_vep` field is empty, so
+`is_null()` and `is_not_null()` give the `not FIELD` and `FIELD` semantics
+exactly.
+
+The same expressions on the wide frame keep whole variants:
+
+```python
+any_stream = df.filter(
+    pl.col("Consequence").list.eval(pl.element().str.contains("stream")).list.any()
+)
+any_high = df.filter(pl.col("IMPACT").list.contains("HIGH"))
+```
+
+## Writing results to disk
+
+`collect()` holds the whole result in memory. On chromosome 1 of a
+whole-genome sample (323,430 variants, `everything=True`) the collected frame
+is about 2.3 GB, but the process peaks at 12.6 GB because Polars buffers the
+Arrow batches on top of the frame. Two things bring that down.
+
+**Leave the `CSQ` string off.** It is off by default (`skip_csq=True`) and
+roughly halves peak memory. Turn it on only when you need the exact VEP string.
+
+**Stream with `sink_parquet` and a small row group.** Polars holds one row
+group in memory before writing it, and its default group is far larger than an
+annotation batch. Setting the group to the engine's buffer size keeps the
+stream flat:
+
+```python
+lf.sink_parquet("annotated.parquet", row_group_size=5000)
+```
+
+Measured on the release-116 Ensembl cache with `workers=1`:
+
+| Input | Path | Wall time | Peak RSS |
+|---|---|---|---|
+| chr22, 50,861 variants | `output_vcf` (bgzf) | 3.9 s | 1.0 GB |
+| | `collect()` | 2.4 s | 1.6 GB |
+| | `sink_parquet()` default | 2.7 s | 2.1 GB |
+| | `sink_parquet(row_group_size=5000)` | 2.5 s | 1.3 GB |
+| chr1, 323,430 variants | `output_vcf` (bgzf) | 21.6 s | 2.9 GB |
+| | `collect()` | 15.3 s | 6.9 GB |
+| | `sink_parquet()` default | 15.8 s | 6.0 GB |
+| | `sink_parquet(row_group_size=5000)` | 16.5 s | 3.5 GB |
+
+With `skip_csq=False` add roughly 1 GB on chr1 for the small-row-group sink and
+5 GB for `collect()`. The engine itself needs about 3 GB on chr1 whichever
+output you choose, so the small-row-group sink is within half a gigabyte of the
+VCF writer. Wall time is unaffected and the Parquet file grows by about 6 %.
+
+List columns cannot be written to CSV directly. Join them with `&` first, on
+the wide frame or on the long frame, where the per-variant value sets are the
+only lists left:
+
+```python
+def join_lists(df: pl.DataFrame) -> pl.DataFrame:
+    return df.with_columns(pl.col(pl.List).cast(pl.List(pl.String)).list.join("&"))
+
+
+join_lists(df).write_csv("annotated.tsv", separator="\t")
+join_lists(consequence_rows(df)).write_csv("annotated_long.tsv", separator="\t")
+```
+
+## Agreement with the VCF output
+
+The DataFrame and VCF paths run the same engine. On chr22 and chr1 of HG002
+against the release-116 Ensembl cache with `everything=True`, the `CSQ`
+column (`skip_csq=False`) matched the VCF's `INFO/CSQ` byte for byte on every
+record, the variant columns matched `CHROM`, `POS`, `ID`, `REF`, `ALT`, `QUAL`
+and `FILTER`, and every typed column matched its CSQ field element for element,
+motif entries included. The only representational difference is the three
+per-variant value-set columns:
+
+!!! note "Per-variant value sets"
+    `Existing_variation`, `CLIN_SIG` and `PUBMED` are deduplicated per
+    variant rather than repeated per consequence. No values are lost, but
+    their list length does not match the per-consequence columns. Elements
+    are split on the cache's `,` separator only, so a combined assertion such
+    as `benign&likely_benign` stays one element; match with `str.contains`.
+
+When a downstream step needs the string itself, decode it directly:
+
+```python
+CSQ_FIELDS = [...]  # the Format: list from the VCF header, or the schema names from "Allele" on
+
+entries = pl.col("CSQ").str.split(",")
+decoded = df.with_columns(
+    entries.list.eval(pl.element().str.split("|").list.get(i, null_on_oob=True))
+           .alias(name)
+    for i, name in enumerate(CSQ_FIELDS)
+)
+```

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -111,10 +111,13 @@ explicit list or tuple may be used instead of `"core"`; its order is
 preserved. Fields needed by plugin match templates are still computed even
 when they are not emitted. With `fields=None` the full CSQ layout is written.
 
-On the DataFrame path `fields=` is not needed: each plugin field (for example
-`CADD_PHRED` and `CADD_RAW`) is always a named `List(String)` column after
-the base columns, and a `select()` decides what the engine computes, plugin
-lookup included. See [Polars DataFrames](dataframes.md#schema).
+On the DataFrame path `fields=` is not needed: each plugin field is always a
+named column after the base columns, typed by the manifest's `type` and
+shaped by its `match_columns`: one value per row for a per-variant plugin
+(`CADD_PHRED: String`), one per consequence entry for a per-feature plugin
+(`am_pathogenicity: List(Float32)`). A `select()` decides what the engine
+computes, plugin lookup included. See
+[Polars DataFrames](dataframes.md#plugin-columns).
 
 ### Choosing which plugins run
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -119,6 +119,10 @@ shaped by its `match_columns`: one value per row for a per-variant plugin
 computes, plugin lookup included. See
 [Polars DataFrames](dataframes.md#plugin-columns).
 
+For why some scores remain strings to preserve VCF body MD5 matches, which
+numeric types retain each field's precision, and Polars casting examples,
+see [String scores and numeric casts in the vepyr-plugins README](https://github.com/biodatageeks/vepyr-plugins/blob/master/README.md#string-scores-and-numeric-casts).
+
 ### Choosing which plugins run
 
 By default every plugin under `<plugin_cache_root>/plugin/` is applied. There

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -106,17 +106,15 @@ result = vepyr.annotate(
 )
 ```
 
-VCF output records the exact ordered layout in the `CSQ` `Format:` header. On
-the DataFrame path, the selected base fields retain their existing named
-columns, unselected annotation columns are omitted, and each plugin field (for
-example `CADD_PHRED` and `CADD_RAW`) is a named `List(String)` column. The raw
-`CSQ` string is still available with `skip_csq=False`, but is not required to
-access plugin values.
-
-An explicit list or tuple may be used instead of `"core"`; its order is
+VCF output records the exact ordered layout in the `CSQ` `Format:` header. An
+explicit list or tuple may be used instead of `"core"`; its order is
 preserved. Fields needed by plugin match templates are still computed even
-when they are not emitted. With `fields=None` the full legacy CSQ layout and
-DataFrame schema remain unchanged.
+when they are not emitted. With `fields=None` the full CSQ layout is written.
+
+On the DataFrame path `fields=` is not needed: each plugin field (for example
+`CADD_PHRED` and `CADD_RAW`) is always a named `List(String)` column after
+the base columns, and a `select()` decides what the engine computes, plugin
+lookup included. See [Polars DataFrames](dataframes.md#schema).
 
 ### Choosing which plugins run
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
       - Architecture: architecture.md
       - Caches: caches.md
       - Download Ensembl VEP and plugin caches: downloads.md
+      - Polars DataFrames: dataframes.md
       - API: api.md
       - Plugins: plugins.md
       - Performance: performance.md

--- a/src/vepyr/__init__.py
+++ b/src/vepyr/__init__.py
@@ -150,6 +150,14 @@ def _flags_for_projection(opts: dict, needed: set[str] | None) -> dict:
             else:
                 for key in _COLOCATED_OPTIONS:
                     out[key] = True
+                unavailable = ", ".join(
+                    sorted(_HGVS_COLUMNS | _EVERYTHING_ONLY_COLUMNS)
+                )
+                warnings.warn(
+                    "no reference_fasta given, so these columns will be null: "
+                    f"{unavailable}. Pass reference_fasta= for the full result",
+                    stacklevel=2,
+                )
         return out
     if "CSQ" in needed:
         return out

--- a/src/vepyr/__init__.py
+++ b/src/vepyr/__init__.py
@@ -119,9 +119,11 @@ _EVERYTHING_ONLY_COLUMNS = frozenset(
 def _flags_for_projection(opts: dict, needed: set[str] | None) -> dict:
     """Derive the annotation flags a query needs from the columns it reads.
 
-    ``needed`` is the query's projection plus any filter columns; ``None``
-    means no projection, which leaves ``opts`` as given. Otherwise only three
-    column groups depend on flags at all (see the constants above):
+    ``needed`` is the query's projection plus any filter columns. ``None``
+    means no projection: the flags stay as given, or, when none were given,
+    ``everything`` is used with a FASTA and the co-located lookup without one.
+    With a projection only three column groups depend on flags at all (see
+    the constants above):
 
     - a group nobody selected has its flags removed, so the engine skips it;
     - a group the user enabled explicitly is kept exactly as configured;
@@ -133,7 +135,23 @@ def _flags_for_projection(opts: dict, needed: set[str] | None) -> dict:
     those leave ``opts`` untouched. Returns a new dict.
     """
     out = dict(opts)
-    if needed is None or "CSQ" in needed or "plugin_cache_root" in opts:
+    user_hgvs = any(opts.get(key) for key in ("hgvs", "hgvsc", "hgvsp"))
+    user_colocated = any(opts.get(key) for key in _COLOCATED_OPTIONS)
+    user_any_flag = bool(opts.get("everything")) or user_hgvs or user_colocated
+    if "plugin_cache_root" in opts:
+        return out
+    if needed is None:
+        # No projection: flags as given, or, when none were given, everything
+        # the inputs allow. HGVS and the everything extras need a FASTA, so
+        # without one only the co-located lookup can be switched on.
+        if not user_any_flag:
+            if out.get("reference_fasta_path"):
+                out["everything"] = True
+            else:
+                for key in _COLOCATED_OPTIONS:
+                    out[key] = True
+        return out
+    if "CSQ" in needed:
         return out
 
     def _needs(group: frozenset) -> bool:
@@ -145,9 +163,6 @@ def _flags_for_projection(opts: dict, needed: set[str] | None) -> dict:
             raise ValueError(
                 f"selecting {columns} needs {flag}, which requires reference_fasta="
             )
-
-    user_hgvs = any(opts.get(key) for key in ("hgvs", "hgvsc", "hgvsp"))
-    user_colocated = any(opts.get(key) for key in _COLOCATED_OPTIONS)
 
     if _needs(_EVERYTHING_ONLY_COLUMNS):
         if not opts.get("everything"):
@@ -1206,8 +1221,11 @@ def annotate(
         A ``select()`` on it decides which annotation flags the engine runs:
         the groups no selected column needs are switched off, and, when no
         flag was given, the groups a column needs are switched on (HGVS and
-        the ``everything`` extras require ``reference_fasta``). ``fields``
-        cannot be combined with such a ``select()``.
+        the ``everything`` extras require ``reference_fasta``). Collected
+        without a ``select()`` and without flags, the frame is the
+        ``everything`` result when ``reference_fasta`` is given and the
+        co-located lookup result otherwise. ``fields`` cannot be combined
+        with a narrowing ``select()``.
         When ``output_vcf`` is set: the output VCF file path.
 
     Examples

--- a/src/vepyr/__init__.py
+++ b/src/vepyr/__init__.py
@@ -206,7 +206,9 @@ def _flags_for_projection(
         # No projection, or the raw CSQ string (which needs every flag): flags
         # as given, or, when none were given, everything the inputs allow.
         # HGVS and the everything extras need a FASTA, so without one only
-        # the co-located lookup can be switched on.
+        # the co-located lookup can be switched on. Plugin requirements come
+        # first so a missing FASTA raises before anything is warned about.
+        _ensure(set(required))
         if not user_any_flag:
             if out.get("reference_fasta_path"):
                 out["everything"] = True
@@ -223,7 +225,6 @@ def _flags_for_projection(
                         "for the full result",
                         stacklevel=2,
                     )
-        _ensure(set(required))
         return out
 
     needed = needed | set(required)

--- a/src/vepyr/__init__.py
+++ b/src/vepyr/__init__.py
@@ -84,9 +84,16 @@ _COLOCATED_OPTIONS = (
     "max_af",
     "pubmed",
 )
-# Columns only ``everything`` fills; selecting one keeps the flag as is.
+# Columns only ``everything`` fills; selecting one keeps the flag as is. The
+# motif columns are among them because the five motif fields exist only in
+# the ``everything`` CSQ layout (the engine leaves them null otherwise).
 _EVERYTHING_ONLY_COLUMNS = frozenset(
     {
+        "MOTIF_NAME",
+        "MOTIF_POS",
+        "HIGH_INF_POS",
+        "MOTIF_SCORE_CHANGE",
+        "TRANSCRIPTION_FACTORS",
         "MANE",
         "APPRIS",
         "SIFT",

--- a/src/vepyr/__init__.py
+++ b/src/vepyr/__init__.py
@@ -191,11 +191,18 @@ def _flags_for_projection(
             out["everything"] = True
         if out.get("everything"):
             return
+        # hgvs computes both HGVS fields; hgvsc and hgvsp one each, so the
+        # check is per field: hgvsp=True alone leaves HGVSc empty. With no
+        # HGVS flag at all, hgvs is switched on like the projection does.
         if fields & _HGVS_COLUMNS and not any(
             out.get(key) for key in ("hgvs", "hgvsc", "hgvsp")
         ):
             _require_fasta(_HGVS_COLUMNS, "hgvs", fields)
             out["hgvs"] = True
+        for field, flag in (("HGVSc", "hgvsc"), ("HGVSp", "hgvsp")):
+            if field in fields and not (out.get("hgvs") or out.get(flag)):
+                _require_fasta(_HGVS_COLUMNS, flag, {field})
+                out[flag] = True
         if fields & _COLOCATED_COLUMNS and not any(
             out.get(key) for key in _COLOCATED_OPTIONS
         ):
@@ -261,6 +268,9 @@ def _flags_for_projection(
     if not keep_colocated:
         for key in _COLOCATED_OPTIONS:
             out.pop(key, None)
+    # Plugin template fields are checked per field: hgvsp=True alone does not
+    # compute the HGVSc a template may read.
+    _ensure(set(required))
     if not any(out.get(key) for key in ("hgvs", "hgvsc", "hgvsp")):
         out.pop("reference_fasta_path", None)
     return out

--- a/src/vepyr/__init__.py
+++ b/src/vepyr/__init__.py
@@ -116,7 +116,9 @@ _EVERYTHING_ONLY_COLUMNS = frozenset(
 )
 
 
-def _flags_for_projection(opts: dict, needed: set[str] | None) -> dict:
+def _flags_for_projection(
+    opts: dict, needed: set[str] | None, available: set[str] | None = None
+) -> dict:
     """Derive the annotation flags a query needs from the columns it reads.
 
     ``needed`` is the query's projection plus any filter columns. ``None``
@@ -131,15 +133,14 @@ def _flags_for_projection(opts: dict, needed: set[str] | None) -> dict:
       HGVS and the ``everything`` extras need ``reference_fasta``; asking for
       them without one is an error rather than a column of nulls.
 
-    The raw ``CSQ`` string and plugin output depend on the full flag set, so
-    those leave ``opts`` untouched. Returns a new dict.
+    The raw ``CSQ`` string depends on the full flag set, so a query reading it
+    leaves ``opts`` untouched. ``available`` is the frame's column set; it
+    limits the no-FASTA warning to columns the frame has. Returns a new dict.
     """
     out = dict(opts)
     user_hgvs = any(opts.get(key) for key in ("hgvs", "hgvsc", "hgvsp"))
     user_colocated = any(opts.get(key) for key in _COLOCATED_OPTIONS)
     user_any_flag = bool(opts.get("everything")) or user_hgvs or user_colocated
-    if "plugin_cache_root" in opts:
-        return out
     if needed is None:
         # No projection: flags as given, or, when none were given, everything
         # the inputs allow. HGVS and the everything extras need a FASTA, so
@@ -150,14 +151,16 @@ def _flags_for_projection(opts: dict, needed: set[str] | None) -> dict:
             else:
                 for key in _COLOCATED_OPTIONS:
                     out[key] = True
-                unavailable = ", ".join(
-                    sorted(_HGVS_COLUMNS | _EVERYTHING_ONLY_COLUMNS)
-                )
-                warnings.warn(
-                    "no reference_fasta given, so these columns will be null: "
-                    f"{unavailable}. Pass reference_fasta= for the full result",
-                    stacklevel=2,
-                )
+                unavailable = _HGVS_COLUMNS | _EVERYTHING_ONLY_COLUMNS
+                if available is not None:
+                    unavailable = unavailable & available
+                if unavailable:
+                    warnings.warn(
+                        "no reference_fasta given, so these columns will be null: "
+                        f"{', '.join(sorted(unavailable))}. Pass reference_fasta= "
+                        "for the full result",
+                        stacklevel=2,
+                    )
         return out
     if "CSQ" in needed:
         return out
@@ -1419,17 +1422,6 @@ def annotate(
                     f"Unknown plugin {unknown[0]!r} in {source_root}. "
                     f"Available: {', '.join(available) or '(none)'}"
                 )
-            if output_vcf is None and skip_csq and selected_fields is None:
-                # Plugin values reach a LazyFrame only inside the CSQ string,
-                # which `skip_csq=True` (the default) drops — so the plugins
-                # would be built and then silently discarded. The VCF path is
-                # unaffected: it writes a header naming the fields.
-                warnings.warn(
-                    "plugin fields are emitted inside CSQ, which skip_csq=True "
-                    "discards; pass skip_csq=False to keep them, or output_vcf= "
-                    "for a header that names them",
-                    stacklevel=2,
-                )
             opts["plugin_cache_root"] = plugin_cache_root
             opts["plugins"] = list(plugins)
     elif plugin_cache_root is not None:
@@ -1532,8 +1524,11 @@ def annotate(
     import polars as pl
     import pyarrow as pa
 
+    # Plugin CSQ fields are named list columns whenever a plugin cache is
+    # configured. The engine appends them after the base layout, whose length
+    # depends on the flags, so they are read as the last fields of each entry.
     plugin_field_names: list[str] = []
-    if selected_fields is not None and plugin_cache_root is not None and plugins != []:
+    if plugin_cache_root is not None and plugins != []:
         import os
 
         plugin_root = os.path.join(plugin_cache_root, "plugin")
@@ -1625,6 +1620,7 @@ def annotate(
         dict(opts),
         engine_skip_csq,
     )
+    plugin_columns = set(plugin_field_names)
 
     def _batch_source(with_columns, predicate, n_rows, batch_size):
         # Projection pushdown: the columns Polars asks for, plus the ones the
@@ -1640,34 +1636,50 @@ def annotate(
             needed = set(with_columns)
             if predicate is not None:
                 needed.update(predicate.meta.root_names())
-        engine_opts = _flags_for_projection(_opts, needed)
+        engine_opts = _flags_for_projection(_opts, needed, set(polars_schema))
+        # The CSQ string is only built when the query reads it or a plugin
+        # column parsed out of it.
+        if needed is None:
+            csq_needed = not _engine_skip
+        else:
+            csq_needed = "CSQ" in needed or bool(needed & plugin_columns)
+            if not csq_needed:
+                # Plugin values only ever reach the frame through the CSQ
+                # string, so a query reading neither skips the plugin lookup.
+                engine_opts.pop("plugin_cache_root", None)
+                engine_opts.pop("plugins", None)
         annotator = _create_annotator(
             _vcf,
             _cache_dir,
             json.dumps(engine_opts),
-            _engine_skip,
+            not csq_needed,
             n_rows,
         )
         remaining = n_rows
         for py_batch in annotator:
             batch_df = pl.from_arrow(py_batch)
-            if plugin_field_names:
-                first_plugin_index = len(selected_fields)
+            if plugin_field_names and "CSQ" in batch_df.columns:
+                n_plugin = len(plugin_field_names)
                 batch_df = batch_df.with_columns(
                     pl.col("CSQ")
                     .str.split(",")
                     .list.eval(
                         pl.element()
                         .str.split("|")
-                        .list.get(first_plugin_index + index, null_on_oob=True)
+                        .list.get(index - n_plugin, null_on_oob=True)
                         .replace("", None)
                     )
                     .alias(name)
                     for index, name in enumerate(plugin_field_names)
                 )
+            if skip_csq and "CSQ" in batch_df.columns:
+                batch_df = batch_df.drop("CSQ")
             if selected_dataframe_columns is not None:
                 batch_df = batch_df.select(
-                    [*selected_dataframe_columns, *plugin_field_names]
+                    [
+                        *selected_dataframe_columns,
+                        *(c for c in plugin_field_names if c in batch_df.columns),
+                    ]
                 )
             if predicate is not None:
                 batch_df = batch_df.filter(predicate)

--- a/src/vepyr/__init__.py
+++ b/src/vepyr/__init__.py
@@ -144,11 +144,11 @@ def _flags_for_projection(
 ) -> dict:
     """Derive the annotation flags a query needs from the columns it reads.
 
-    ``needed`` is the query's projection plus any filter columns. ``None``
-    means no projection: the flags stay as given, or, when none were given,
-    ``everything`` is used with a FASTA and the co-located lookup without one.
-    With a projection only three column groups depend on flags at all (see
-    the constants above):
+    ``needed`` is the query's projection plus any filter columns. With no
+    projection (``None``), or when the raw ``CSQ`` string is read, the flags
+    stay as given, or, when none were given, ``everything`` is used with a
+    FASTA and the co-located lookup without one. Otherwise only three column
+    groups depend on flags at all (see the constants above):
 
     - a group nobody selected has its flags removed, so the engine skips it;
     - a group the user enabled explicitly is kept exactly as configured;
@@ -156,18 +156,18 @@ def _flags_for_projection(
       HGVS and the ``everything`` extras need ``reference_fasta``; asking for
       them without one is an error rather than a column of nulls.
 
-    The raw ``CSQ`` string depends on the full flag set, so a query reading it
-    leaves ``opts`` untouched. ``available`` is the frame's column set; it
-    limits the no-FASTA warning to columns the frame has. Returns a new dict.
+    ``available`` is the frame's column set; it limits the no-FASTA warning
+    to columns the frame has. Returns a new dict.
     """
     out = dict(opts)
     user_hgvs = any(opts.get(key) for key in ("hgvs", "hgvsc", "hgvsp"))
     user_colocated = any(opts.get(key) for key in _COLOCATED_OPTIONS)
     user_any_flag = bool(opts.get("everything")) or user_hgvs or user_colocated
-    if needed is None:
-        # No projection: flags as given, or, when none were given, everything
-        # the inputs allow. HGVS and the everything extras need a FASTA, so
-        # without one only the co-located lookup can be switched on.
+    if needed is None or "CSQ" in needed:
+        # No projection, or the raw CSQ string (which needs every flag): flags
+        # as given, or, when none were given, everything the inputs allow.
+        # HGVS and the everything extras need a FASTA, so without one only
+        # the co-located lookup can be switched on.
         if not user_any_flag:
             if out.get("reference_fasta_path"):
                 out["everything"] = True
@@ -184,8 +184,6 @@ def _flags_for_projection(
                         "for the full result",
                         stacklevel=2,
                     )
-        return out
-    if "CSQ" in needed:
         return out
 
     def _needs(group: frozenset) -> bool:

--- a/src/vepyr/__init__.py
+++ b/src/vepyr/__init__.py
@@ -1713,8 +1713,12 @@ def annotate(
                 needed.update(predicate.meta.root_names())
         # Fields the match templates of every plugin column read, this query
         # included, must be computed whatever flags were given: a plugin whose
-        # template needs HGVSc is null without hgvs.
-        read_plugins = plugin_columns if needed is None else needed & plugin_columns
+        # template needs HGVSc is null without hgvs. The raw CSQ string carries
+        # every plugin's values, so reading it reads every plugin.
+        if needed is None or "CSQ" in needed:
+            read_plugins = plugin_columns
+        else:
+            read_plugins = needed & plugin_columns
         required = set().union(*(plugin_column_inputs[c] for c in read_plugins))
         engine_opts = _flags_for_projection(_opts, needed, set(polars_schema), required)
         # The CSQ string is only built when the query reads it or a plugin

--- a/src/vepyr/__init__.py
+++ b/src/vepyr/__init__.py
@@ -116,6 +116,28 @@ _EVERYTHING_ONLY_COLUMNS = frozenset(
 )
 
 
+# Plugin cache manifest value types (engine ``ValueType``) to Polars dtypes.
+_PLUGIN_VALUE_TYPES = {"Utf8": "String", "Float32": "Float32", "Int32": "Int32"}
+
+
+def _plugin_value_dtype(type_name: str | None):
+    import polars as pl
+
+    return getattr(pl, _PLUGIN_VALUE_TYPES.get(type_name, "String"))
+
+
+def _plugin_column(values, dtype, per_variant: bool):
+    """Shape one plugin field parsed out of CSQ: ``values`` is a list of one
+    string per consequence entry. A per-variant plugin repeats the same value
+    on every entry, so it collapses to one typed scalar; a per-feature plugin
+    stays a typed list aligned with ``Consequence``."""
+    import polars as pl
+
+    if per_variant:
+        return values.list.drop_nulls().list.first().cast(dtype)
+    return values.cast(pl.List(dtype))
+
+
 def _flags_for_projection(
     opts: dict, needed: set[str] | None, available: set[str] | None = None
 ) -> dict:
@@ -1528,6 +1550,10 @@ def annotate(
     # configured. The engine appends them after the base layout, whose length
     # depends on the flags, so they are read as the last fields of each entry.
     plugin_field_names: list[str] = []
+    # (csq_field, element dtype, per_variant): a plugin keyed only on the
+    # variant (no match_columns) carries one value per row, a per-feature
+    # plugin one value per consequence entry.
+    plugin_column_specs: list[tuple[str, "pl.DataType", bool]] = []
     if plugin_cache_root is not None and plugins != []:
         import os
 
@@ -1555,7 +1581,11 @@ def annotate(
                 value_columns = sorted(
                     value_columns, key=lambda column: column["csq_field"]
                 )
-            plugin_field_names.extend(column["csq_field"] for column in value_columns)
+            per_variant = not manifest.get("match_columns")
+            for column in value_columns:
+                dtype = _plugin_value_dtype(column.get("type"))
+                plugin_field_names.append(column["csq_field"])
+                plugin_column_specs.append((column["csq_field"], dtype, per_variant))
         if len(set(plugin_field_names)) != len(plugin_field_names):
             raise ValueError(
                 "selected plugins expose duplicate CSQ field names, which cannot be "
@@ -1602,12 +1632,12 @@ def annotate(
             name: polars_schema[name] for name in selected_dataframe_columns
         }
     if plugin_field_names:
-        for name in plugin_field_names:
+        for name, dtype, per_variant in plugin_column_specs:
             if name in polars_schema:
                 raise ValueError(
                     f"plugin CSQ field {name!r} conflicts with an existing DataFrame column"
                 )
-            polars_schema[name] = pl.List(pl.String)
+            polars_schema[name] = dtype if per_variant else pl.List(dtype)
         if skip_csq:
             polars_schema.pop("CSQ", None)
     del probe
@@ -1661,16 +1691,21 @@ def annotate(
             if plugin_field_names and "CSQ" in batch_df.columns:
                 n_plugin = len(plugin_field_names)
                 batch_df = batch_df.with_columns(
-                    pl.col("CSQ")
-                    .str.split(",")
-                    .list.eval(
-                        pl.element()
-                        .str.split("|")
-                        .list.get(index - n_plugin, null_on_oob=True)
-                        .replace("", None)
+                    _plugin_column(
+                        pl.col("CSQ")
+                        .str.split(",")
+                        .list.eval(
+                            pl.element()
+                            .str.split("|")
+                            .list.get(index - n_plugin, null_on_oob=True)
+                            .replace("", None)
+                        ),
+                        dtype,
+                        per_variant,
+                    ).alias(name)
+                    for index, (name, dtype, per_variant) in enumerate(
+                        plugin_column_specs
                     )
-                    .alias(name)
-                    for index, name in enumerate(plugin_field_names)
                 )
             if skip_csq and "CSQ" in batch_df.columns:
                 batch_df = batch_df.drop("CSQ")

--- a/src/vepyr/__init__.py
+++ b/src/vepyr/__init__.py
@@ -31,6 +31,158 @@ __version__ = importlib.metadata.version("vepyr")
 
 log = logging.getLogger(__name__)
 
+# Projection pushdown: which annotation flags each DataFrame column depends on.
+# Every other column has the same value whatever flags are set, so a
+# ``select()`` decides which groups the engine runs: unused groups are dropped
+# and, when no flag was given, needed groups are switched on. Verified column by column on HG002 chr22 against the
+# release-116 Ensembl cache; ``tests/test_annotate.py::TestProjectionPruning``
+# guards the value identity on the fixture cache.
+_HGVS_COLUMNS = frozenset({"HGVSc", "HGVSp"})
+_HGVS_OPTIONS = (
+    "hgvs",
+    "hgvsc",
+    "hgvsp",
+    "shift_hgvs",
+    "no_escape",
+    "remove_hgvsp_version",
+    "hgvsp_use_prediction",
+)
+_COLOCATED_COLUMNS = frozenset(
+    {
+        "Existing_variation",
+        "AF",
+        "AFR_AF",
+        "AMR_AF",
+        "EAS_AF",
+        "EUR_AF",
+        "SAS_AF",
+        "gnomADe_AF",
+        "gnomADg_AF",
+        "MAX_AF",
+        "MAX_AF_POPS",
+        "CLIN_SIG",
+        "SOMATIC",
+        "PHENO",
+        "PUBMED",
+        # cache-only columns: kept conservative, they come from the same lookup
+        "clin_sig_allele",
+        "clinical_impact",
+        "minor_allele",
+        "minor_allele_freq",
+        "clinvar_ids",
+        "cosmic_ids",
+        "dbsnp_ids",
+    }
+)
+_COLOCATED_OPTIONS = (
+    "check_existing",
+    "af",
+    "af_1kg",
+    "af_gnomade",
+    "af_gnomadg",
+    "max_af",
+    "pubmed",
+)
+# Columns only ``everything`` fills; selecting one keeps the flag as is.
+_EVERYTHING_ONLY_COLUMNS = frozenset(
+    {
+        "MANE",
+        "APPRIS",
+        "SIFT",
+        "PolyPhen",
+        "DOMAINS",
+        "miRNA",
+        "HGVS_OFFSET",
+        "gnomADe_AFR_AF",
+        "gnomADe_AMR_AF",
+        "gnomADe_ASJ_AF",
+        "gnomADe_EAS_AF",
+        "gnomADe_FIN_AF",
+        "gnomADe_MID_AF",
+        "gnomADe_NFE_AF",
+        "gnomADe_REMAINING_AF",
+        "gnomADe_SAS_AF",
+        "gnomADg_AFR_AF",
+        "gnomADg_AMI_AF",
+        "gnomADg_AMR_AF",
+        "gnomADg_ASJ_AF",
+        "gnomADg_EAS_AF",
+        "gnomADg_FIN_AF",
+        "gnomADg_MID_AF",
+        "gnomADg_NFE_AF",
+        "gnomADg_REMAINING_AF",
+        "gnomADg_SAS_AF",
+    }
+)
+
+
+def _flags_for_projection(opts: dict, needed: set[str] | None) -> dict:
+    """Derive the annotation flags a query needs from the columns it reads.
+
+    ``needed`` is the query's projection plus any filter columns; ``None``
+    means no projection, which leaves ``opts`` as given. Otherwise only three
+    column groups depend on flags at all (see the constants above):
+
+    - a group nobody selected has its flags removed, so the engine skips it;
+    - a group the user enabled explicitly is kept exactly as configured;
+    - a group the user did not mention is enabled when a column needs it.
+      HGVS and the ``everything`` extras need ``reference_fasta``; asking for
+      them without one is an error rather than a column of nulls.
+
+    The raw ``CSQ`` string and plugin output depend on the full flag set, so
+    those leave ``opts`` untouched. Returns a new dict.
+    """
+    out = dict(opts)
+    if needed is None or "CSQ" in needed or "plugin_cache_root" in opts:
+        return out
+
+    def _needs(group: frozenset) -> bool:
+        return bool(needed & group)
+
+    def _require_fasta(group: frozenset, flag: str) -> None:
+        if not out.get("reference_fasta_path"):
+            columns = ", ".join(sorted(needed & group))
+            raise ValueError(
+                f"selecting {columns} needs {flag}, which requires reference_fasta="
+            )
+
+    user_hgvs = any(opts.get(key) for key in ("hgvs", "hgvsc", "hgvsp"))
+    user_colocated = any(opts.get(key) for key in _COLOCATED_OPTIONS)
+
+    if _needs(_EVERYTHING_ONLY_COLUMNS):
+        if not opts.get("everything"):
+            _require_fasta(_EVERYTHING_ONLY_COLUMNS, "everything")
+            out["everything"] = True
+        return out  # everything covers every group; sub-options stay as given
+
+    keep_hgvs = _needs(_HGVS_COLUMNS)
+    keep_colocated = _needs(_COLOCATED_COLUMNS)
+    if out.pop("everything", False):
+        # Expand into the groups still needed; each alone yields the same
+        # column values as ``everything`` does.
+        if keep_hgvs:
+            out["hgvs"] = True
+        if keep_colocated:
+            for key in _COLOCATED_OPTIONS:
+                out[key] = True
+    else:
+        if keep_hgvs and not user_hgvs:
+            _require_fasta(_HGVS_COLUMNS, "hgvs")
+            out["hgvs"] = True
+        if keep_colocated and not user_colocated:
+            for key in _COLOCATED_OPTIONS:
+                out[key] = True
+    if not keep_hgvs:
+        for key in _HGVS_OPTIONS:
+            out.pop(key, None)
+    if not keep_colocated:
+        for key in _COLOCATED_OPTIONS:
+            out.pop(key, None)
+    if not any(out.get(key) for key in ("hgvs", "hgvsc", "hgvsp")):
+        out.pop("reference_fasta_path", None)
+    return out
+
+
 _CORE_CSQ_FIELDS = (
     "Allele",
     "Gene",
@@ -1051,6 +1203,11 @@ def annotate(
     polars.LazyFrame or str
         When ``output_vcf`` is ``None``: annotated variants as a polars
         ``LazyFrame`` with typed annotation columns plus original VCF fields.
+        A ``select()`` on it decides which annotation flags the engine runs:
+        the groups no selected column needs are switched off, and, when no
+        flag was given, the groups a column needs are switched on (HGVS and
+        the ``everything`` extras require ``reference_fasta``). ``fields``
+        cannot be combined with such a ``select()``.
         When ``output_vcf`` is set: the output VCF file path.
 
     Examples
@@ -1439,16 +1596,29 @@ def annotate(
     _vcf, _cache_dir, _opts, _engine_skip = (
         vcf,
         cache_dir,
-        options_json,
+        dict(opts),
         engine_skip_csq,
     )
 
     def _batch_source(with_columns, predicate, n_rows, batch_size):
-        # Pass n_rows as LIMIT to the DataFusion query for engine-level pushdown
+        # Projection pushdown: the columns Polars asks for, plus the ones the
+        # pushed-down filter reads, decide which annotation flags the engine
+        # needs. n_rows becomes a LIMIT in the DataFusion query.
+        needed = None
+        if with_columns is not None and set(with_columns) != set(polars_schema):
+            if "fields" in _opts:
+                raise ValueError(
+                    "annotate(fields=...) already fixes the annotation layout; "
+                    "select columns on the LazyFrame or pass fields=, not both"
+                )
+            needed = set(with_columns)
+            if predicate is not None:
+                needed.update(predicate.meta.root_names())
+        engine_opts = _flags_for_projection(_opts, needed)
         annotator = _create_annotator(
             _vcf,
             _cache_dir,
-            _opts,
+            json.dumps(engine_opts),
             _engine_skip,
             n_rows,
         )

--- a/src/vepyr/__init__.py
+++ b/src/vepyr/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import importlib.metadata
 import logging
+import re
 import warnings
 from collections.abc import Callable, Iterator
 from typing import TYPE_CHECKING
@@ -1554,6 +1555,9 @@ def annotate(
     # variant (no match_columns) carries one value per row, a per-feature
     # plugin one value per consequence entry.
     plugin_column_specs: list[tuple[str, "pl.DataType", bool]] = []
+    # Fields a plugin's match templates read (``{HGVSc}`` say), per plugin
+    # column: reading the column needs those fields' flags too.
+    plugin_column_inputs: dict[str, set[str]] = {}
     if plugin_cache_root is not None and plugins != []:
         import os
 
@@ -1581,11 +1585,18 @@ def annotate(
                 value_columns = sorted(
                     value_columns, key=lambda column: column["csq_field"]
                 )
-            per_variant = not manifest.get("match_columns")
+            match_columns = manifest.get("match_columns") or []
+            per_variant = not match_columns
+            template_fields = {
+                field
+                for match in match_columns
+                for field in re.findall(r"\{([^{}]+)\}", match.get("template", ""))
+            }
             for column in value_columns:
                 dtype = _plugin_value_dtype(column.get("type"))
                 plugin_field_names.append(column["csq_field"])
                 plugin_column_specs.append((column["csq_field"], dtype, per_variant))
+                plugin_column_inputs[column["csq_field"]] = template_fields
         if len(set(plugin_field_names)) != len(plugin_field_names):
             raise ValueError(
                 "selected plugins expose duplicate CSQ field names, which cannot be "
@@ -1666,6 +1677,8 @@ def annotate(
             needed = set(with_columns)
             if predicate is not None:
                 needed.update(predicate.meta.root_names())
+            for column in needed & plugin_columns:
+                needed |= plugin_column_inputs[column]
         engine_opts = _flags_for_projection(_opts, needed, set(polars_schema))
         # The CSQ string is only built when the query reads it or a plugin
         # column parsed out of it.

--- a/src/vepyr/__init__.py
+++ b/src/vepyr/__init__.py
@@ -147,7 +147,10 @@ def _plugin_column(values, dtype, per_variant: bool):
 
 
 def _flags_for_projection(
-    opts: dict, needed: set[str] | None, available: set[str] | None = None
+    opts: dict,
+    needed: set[str] | None,
+    available: set[str] | None = None,
+    required: frozenset[str] | set[str] = frozenset(),
 ) -> dict:
     """Derive the annotation flags a query needs from the columns it reads.
 
@@ -164,12 +167,41 @@ def _flags_for_projection(
       them without one is an error rather than a column of nulls.
 
     ``available`` is the frame's column set; it limits the no-FASTA warning
-    to columns the frame has. Returns a new dict.
+    to columns the frame has. ``required`` names fields that must be computed
+    whatever the projection, the fields a plugin's match templates read: their
+    groups are switched on even when other flags were given explicitly.
+    Returns a new dict.
     """
     out = dict(opts)
     user_hgvs = any(opts.get(key) for key in ("hgvs", "hgvsc", "hgvsp"))
     user_colocated = any(opts.get(key) for key in _COLOCATED_OPTIONS)
     user_any_flag = bool(opts.get("everything")) or user_hgvs or user_colocated
+
+    def _require_fasta(group: frozenset, flag: str, fields: set[str]) -> None:
+        if not out.get("reference_fasta_path"):
+            columns = ", ".join(sorted(fields & group))
+            raise ValueError(
+                f"selecting {columns} needs {flag}, which requires reference_fasta="
+            )
+
+    def _ensure(fields: set[str]) -> None:
+        """Switch on the groups ``fields`` need, whatever the user set."""
+        if fields & _EVERYTHING_ONLY_COLUMNS and not out.get("everything"):
+            _require_fasta(_EVERYTHING_ONLY_COLUMNS, "everything", fields)
+            out["everything"] = True
+        if out.get("everything"):
+            return
+        if fields & _HGVS_COLUMNS and not any(
+            out.get(key) for key in ("hgvs", "hgvsc", "hgvsp")
+        ):
+            _require_fasta(_HGVS_COLUMNS, "hgvs", fields)
+            out["hgvs"] = True
+        if fields & _COLOCATED_COLUMNS and not any(
+            out.get(key) for key in _COLOCATED_OPTIONS
+        ):
+            for key in _COLOCATED_OPTIONS:
+                out[key] = True
+
     if needed is None or "CSQ" in needed:
         # No projection, or the raw CSQ string (which needs every flag): flags
         # as given, or, when none were given, everything the inputs allow.
@@ -191,21 +223,17 @@ def _flags_for_projection(
                         "for the full result",
                         stacklevel=2,
                     )
+        _ensure(set(required))
         return out
+
+    needed = needed | set(required)
 
     def _needs(group: frozenset) -> bool:
         return bool(needed & group)
 
-    def _require_fasta(group: frozenset, flag: str) -> None:
-        if not out.get("reference_fasta_path"):
-            columns = ", ".join(sorted(needed & group))
-            raise ValueError(
-                f"selecting {columns} needs {flag}, which requires reference_fasta="
-            )
-
     if _needs(_EVERYTHING_ONLY_COLUMNS):
         if not opts.get("everything"):
-            _require_fasta(_EVERYTHING_ONLY_COLUMNS, "everything")
+            _require_fasta(_EVERYTHING_ONLY_COLUMNS, "everything", needed)
             out["everything"] = True
         return out  # everything covers every group; sub-options stay as given
 
@@ -221,7 +249,7 @@ def _flags_for_projection(
                 out[key] = True
     else:
         if keep_hgvs and not user_hgvs:
-            _require_fasta(_HGVS_COLUMNS, "hgvs")
+            _require_fasta(_HGVS_COLUMNS, "hgvs", needed)
             out["hgvs"] = True
         if keep_colocated and not user_colocated:
             for key in _COLOCATED_OPTIONS:
@@ -1682,9 +1710,12 @@ def annotate(
             needed = set(with_columns)
             if predicate is not None:
                 needed.update(predicate.meta.root_names())
-            for column in needed & plugin_columns:
-                needed |= plugin_column_inputs[column]
-        engine_opts = _flags_for_projection(_opts, needed, set(polars_schema))
+        # Fields the match templates of every plugin column read, this query
+        # included, must be computed whatever flags were given: a plugin whose
+        # template needs HGVSc is null without hgvs.
+        read_plugins = plugin_columns if needed is None else needed & plugin_columns
+        required = set().union(*(plugin_column_inputs[c] for c in read_plugins))
+        engine_opts = _flags_for_projection(_opts, needed, set(polars_schema), required)
         # The CSQ string is only built when the query reads it or a plugin
         # column parsed out of it.
         if needed is None:

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -1913,3 +1913,87 @@ class TestPluginColumns:
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             vepyr.annotate("in.vcf", CACHE_DIR, fields="core").collect()
+
+
+class TestPluginMatchTemplates:
+    """A per-feature plugin's match template can reference a flag-dependent
+    field (``{HGVSc}`` say); reading that plugin's column then needs the
+    field's flags even though the field itself is not selected."""
+
+    def _hgvs_plugin(self, tmp_path, monkeypatch):
+        import pyarrow as pa
+        import vepyr
+
+        root = Path(_fake_plugin_root(tmp_path, ["byhgvs"]))
+        (root / "plugin" / "byhgvs" / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "plugin_name": "byhgvs",
+                    "field_order": "declared",
+                    "match_columns": [{"column": "hgvsc", "template": "{HGVSc}"}],
+                    "value_columns": [
+                        {
+                            "column": "score",
+                            "csq_field": "BYHGVS_score",
+                            "type": "Float32",
+                        }
+                    ],
+                }
+            )
+        )
+        names = ["chrom", "CSQ", "most_severe_consequence", "Consequence", "HGVSc"]
+        calls = []
+
+        class FakeAnnotator:
+            schema = pa.schema([pa.field(n, pa.string()) for n in names])
+
+            def __iter__(self):
+                return iter(())
+
+        def fake(vcf, cache_dir, options_json, skip_csq, limit):
+            calls.append(json.loads(options_json))
+            return FakeAnnotator()
+
+        monkeypatch.setattr(vepyr, "_create_annotator", fake)
+        return str(root), calls
+
+    def test_template_fields_keep_their_flags(self, tmp_path, monkeypatch):
+        import vepyr
+
+        root, calls = self._hgvs_plugin(tmp_path, monkeypatch)
+        vepyr.annotate(
+            "in.vcf",
+            CACHE_DIR,
+            everything=True,
+            reference_fasta=REFERENCE_FASTA,
+            plugin_cache_root=root,
+            plugins=["byhgvs"],
+        ).select("chrom", "BYHGVS_score").collect()
+        opts = calls[-1]
+        assert opts["hgvs"] is True and opts["reference_fasta_path"] == REFERENCE_FASTA
+        assert "check_existing" not in opts
+
+    def test_template_fields_are_inferred_on_a_flagless_frame(
+        self, tmp_path, monkeypatch
+    ):
+        import vepyr
+
+        root, calls = self._hgvs_plugin(tmp_path, monkeypatch)
+        vepyr.annotate(
+            "in.vcf",
+            CACHE_DIR,
+            reference_fasta=REFERENCE_FASTA,
+            plugin_cache_root=root,
+            plugins=["byhgvs"],
+        ).select("chrom", "BYHGVS_score").collect()
+        assert calls[-1]["hgvs"] is True
+
+    def test_template_fields_without_fasta_raise(self, tmp_path, monkeypatch):
+        import vepyr
+
+        root, _ = self._hgvs_plugin(tmp_path, monkeypatch)
+        lf = vepyr.annotate(
+            "in.vcf", CACHE_DIR, plugin_cache_root=root, plugins=["byhgvs"]
+        )
+        with pytest.raises(Exception, match="HGVSc.*reference_fasta"):
+            lf.select("chrom", "BYHGVS_score").collect()

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -1476,6 +1476,7 @@ class TestFlagInference:
             "AFR_AF",
             "MANE",
             "SIFT",
+            "MOTIF_NAME",
             "dbsnp_ids",
         ]
 
@@ -1541,6 +1542,16 @@ class TestFlagInference:
         ).collect()
         assert seen[-1]["everything"] is True
         assert seen[-1]["reference_fasta_path"] == REFERENCE_FASTA
+
+    def test_motif_columns_infer_everything(self, monkeypatch):
+        # the motif fields exist only in the everything CSQ layout
+        import vepyr
+
+        seen = self._capture(monkeypatch)
+        vepyr.annotate(INPUT_VCF, CACHE_DIR, reference_fasta=REFERENCE_FASTA).select(
+            ["chrom", "MOTIF_NAME"]
+        ).collect()
+        assert seen[-1]["everything"] is True
 
     def test_everything_only_column_without_fasta_is_an_error(self, monkeypatch):
         import vepyr

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -1208,3 +1208,402 @@ def test_annotate_nonempty_plugins_warns_only_when_csq_is_dropped(
                 )
         hits = [w for w in caught if "skip_csq" in str(w.message)]
         assert len(hits) == expected, f"skip_csq={skip_csq}"
+
+
+class TestProjectionPruning:
+    """A ``select()`` on the LazyFrame is translated into the smallest flag set
+    that still yields the selected columns, so the engine skips HGVS, the
+    co-located lookup and the ``everything`` extras when nothing asks for them."""
+
+    BASE = ("chrom", "start", "ref", "alt", "SYMBOL", "Consequence", "IMPACT")
+
+    def _capture(self, monkeypatch):
+        import pyarrow as pa
+        import vepyr
+
+        seen = []
+        names = [
+            "chrom",
+            "start",
+            "ref",
+            "alt",
+            "CSQ",
+            "most_severe_consequence",
+            "SYMBOL",
+            "Consequence",
+            "IMPACT",
+            "HGVSc",
+            "AF",
+            "MANE",
+            "dbsnp_ids",
+        ]
+
+        class FakeAnnotator:
+            schema = pa.schema([pa.field(n, pa.string()) for n in names])
+
+            def __iter__(self):
+                return iter(())
+
+        def fake_create_annotator(
+            vcf_path, cache_dir, options_json, skip_csq=True, limit=None
+        ):
+            seen.append(json.loads(options_json))
+            return FakeAnnotator()
+
+        monkeypatch.setattr(vepyr, "_create_annotator", fake_create_annotator)
+        return seen
+
+    def _engine_opts(self, seen):
+        # seen[0] is the schema probe, seen[1] the collect
+        assert len(seen) == 2
+        return seen[1]
+
+    def test_everything_is_dropped_when_only_base_columns_are_selected(
+        self, monkeypatch
+    ):
+        import vepyr
+
+        seen = self._capture(monkeypatch)
+        vepyr.annotate(
+            INPUT_VCF, CACHE_DIR, everything=True, reference_fasta=REFERENCE_FASTA
+        ).select(list(self.BASE)).collect()
+        opts = self._engine_opts(seen)
+        for key in (
+            "everything",
+            "hgvs",
+            "check_existing",
+            "af",
+            "pubmed",
+            "reference_fasta_path",
+        ):
+            assert key not in opts, key
+        assert opts["cache_format"] == "parquet"
+
+    def test_hgvs_column_keeps_hgvs_only(self, monkeypatch):
+        import vepyr
+
+        seen = self._capture(monkeypatch)
+        vepyr.annotate(
+            INPUT_VCF, CACHE_DIR, everything=True, reference_fasta=REFERENCE_FASTA
+        ).select(["chrom", "HGVSc"]).collect()
+        opts = self._engine_opts(seen)
+        assert opts["hgvs"] is True
+        assert opts["reference_fasta_path"] == REFERENCE_FASTA
+        assert "everything" not in opts
+        assert "check_existing" not in opts
+
+    def test_frequency_column_keeps_colocated_flags_only(self, monkeypatch):
+        import vepyr
+
+        seen = self._capture(monkeypatch)
+        vepyr.annotate(
+            INPUT_VCF, CACHE_DIR, everything=True, reference_fasta=REFERENCE_FASTA
+        ).select(["chrom", "AF"]).collect()
+        opts = self._engine_opts(seen)
+        for key in (
+            "check_existing",
+            "af",
+            "af_1kg",
+            "af_gnomade",
+            "af_gnomadg",
+            "max_af",
+            "pubmed",
+        ):
+            assert opts[key] is True, key
+        assert "everything" not in opts
+        assert "hgvs" not in opts
+        assert "reference_fasta_path" not in opts
+
+    def test_everything_only_column_keeps_everything(self, monkeypatch):
+        import vepyr
+
+        seen = self._capture(monkeypatch)
+        vepyr.annotate(
+            INPUT_VCF, CACHE_DIR, everything=True, reference_fasta=REFERENCE_FASTA
+        ).select(["chrom", "MANE"]).collect()
+        assert self._engine_opts(seen)["everything"] is True
+
+    def test_csq_column_disables_pruning(self, monkeypatch):
+        import vepyr
+
+        seen = self._capture(monkeypatch)
+        vepyr.annotate(
+            INPUT_VCF,
+            CACHE_DIR,
+            everything=True,
+            reference_fasta=REFERENCE_FASTA,
+            skip_csq=False,
+        ).select(["chrom", "CSQ"]).collect()
+        assert self._engine_opts(seen)["everything"] is True
+
+    def test_individual_flags_are_pruned_too(self, monkeypatch):
+        import vepyr
+
+        seen = self._capture(monkeypatch)
+        vepyr.annotate(
+            INPUT_VCF,
+            CACHE_DIR,
+            hgvs=True,
+            reference_fasta=REFERENCE_FASTA,
+            af=True,
+            pubmed=True,
+        ).select(["chrom", "Consequence"]).collect()
+        opts = self._engine_opts(seen)
+        for key in ("hgvs", "af", "pubmed", "reference_fasta_path"):
+            assert key not in opts, key
+
+    def test_filter_column_counts_as_needed(self, monkeypatch):
+        import vepyr
+
+        seen = self._capture(monkeypatch)
+        (
+            vepyr.annotate(
+                INPUT_VCF, CACHE_DIR, everything=True, reference_fasta=REFERENCE_FASTA
+            )
+            .filter(pl.col("AF") > 0.5)
+            .select(["chrom"])
+            .collect()
+        )
+        assert self._engine_opts(seen)["af"] is True
+
+    def test_no_select_keeps_everything(self, monkeypatch):
+        import vepyr
+
+        seen = self._capture(monkeypatch)
+        vepyr.annotate(
+            INPUT_VCF, CACHE_DIR, everything=True, reference_fasta=REFERENCE_FASTA
+        ).collect()
+        assert self._engine_opts(seen)["everything"] is True
+
+    def test_fields_and_select_together_is_an_error(self, monkeypatch):
+        import vepyr
+
+        self._capture(monkeypatch)
+        lf = vepyr.annotate(
+            INPUT_VCF,
+            CACHE_DIR,
+            everything=True,
+            reference_fasta=REFERENCE_FASTA,
+            fields=["Consequence", "IMPACT"],
+        )
+        # Polars wraps the source's ValueError in a ComputeError; match the text.
+        with pytest.raises(Exception, match="already fixes the annotation layout"):
+            lf.select(["chrom", "Consequence"]).collect()
+
+    def test_fields_without_a_narrowing_select_is_fine(self, monkeypatch):
+        import vepyr
+
+        seen = self._capture(monkeypatch)
+        lf = vepyr.annotate(
+            INPUT_VCF,
+            CACHE_DIR,
+            everything=True,
+            reference_fasta=REFERENCE_FASTA,
+            fields=["Consequence", "IMPACT"],
+        )
+        lf.collect()
+        lf.select(pl.all()).collect()
+        lf.select(list(lf.collect_schema())).collect()
+        assert all(
+            o["everything"] is True and o["fields"] == ["Consequence", "IMPACT"]
+            for o in seen
+        )
+
+    @pytest.mark.parametrize(
+        "columns",
+        [
+            [
+                "chrom",
+                "start",
+                "ref",
+                "alt",
+                "most_severe_consequence",
+                "SYMBOL",
+                "Consequence",
+                "IMPACT",
+            ],
+            ["chrom", "start", "HGVSc", "HGVSp"],
+            ["chrom", "start", "Existing_variation", "AF", "MAX_AF", "CLIN_SIG"],
+            ["chrom", "start", "Consequence", "dbsnp_ids"],
+        ],
+    )
+    def test_pruned_values_equal_the_full_run(self, metadata_cache_dir, columns):
+        import vepyr
+
+        lf = vepyr.annotate(
+            INPUT_VCF,
+            metadata_cache_dir,
+            everything=True,
+            reference_fasta=REFERENCE_FASTA,
+        )
+        full = lf.collect().select(columns)
+        pruned = lf.select(columns).collect()
+        assert pruned.equals(full)
+
+
+class TestFlagInference:
+    """With no annotation flags given, a narrowing ``select()`` turns on the flag
+    groups its columns need. Explicit flags are kept as given (and pruned when
+    unused) rather than widened."""
+
+    def _capture(self, monkeypatch):
+        import pyarrow as pa
+        import vepyr
+
+        seen = []
+        names = [
+            "chrom",
+            "start",
+            "ref",
+            "alt",
+            "CSQ",
+            "most_severe_consequence",
+            "SYMBOL",
+            "Consequence",
+            "IMPACT",
+            "HGVSc",
+            "AF",
+            "AFR_AF",
+            "MANE",
+            "SIFT",
+            "dbsnp_ids",
+        ]
+
+        class FakeAnnotator:
+            schema = pa.schema([pa.field(n, pa.string()) for n in names])
+
+            def __iter__(self):
+                return iter(())
+
+        def fake_create_annotator(
+            vcf_path, cache_dir, options_json, skip_csq=True, limit=None
+        ):
+            seen.append(json.loads(options_json))
+            return FakeAnnotator()
+
+        monkeypatch.setattr(vepyr, "_create_annotator", fake_create_annotator)
+        return seen
+
+    def test_hgvs_is_inferred_from_hgvs_columns(self, monkeypatch):
+        import vepyr
+
+        seen = self._capture(monkeypatch)
+        vepyr.annotate(INPUT_VCF, CACHE_DIR, reference_fasta=REFERENCE_FASTA).select(
+            ["chrom", "HGVSc"]
+        ).collect()
+        opts = seen[-1]
+        assert opts["hgvs"] is True
+        assert opts["reference_fasta_path"] == REFERENCE_FASTA
+        assert "check_existing" not in opts and "everything" not in opts
+
+    def test_hgvs_column_without_fasta_is_an_error(self, monkeypatch):
+        import vepyr
+
+        self._capture(monkeypatch)
+        lf = vepyr.annotate(INPUT_VCF, CACHE_DIR)
+        with pytest.raises(Exception, match="HGVSc.*reference_fasta"):
+            lf.select(["chrom", "HGVSc"]).collect()
+
+    def test_colocated_flags_are_inferred_from_frequency_columns(self, monkeypatch):
+        import vepyr
+
+        seen = self._capture(monkeypatch)
+        vepyr.annotate(INPUT_VCF, CACHE_DIR).select(["chrom", "AF"]).collect()
+        opts = seen[-1]
+        for key in (
+            "check_existing",
+            "af",
+            "af_1kg",
+            "af_gnomade",
+            "af_gnomadg",
+            "max_af",
+            "pubmed",
+        ):
+            assert opts[key] is True, key
+        assert "hgvs" not in opts and "reference_fasta_path" not in opts
+
+    def test_everything_is_inferred_from_everything_only_columns(self, monkeypatch):
+        import vepyr
+
+        seen = self._capture(monkeypatch)
+        vepyr.annotate(INPUT_VCF, CACHE_DIR, reference_fasta=REFERENCE_FASTA).select(
+            ["chrom", "SIFT"]
+        ).collect()
+        assert seen[-1]["everything"] is True
+        assert seen[-1]["reference_fasta_path"] == REFERENCE_FASTA
+
+    def test_everything_only_column_without_fasta_is_an_error(self, monkeypatch):
+        import vepyr
+
+        self._capture(monkeypatch)
+        lf = vepyr.annotate(INPUT_VCF, CACHE_DIR)
+        with pytest.raises(Exception, match="SIFT.*reference_fasta"):
+            lf.select(["chrom", "SIFT"]).collect()
+
+    def test_explicit_partial_flags_are_not_widened(self, monkeypatch):
+        import vepyr
+
+        seen = self._capture(monkeypatch)
+        vepyr.annotate(INPUT_VCF, CACHE_DIR, af=True).select(
+            ["chrom", "AFR_AF"]
+        ).collect()
+        opts = seen[-1]
+        assert opts["af"] is True
+        assert "af_1kg" not in opts
+        assert "check_existing" not in opts
+
+    def test_explicit_hgvs_sub_options_are_kept(self, monkeypatch):
+        import vepyr
+
+        seen = self._capture(monkeypatch)
+        vepyr.annotate(
+            INPUT_VCF,
+            CACHE_DIR,
+            hgvs=True,
+            shift_hgvs=False,
+            reference_fasta=REFERENCE_FASTA,
+        ).select(["chrom", "HGVSc"]).collect()
+        assert seen[-1]["hgvs"] is True
+        assert seen[-1]["shift_hgvs"] is False
+
+    def test_plain_collect_without_flags_stays_bare(self, monkeypatch):
+        import vepyr
+
+        seen = self._capture(monkeypatch)
+        vepyr.annotate(INPUT_VCF, CACHE_DIR, reference_fasta=REFERENCE_FASTA).collect()
+        opts = seen[-1]
+        assert (
+            "hgvs" not in opts
+            and "everything" not in opts
+            and "check_existing" not in opts
+        )
+
+    @pytest.mark.parametrize(
+        "columns",
+        [
+            ["chrom", "start", "HGVSc", "HGVSp"],
+            ["chrom", "start", "Existing_variation", "AF", "MAX_AF", "CLIN_SIG"],
+            ["chrom", "start", "SIFT", "PolyPhen", "MANE", "HGVS_OFFSET"],
+        ],
+    )
+    def test_inferred_values_equal_an_everything_run(self, metadata_cache_dir, columns):
+        import vepyr
+
+        everything = (
+            vepyr.annotate(
+                INPUT_VCF,
+                metadata_cache_dir,
+                everything=True,
+                reference_fasta=REFERENCE_FASTA,
+            )
+            .collect()
+            .select(columns)
+        )
+        inferred = (
+            vepyr.annotate(
+                INPUT_VCF, metadata_cache_dir, reference_fasta=REFERENCE_FASTA
+            )
+            .select(columns)
+            .collect()
+        )
+        assert inferred.equals(everything)

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -232,9 +232,7 @@ class TestPartialPluginCache:
         ).collect()
         assert "DEMO" in frame.columns
         assert "DISTANCE" not in frame.columns
-        assert any(
-            value is not None for values in frame["DEMO"].to_list() for value in values
-        )
+        assert frame["DEMO"].is_not_null().sum() == 2
 
     def test_annotates_the_contigs_it_has(
         self,
@@ -1156,8 +1154,9 @@ def test_selected_plugin_fields_are_named_dataframe_columns(tmp_path, monkeypatc
         "CADD_PHRED",
         "CADD_RAW",
     ]
-    assert result["CADD_PHRED"].to_list() == [["24.5"]]
-    assert result["CADD_RAW"].to_list() == [["0.12"]]
+    # No match_columns in the manifest: a per-variant plugin, one value per row.
+    assert result["CADD_PHRED"].to_list() == ["24.5"]
+    assert result["CADD_RAW"].to_list() == ["0.12"]
 
 
 def test_annotate_empty_plugins_is_plugin_free_without_cache_validation(
@@ -1677,8 +1676,31 @@ class TestPluginColumns:
                     "plugin_name": "cadd",
                     "field_order": "declared",
                     "value_columns": [
-                        {"column": "phred", "csq_field": "CADD_PHRED"},
-                        {"column": "raw", "csq_field": "CADD_RAW"},
+                        {"column": "phred", "csq_field": "CADD_PHRED", "type": "Utf8"},
+                        {"column": "raw", "csq_field": "CADD_RAW", "type": "Utf8"},
+                    ],
+                }
+            )
+        )
+        # A per-feature plugin (match_columns set) with typed values.
+        (root / "plugin" / "spliceai").mkdir()
+        (root / "plugin" / "spliceai" / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "plugin_name": "spliceai",
+                    "field_order": "declared",
+                    "match_columns": [{"column": "symbol", "template": "{SYMBOL}"}],
+                    "value_columns": [
+                        {
+                            "column": "ds_ag",
+                            "csq_field": "SpliceAI_DS_AG",
+                            "type": "Float32",
+                        },
+                        {
+                            "column": "dp_ag",
+                            "csq_field": "SpliceAI_DP_AG",
+                            "type": "Int32",
+                        },
                     ],
                 }
             )
@@ -1688,14 +1710,21 @@ class TestPluginColumns:
         calls = []
 
         class FakeAnnotator:
-            def __init__(self, skip_csq):
+            def __init__(self, skip_csq, plugin_names):
                 self.schema = schema
                 self.skip_csq = skip_csq
+                self.plugin_names = plugin_names
 
             def __iter__(self):
-                # The engine's CSQ layout is flag-dependent; plugin values are
-                # always its last fields. Two entries here.
-                csq = "G|missense_variant|A|B|24.5|0.12,G|intron_variant|A|B||"
+                # The engine's CSQ layout is flag-dependent; the requested
+                # plugins' values are always its last fields. Two entries here.
+                tails = {
+                    "cadd": ("24.5|0.12", "24.5|0.12"),
+                    "spliceai": ("0.91|8", "|"),
+                }
+                first = "|".join(tails[p][0] for p in self.plugin_names)
+                second = "|".join(tails[p][1] for p in self.plugin_names)
+                csq = f"G|missense_variant|A|B|{first},G|intron_variant|A|B|{second}"
                 cols = {
                     "chrom": ["1"],
                     "CSQ": [csq],
@@ -1711,8 +1740,9 @@ class TestPluginColumns:
                 )
 
         def fake(vcf, cache_dir, options_json, skip_csq, limit):
-            calls.append((json.loads(options_json), skip_csq))
-            return FakeAnnotator(skip_csq)
+            opts = json.loads(options_json)
+            calls.append((opts, skip_csq))
+            return FakeAnnotator(skip_csq, opts.get("plugins", []))
 
         monkeypatch.setattr(vepyr, "_create_annotator", fake)
         return str(root), calls
@@ -1729,12 +1759,13 @@ class TestPluginColumns:
                 "in.vcf", CACHE_DIR, plugin_cache_root=root, plugins=["cadd"]
             )
         schema = lf.collect_schema()
-        assert schema["CADD_PHRED"] == pl.List(pl.String)
-        assert schema["CADD_RAW"] == pl.List(pl.String)
+        # per-variant plugin: one scalar per row, typed as the manifest says
+        assert schema["CADD_PHRED"] == pl.String
+        assert schema["CADD_RAW"] == pl.String
         assert "CSQ" not in schema
         df = lf.collect()
-        assert df["CADD_PHRED"].to_list() == [["24.5", None]]
-        assert df["CADD_RAW"].to_list() == [["0.12", None]]
+        assert df["CADD_PHRED"].to_list() == ["24.5"]
+        assert df["CADD_RAW"].to_list() == ["0.12"]
         assert "CSQ" not in df.columns
         assert calls[-1][1] is False, "CSQ built because the plugin columns were read"
 
@@ -1752,8 +1783,31 @@ class TestPluginColumns:
             .collect()
         )
         assert df.columns == ["chrom", "CADD_PHRED"]
-        assert df["CADD_PHRED"].to_list() == [["24.5", None]]
+        assert df["CADD_PHRED"].to_list() == ["24.5"]
         assert calls[-1][1] is False
+
+    def test_per_feature_plugin_is_a_typed_list_aligned_with_consequence(
+        self, tmp_path, monkeypatch
+    ):
+        import vepyr
+
+        root, _ = self._fake_cadd(tmp_path, monkeypatch)
+        lf = vepyr.annotate(
+            "in.vcf", CACHE_DIR, plugin_cache_root=root, plugins=["cadd", "spliceai"]
+        )
+        schema = lf.collect_schema()
+        assert schema["SpliceAI_DS_AG"] == pl.List(pl.Float32)
+        assert schema["SpliceAI_DP_AG"] == pl.List(pl.Int32)
+        df = lf.collect()
+        assert df["SpliceAI_DS_AG"].to_list() == [[pytest.approx(0.91), None]]
+        assert df["SpliceAI_DP_AG"].to_list() == [[8, None]]
+        assert df["CADD_PHRED"].to_list() == ["24.5"]
+        assert list(df.columns[-4:]) == [
+            "CADD_PHRED",
+            "CADD_RAW",
+            "SpliceAI_DS_AG",
+            "SpliceAI_DP_AG",
+        ]
 
     def test_selecting_only_base_columns_skips_the_csq_string(
         self, tmp_path, monkeypatch
@@ -1837,7 +1891,9 @@ class TestPluginColumns:
             .select("chrom", "start", "ref", "alt", "DEMO")
         )
         assert plain.equals(core)
-        assert any(v is not None for vs in plain["DEMO"].to_list() for v in vs)
+        # per-variant plugin, declared Float32 in its manifest: a typed scalar
+        assert plain.schema["DEMO"] == pl.Float32
+        assert sorted(plain["DEMO"].drop_nulls().to_list()) == [0.25, 0.5]
 
     def test_fields_core_without_fasta_does_not_warn_about_absent_columns(
         self, monkeypatch

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -1184,9 +1184,9 @@ def test_annotate_empty_plugins_is_plugin_free_without_cache_validation(
     assert [w for w in caught if "skip_csq" in str(w.message)] == []
 
 
-def test_annotate_nonempty_plugins_warns_only_when_csq_is_dropped(
-    tmp_path, monkeypatch
-):
+def test_annotate_nonempty_plugins_never_warn_about_csq(tmp_path, monkeypatch):
+    """Plugin fields are named columns on the DataFrame path whatever skip_csq
+    is, so there is nothing to warn about."""
     import vepyr
 
     root = _fake_plugin_root(tmp_path, ["cadd"])
@@ -1195,7 +1195,7 @@ def test_annotate_nonempty_plugins_warns_only_when_csq_is_dropped(
         raise _Stop()
 
     monkeypatch.setattr(vepyr, "_create_annotator", fake)
-    for skip_csq, expected in ((True, 1), (False, 0)):
+    for skip_csq in (True, False):
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             with pytest.raises(_Stop):
@@ -1206,8 +1206,7 @@ def test_annotate_nonempty_plugins_warns_only_when_csq_is_dropped(
                     plugins=["cadd"],
                     skip_csq=skip_csq,
                 )
-        hits = [w for w in caught if "skip_csq" in str(w.message)]
-        assert len(hits) == expected, f"skip_csq={skip_csq}"
+        assert not [w for w in caught if "skip_csq" in str(w.message)]
 
 
 class TestProjectionPruning:
@@ -1660,3 +1659,201 @@ class TestFlagInference:
             .collect()
         )
         assert inferred.equals(everything)
+
+
+class TestPluginColumns:
+    """Plugin CSQ fields are named LazyFrame columns whenever a plugin cache is
+    configured, with or without ``fields=``, and a query only pays for the CSQ
+    string when it reads a plugin column (or ``CSQ`` itself)."""
+
+    def _fake_cadd(self, tmp_path, monkeypatch):
+        import pyarrow as pa
+        import vepyr
+
+        root = Path(_fake_plugin_root(tmp_path, ["cadd"]))
+        (root / "plugin" / "cadd" / "manifest.json").write_text(
+            json.dumps(
+                {
+                    "plugin_name": "cadd",
+                    "field_order": "declared",
+                    "value_columns": [
+                        {"column": "phred", "csq_field": "CADD_PHRED"},
+                        {"column": "raw", "csq_field": "CADD_RAW"},
+                    ],
+                }
+            )
+        )
+        base = ["chrom", "CSQ", "most_severe_consequence", "SYMBOL", "Consequence"]
+        schema = pa.schema([pa.field(n, pa.string()) for n in base])
+        calls = []
+
+        class FakeAnnotator:
+            def __init__(self, skip_csq):
+                self.schema = schema
+                self.skip_csq = skip_csq
+
+            def __iter__(self):
+                # The engine's CSQ layout is flag-dependent; plugin values are
+                # always its last fields. Two entries here.
+                csq = "G|missense_variant|A|B|24.5|0.12,G|intron_variant|A|B||"
+                cols = {
+                    "chrom": ["1"],
+                    "CSQ": [csq],
+                    "most_severe_consequence": ["missense_variant"],
+                    "SYMBOL": ["X"],
+                    "Consequence": ["missense_variant"],
+                }
+                if self.skip_csq:
+                    cols.pop("CSQ")
+                yield pa.record_batch(
+                    [pa.array(v) for v in cols.values()],
+                    schema=pa.schema([pa.field(n, pa.string()) for n in cols]),
+                )
+
+        def fake(vcf, cache_dir, options_json, skip_csq, limit):
+            calls.append((json.loads(options_json), skip_csq))
+            return FakeAnnotator(skip_csq)
+
+        monkeypatch.setattr(vepyr, "_create_annotator", fake)
+        return str(root), calls
+
+    def test_plugin_columns_exist_without_fields(self, tmp_path, monkeypatch):
+        import vepyr
+
+        root, calls = self._fake_cadd(tmp_path, monkeypatch)
+        with warnings.catch_warnings():
+            warnings.simplefilter(
+                "error"
+            )  # the old "emitted inside CSQ" warning is gone
+            lf = vepyr.annotate(
+                "in.vcf", CACHE_DIR, plugin_cache_root=root, plugins=["cadd"]
+            )
+        schema = lf.collect_schema()
+        assert schema["CADD_PHRED"] == pl.List(pl.String)
+        assert schema["CADD_RAW"] == pl.List(pl.String)
+        assert "CSQ" not in schema
+        df = lf.collect()
+        assert df["CADD_PHRED"].to_list() == [["24.5", None]]
+        assert df["CADD_RAW"].to_list() == [["0.12", None]]
+        assert "CSQ" not in df.columns
+        assert calls[-1][1] is False, "CSQ built because the plugin columns were read"
+
+    def test_selecting_a_plugin_column_reads_the_last_csq_fields(
+        self, tmp_path, monkeypatch
+    ):
+        import vepyr
+
+        root, calls = self._fake_cadd(tmp_path, monkeypatch)
+        df = (
+            vepyr.annotate(
+                "in.vcf", CACHE_DIR, plugin_cache_root=root, plugins=["cadd"]
+            )
+            .select("chrom", "CADD_PHRED")
+            .collect()
+        )
+        assert df.columns == ["chrom", "CADD_PHRED"]
+        assert df["CADD_PHRED"].to_list() == [["24.5", None]]
+        assert calls[-1][1] is False
+
+    def test_selecting_only_base_columns_skips_the_csq_string(
+        self, tmp_path, monkeypatch
+    ):
+        import vepyr
+
+        root, calls = self._fake_cadd(tmp_path, monkeypatch)
+        df = (
+            vepyr.annotate(
+                "in.vcf", CACHE_DIR, plugin_cache_root=root, plugins=["cadd"]
+            )
+            .select("chrom", "SYMBOL")
+            .collect()
+        )
+        assert df.columns == ["chrom", "SYMBOL"]
+        assert calls[-1][1] is True, "no plugin column read, so no CSQ string built"
+        assert "plugin_cache_root" not in calls[-1][0], "and no plugin lookup either"
+        assert "plugins" not in calls[-1][0]
+
+    def test_skip_csq_false_keeps_csq_and_plugin_columns(self, tmp_path, monkeypatch):
+        import vepyr
+
+        root, _ = self._fake_cadd(tmp_path, monkeypatch)
+        df = vepyr.annotate(
+            "in.vcf",
+            CACHE_DIR,
+            plugin_cache_root=root,
+            plugins=["cadd"],
+            skip_csq=False,
+        ).collect()
+        assert "CSQ" in df.columns and df.columns[-2:] == ["CADD_PHRED", "CADD_RAW"]
+
+    def test_flags_are_still_inferred_with_plugins(self, tmp_path, monkeypatch):
+        import vepyr
+
+        root, calls = self._fake_cadd(tmp_path, monkeypatch)
+        vepyr.annotate(
+            "in.vcf",
+            CACHE_DIR,
+            plugin_cache_root=root,
+            plugins=["cadd"],
+            everything=True,
+            reference_fasta=REFERENCE_FASTA,
+        ).select("chrom", "CADD_PHRED").collect()
+        assert "everything" not in calls[-1][0]
+        assert calls[-1][0]["plugin_cache_root"] == root
+
+    def test_unknown_plugin_column_without_a_plugin_cache_fails_at_plan_time(
+        self, metadata_cache_dir
+    ):
+        import vepyr
+
+        lf = vepyr.annotate(INPUT_VCF, metadata_cache_dir)
+        with pytest.raises(pl.exceptions.ColumnNotFoundError, match="CADD_PHRED"):
+            lf.select("chrom", "CADD_PHRED").collect_schema()
+
+    def test_demo_plugin_values_match_the_fields_core_path(
+        self, demo_plugin_cache, metadata_cache_dir
+    ):
+        import vepyr
+
+        plain = (
+            vepyr.annotate(
+                INPUT_VCF,
+                metadata_cache_dir,
+                plugin_cache_root=demo_plugin_cache,
+                plugins=["demo"],
+            )
+            .select("chrom", "start", "ref", "alt", "DEMO")
+            .collect()
+        )
+        core = (
+            vepyr.annotate(
+                INPUT_VCF,
+                metadata_cache_dir,
+                fields="core",
+                plugin_cache_root=demo_plugin_cache,
+                plugins=["demo"],
+            )
+            .collect()
+            .select("chrom", "start", "ref", "alt", "DEMO")
+        )
+        assert plain.equals(core)
+        assert any(v is not None for vs in plain["DEMO"].to_list() for v in vs)
+
+    def test_fields_core_without_fasta_does_not_warn_about_absent_columns(
+        self, monkeypatch
+    ):
+        import pyarrow as pa
+        import vepyr
+
+        names = ["chrom", "CSQ", "most_severe_consequence", *vepyr._CORE_CSQ_FIELDS]
+
+        class FakeAnnotator:
+            schema = pa.schema([pa.field(n, pa.string()) for n in names])
+
+            def __iter__(self):
+                return iter(())
+
+        monkeypatch.setattr(vepyr, "_create_annotator", lambda *a, **k: FakeAnnotator())
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            vepyr.annotate("in.vcf", CACHE_DIR, fields="core").collect()

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -2060,6 +2060,22 @@ class TestPluginMatchTemplates:
         with pytest.raises(Exception, match="HGVSc.*reference_fasta"):
             lf.collect()
 
+    def test_flagless_plain_collect_without_fasta_raises_before_warning(
+        self, tmp_path, monkeypatch
+    ):
+        # no flags, no FASTA, full collect: the plugin needs HGVSc, so this
+        # raises, and it must not first warn that HGVSc "will be null"
+        import vepyr
+
+        root, _ = self._hgvs_plugin(tmp_path, monkeypatch)
+        lf = vepyr.annotate(
+            "in.vcf", CACHE_DIR, plugin_cache_root=root, plugins=["byhgvs"]
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            with pytest.raises(Exception, match="HGVSc.*reference_fasta"):
+                lf.collect()
+
     def test_template_fields_without_fasta_raise(self, tmp_path, monkeypatch):
         import vepyr
 

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -1566,17 +1566,65 @@ class TestFlagInference:
         assert seen[-1]["hgvs"] is True
         assert seen[-1]["shift_hgvs"] is False
 
-    def test_plain_collect_without_flags_stays_bare(self, monkeypatch):
+    def test_plain_collect_without_flags_infers_everything_with_a_fasta(
+        self, monkeypatch
+    ):
         import vepyr
 
         seen = self._capture(monkeypatch)
         vepyr.annotate(INPUT_VCF, CACHE_DIR, reference_fasta=REFERENCE_FASTA).collect()
         opts = seen[-1]
+        assert opts["everything"] is True
+        assert opts["reference_fasta_path"] == REFERENCE_FASTA
+
+    def test_plain_collect_without_flags_or_fasta_infers_the_colocated_lookup(
+        self, monkeypatch
+    ):
+        import vepyr
+
+        seen = self._capture(monkeypatch)
+        vepyr.annotate(INPUT_VCF, CACHE_DIR).collect()
+        opts = seen[-1]
+        for key in (
+            "check_existing",
+            "af",
+            "af_1kg",
+            "af_gnomade",
+            "af_gnomadg",
+            "max_af",
+            "pubmed",
+        ):
+            assert opts[key] is True, key
+        assert "everything" not in opts and "hgvs" not in opts
+
+    def test_plain_collect_with_explicit_flags_keeps_them(self, monkeypatch):
+        import vepyr
+
+        seen = self._capture(monkeypatch)
+        vepyr.annotate(
+            INPUT_VCF, CACHE_DIR, af=True, reference_fasta=REFERENCE_FASTA
+        ).collect()
+        opts = seen[-1]
+        assert opts["af"] is True
         assert (
-            "hgvs" not in opts
-            and "everything" not in opts
+            "everything" not in opts
+            and "hgvs" not in opts
             and "check_existing" not in opts
         )
+
+    def test_flagless_collect_equals_an_everything_run(self, metadata_cache_dir):
+        import vepyr
+
+        everything = vepyr.annotate(
+            INPUT_VCF,
+            metadata_cache_dir,
+            everything=True,
+            reference_fasta=REFERENCE_FASTA,
+        ).collect()
+        inferred = vepyr.annotate(
+            INPUT_VCF, metadata_cache_dir, reference_fasta=REFERENCE_FASTA
+        ).collect()
+        assert inferred.equals(everything)
 
     @pytest.mark.parametrize(
         "columns",

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -2076,6 +2076,25 @@ class TestPluginMatchTemplates:
             with pytest.raises(Exception, match="HGVSc.*reference_fasta"):
                 lf.collect()
 
+    def test_template_fields_are_honoured_when_csq_is_selected(
+        self, tmp_path, monkeypatch
+    ):
+        # the raw CSQ string carries every plugin's values
+        import vepyr
+
+        root, calls = self._hgvs_plugin(tmp_path, monkeypatch)
+        vepyr.annotate(
+            "in.vcf",
+            CACHE_DIR,
+            af=True,
+            reference_fasta=REFERENCE_FASTA,
+            skip_csq=False,
+            plugin_cache_root=root,
+            plugins=["byhgvs"],
+        ).select("chrom", "CSQ").collect()
+        opts = calls[-1]
+        assert opts["hgvs"] is True and opts["af"] is True
+
     def test_template_fields_without_fasta_raise(self, tmp_path, monkeypatch):
         import vepyr
 

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -2011,6 +2011,55 @@ class TestPluginMatchTemplates:
         ).select("chrom", "BYHGVS_score").collect()
         assert calls[-1]["hgvs"] is True
 
+    def test_template_fields_are_honoured_on_a_plain_collect(
+        self, tmp_path, monkeypatch
+    ):
+        # explicit unrelated flag + full collect: the plugin still needs hgvs
+        import vepyr
+
+        root, calls = self._hgvs_plugin(tmp_path, monkeypatch)
+        vepyr.annotate(
+            "in.vcf",
+            CACHE_DIR,
+            af=True,
+            reference_fasta=REFERENCE_FASTA,
+            plugin_cache_root=root,
+            plugins=["byhgvs"],
+        ).collect()
+        opts = calls[-1]
+        assert opts["hgvs"] is True and opts["af"] is True
+        assert "everything" not in opts
+
+    def test_template_fields_with_explicit_other_flags_and_a_select(
+        self, tmp_path, monkeypatch
+    ):
+        import vepyr
+
+        root, calls = self._hgvs_plugin(tmp_path, monkeypatch)
+        vepyr.annotate(
+            "in.vcf",
+            CACHE_DIR,
+            af=True,
+            reference_fasta=REFERENCE_FASTA,
+            plugin_cache_root=root,
+            plugins=["byhgvs"],
+        ).select("chrom", "BYHGVS_score").collect()
+        opts = calls[-1]
+        assert opts["hgvs"] is True
+        assert "af" not in opts, "af is pruned: nothing selected needs it"
+
+    def test_template_fields_on_a_plain_collect_without_fasta_raise(
+        self, tmp_path, monkeypatch
+    ):
+        import vepyr
+
+        root, _ = self._hgvs_plugin(tmp_path, monkeypatch)
+        lf = vepyr.annotate(
+            "in.vcf", CACHE_DIR, af=True, plugin_cache_root=root, plugins=["byhgvs"]
+        )
+        with pytest.raises(Exception, match="HGVSc.*reference_fasta"):
+            lf.collect()
+
     def test_template_fields_without_fasta_raise(self, tmp_path, monkeypatch):
         import vepyr
 

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -1583,7 +1583,8 @@ class TestFlagInference:
         import vepyr
 
         seen = self._capture(monkeypatch)
-        vepyr.annotate(INPUT_VCF, CACHE_DIR).collect()
+        with pytest.warns(UserWarning, match=r"no reference_fasta.*HGVSc.*SIFT"):
+            vepyr.annotate(INPUT_VCF, CACHE_DIR).collect()
         opts = seen[-1]
         for key in (
             "check_existing",
@@ -1601,10 +1602,14 @@ class TestFlagInference:
         import vepyr
 
         seen = self._capture(monkeypatch)
-        vepyr.annotate(
-            INPUT_VCF, CACHE_DIR, af=True, reference_fasta=REFERENCE_FASTA
-        ).collect()
-        opts = seen[-1]
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # explicit flags or a select() never warn
+            vepyr.annotate(
+                INPUT_VCF, CACHE_DIR, af=True, reference_fasta=REFERENCE_FASTA
+            ).collect()
+            opts = seen[-1]
+            vepyr.annotate(INPUT_VCF, CACHE_DIR, af=True).collect()
+            vepyr.annotate(INPUT_VCF, CACHE_DIR).select(["chrom", "AF"]).collect()
         assert opts["af"] is True
         assert (
             "everything" not in opts

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -2095,6 +2095,28 @@ class TestPluginMatchTemplates:
         opts = calls[-1]
         assert opts["hgvs"] is True and opts["af"] is True
 
+    @pytest.mark.parametrize("query", ["collect", "select"])
+    def test_template_fields_are_checked_per_hgvs_field(
+        self, tmp_path, monkeypatch, query
+    ):
+        # hgvsp=True alone does not compute HGVSc, which the template needs
+        import vepyr
+
+        root, calls = self._hgvs_plugin(tmp_path, monkeypatch)
+        lf = vepyr.annotate(
+            "in.vcf",
+            CACHE_DIR,
+            hgvsp=True,
+            reference_fasta=REFERENCE_FASTA,
+            plugin_cache_root=root,
+            plugins=["byhgvs"],
+        )
+        (lf.select("chrom", "BYHGVS_score") if query == "select" else lf).collect()
+        opts = calls[-1]
+        assert opts["hgvsc"] is True, "the field the template reads is switched on"
+        assert opts["hgvsp"] is True, "the explicit flag is kept"
+        assert "hgvs" not in opts
+
     def test_template_fields_without_fasta_raise(self, tmp_path, monkeypatch):
         import vepyr
 

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -1334,6 +1334,18 @@ class TestProjectionPruning:
         ).select(["chrom", "CSQ"]).collect()
         assert self._engine_opts(seen)["everything"] is True
 
+    def test_csq_column_on_a_flagless_frame_gets_the_flagless_default(
+        self, monkeypatch
+    ):
+        # select("CSQ") and collect().select("CSQ") must carry the same string
+        import vepyr
+
+        seen = self._capture(monkeypatch)
+        vepyr.annotate(
+            INPUT_VCF, CACHE_DIR, reference_fasta=REFERENCE_FASTA, skip_csq=False
+        ).select(["chrom", "CSQ"]).collect()
+        assert self._engine_opts(seen)["everything"] is True
+
     def test_individual_flags_are_pruned_too(self, monkeypatch):
         import vepyr
 

--- a/tests/test_build_plugin_cache.py
+++ b/tests/test_build_plugin_cache.py
@@ -294,12 +294,26 @@ def test_failed_clone_leaves_no_temp_dir():
     assert set(glob.glob(pat)) == before  # no leaked clone/worktree
 
 
-def test_plugin_cache_root_reaches_streaming_options(monkeypatch):
+def test_plugin_cache_root_reaches_streaming_options(monkeypatch, tmp_path):
     """The LazyFrame/streaming path (output_vcf=None) must forward
     plugin_cache_root too — it flows through the same options_json to
-    _create_annotator, so plugin CSQ fields are emitted in both output modes."""
+    _create_annotator, so plugin CSQ fields are emitted in both output modes.
+    The root is read for the plugin manifests (they name the DataFrame
+    columns), so it has to exist."""
+    import json
+
     import pyarrow as pa
 
+    root = tmp_path / "pc"
+    (root / "plugin" / "cadd").mkdir(parents=True)
+    (root / "plugin" / "cadd" / "manifest.json").write_text(
+        json.dumps(
+            {
+                "plugin_name": "cadd",
+                "value_columns": [{"column": "phred", "csq_field": "CADD_PHRED"}],
+            }
+        )
+    )
     captured: dict = {}
 
     class _Probe:
@@ -311,10 +325,11 @@ def test_plugin_cache_root_reaches_streaming_options(monkeypatch):
 
     monkeypatch.setattr(vepyr, "_create_annotator", fake_create_annotator)
     lf = vepyr.annotate(
-        "in.vcf", "cache", plugin_cache_root="/tmp/pc", show_progress=False
+        "in.vcf", "cache", plugin_cache_root=str(root), show_progress=False
     )
     assert lf is not None  # a LazyFrame, not a written path
-    assert '"plugin_cache_root": "/tmp/pc"' in captured["options_json"]
+    assert f'"plugin_cache_root": "{root}"' in captured["options_json"]
+    assert "CADD_PHRED" in lf.collect_schema()
 
 
 def _build(repo, tmp_path, source_path, **kw):

--- a/tests/test_build_plugin_cache.py
+++ b/tests/test_build_plugin_cache.py
@@ -328,7 +328,9 @@ def test_plugin_cache_root_reaches_streaming_options(monkeypatch, tmp_path):
         "in.vcf", "cache", plugin_cache_root=str(root), show_progress=False
     )
     assert lf is not None  # a LazyFrame, not a written path
-    assert f'"plugin_cache_root": "{root}"' in captured["options_json"]
+    # compare the parsed value: on Windows the path's backslashes are
+    # JSON-escaped in the raw string
+    assert json.loads(captured["options_json"])["plugin_cache_root"] == str(root)
     assert "CADD_PHRED" in lf.collect_schema()
 
 


### PR DESCRIPTION
## Summary

Polars hands the IO source its projection, but `annotate()` only applied it after the engine had computed every column. This PR turns the columns a query reads into the flag set the engine runs with, and makes `everything=True` unnecessary on the DataFrame path.

```python
lf = vepyr.annotate("input.vcf.gz", cache, reference_fasta=fasta)   # no flags

lf.select("chrom", "start", "SYMBOL", "Consequence")   # engine flags: none
lf.select("chrom", "start", "HGVSc", "HGVSp")          # hgvs
lf.select("chrom", "start", "AF", "CLIN_SIG")          # the co-located lookup
lf.select("chrom", "start", "SIFT")                    # everything
lf.collect()                                           # no projection: everything
```

Measured on the release-116 Ensembl cache, `workers=1`, selected columns value-identical to a full run on chr22 and chr1:

| Query | chr22 | chr1 |
|---|---|---|
| `collect()` | 2.3 s | 15.2 s |
| `filter(IMPACT has HIGH).select(chrom, start, ref, alt, SYMBOL, Consequence)` | 1.2 s | 6.0 s |
| `select(chrom, start, HGVSc, HGVSp)` | 1.4 s | 9.0 s |
| `select(chrom, start, Existing_variation, AF, MAX_AF, CLIN_SIG, PUBMED)` | 1.9 s | 14.2 s |

## How

The engine's `fields` option only trims output (2.27 s vs 2.26 s on chr22); the expensive work is gated by the feature flags. Diffing every column across flag combinations on chr22 showed that only three groups depend on flags:

- `HGVSc`, `HGVSp` on `hgvs`
- `Existing_variation`, `CLIN_SIG`, `SOMATIC`, `PHENO`, `PUBMED`, the `AF` family and the cache-only columns on `check_existing` and the `af` flags
- `MANE`, `APPRIS`, `SIFT`, `PolyPhen`, `DOMAINS`, `miRNA`, `HGVS_OFFSET`, the five motif columns and the gnomAD sub-populations on `everything`

Everything else, including `most_severe_consequence`, is identical with no flags. `_flags_for_projection()` applies:

- with a narrowing `select()` (plus the columns a pushed-down `filter()` reads): a group no selected column needs is switched off; a group a column needs is switched on when no flag was given for it; flags the user set are kept as configured, never widened. HGVS and the `everything` extras need `reference_fasta`, and selecting them without one raises with the column names instead of returning nulls (the engine refuses to run without one anyway);
- without a projection: flags as given, or, when none were given, `everything` with a FASTA and the co-located lookup without one. In that last case the HGVS and `everything`-only columns stay null and a `UserWarning` names them:

  ```
  UserWarning: no reference_fasta given, so these columns will be null: APPRIS, DOMAINS,
  HGVS_OFFSET, HGVSc, HGVSp, MANE, PolyPhen, SIFT, gnomADe_AFR_AF, ..., gnomADg_SAS_AF.
  Pass reference_fasta= for the full result
  ```

  The warning fires only there: explicit flags, a `select()`, or a frame with a FASTA never warn, and selecting one of those columns without a FASTA raises instead.

Selecting `CSQ` or using plugins keeps the flags as given. `fields=` combined with a narrowing `select()` raises at collect time; a plain `collect()`, `head()` or `select(pl.all())` with `fields=` still works.

## Plugins

Plugin CSQ fields used to become named DataFrame columns only with `fields=`; otherwise they sat inside the CSQ string behind a warning. They are now `List(String)` columns after the base block whenever a plugin cache is configured. The engine appends them after a base layout whose length depends on the flags (74 fields with none, 80 with `everything`), so they are read as the last fields of each CSQ entry. The CSQ string is built only when a query reads it or a plugin column, and a query reading neither also skips the plugin lookup:

```python
lf = vepyr.annotate("input.vcf.gz", cache, reference_fasta=fasta,
                    plugin_cache_root="/data/plugin_cache", plugins=["cadd"])
lf.select("chrom", "start", "ref", "alt", "CADD_PHRED")   # plugin lookup, no HGVS
lf.select("chrom", "start", "SYMBOL")                     # neither
```

### Column shape and type

Each plugin column's shape and type come from the built cache's `manifest.json`, not from the CSQ text it travels in. Two manifest facts decide it:

- **`match_columns`** decides the shape. A plugin keyed on the variant alone (no match column) is one value per row, because the value is identical on every consequence entry (0 conflicting rows on chr22 for CADD and ClinVar). A plugin keyed on a transcript feature is a list aligned with `Consequence`, null on the entries the plugin did not match (SpliceAI had 105 chr22 variants with differing values across entries, so the list is necessary).
- **`type`** decides the element type: the engine's `ValueType`, one of `Utf8`, `Int32`, `Float32`.

For the published caches:

| Plugin | Match column | Shape | Columns |
|---|---|---|---|
| CADD | none | scalar | `CADD_PHRED: String`, `CADD_RAW: String` |
| ClinVar | none | scalar | `ClinVar: String`, `ClinVar_CLNSIG: String`, `ClinVar_CLNREVSTAT: String`, `ClinVar_CLNDN: String`, `ClinVar_CLNVC: String`, `ClinVar_CLNVI: String` |
| SpliceAI | `{SYMBOL}` | list | `SpliceAI_pred_DP_AG/AL/DG/DL: List(Int32)`, `SpliceAI_pred_DS_AG/AL/DG/DL: List(String)`, `SpliceAI_pred_SYMBOL: List(String)` |
| AlphaMissense | `{ref_aa}{Protein_position}{alt_aa}` | list | `am_pathogenicity: List(Float32)`, `am_class: List(String)` |
| dbNSFP | `{ref_aa}/{alt_aa}` | list | 19 `List(String)` columns |

CADD's and SpliceAI's scores are declared `Utf8` in their caches so the VCF reproduces the source digits exactly; they stay strings on the DataFrame path and need a `cast()`. A numeric DataFrame type for them would need the manifest to carry a separate DataFrame type, which is an engine-side change.

On chr22 with cadd, clinvar, spliceai and alphamissense every plugin column equals the CSQ tail under its shape and type on all 50,861 rows; `select(SYMBOL)` drops from 5.1 s to 1.2 s without the plugin lookup. Selecting a plugin column on a frame without a plugin cache stays Polars' plan-time `ColumnNotFoundError`, which lists the frame's columns. The old "plugin fields are emitted inside CSQ" warning is gone, and the no-FASTA warning now names only columns the frame actually has.

## Docs

`docs/dataframes.md` has a Plugins section with worked Polars examples for the four published caches. `docs/plugins.md` no longer asks for `fields="core"` on the DataFrame path. `docs/dataframes.md` is new: the schema as `collect_schema()` prints it, the pushdown rules, a null-safe explode helper, the `filter_vep` examples translated to Polars, `sink_parquet(row_group_size=5000)` with measured RSS, and the verified agreement with the VCF output. Its schema snippet and "agreement" section describe the typed motif columns as decoded, which the pin to biodatageeks/datafusion-bio-functions#238 (merged as `44f5954`) delivers.

## End-to-end md5 parity

Run after the reviews closed, on this branch at `55810e4` with `datafusion-bio-function-vep` pinned to `4e1446b`, the head of biodatageeks/datafusion-bio-functions#238; the branch now pins its squash-merge commit `44f5954`, which has identical crate content, and chr22 with the five plugins re-matched on that build: `run_comparison.py --release 116 --comparison-mode md5 --bgzf --workers 10`, all 22 contigs of HG002 (4,096,123 variants per profile), each contig hashed against the Ensembl VEP 116.0 reference in both strict and canonical mode.

| Profile | Contigs strict MATCH | Contigs canonical MATCH | Mismatches | Annotation time |
|---|---|---|---|---|
| ensembl | 22 / 22 | 22 / 22 | 0 | 51 s |
| merged | 22 / 22 | 22 / 22 | 0 | 70 s |
| refseq | 22 / 22 | 22 / 22 | 0 | 45 s |
| merged_plugins (cadd, clinvar, spliceai, alphamissense, dbnsfp) | 22 / 22 | 22 / 22 | 0 | 125 s |

Wall time per profile including reference slicing and hashing was 5 to 9 minutes. The same four profiles also matched 22/22 on the path-patched build before the pin bump (serial and 10-worker), so both the serial and the within-contig parallel VCF paths are byte-identical to VEP with this engine.

## Verification

- `uv run pytest`: 1239 passed, 2 skipped (38 new tests in `TestProjectionPruning` and `TestFlagInference`, including value identity against an `everything` run on the fixture cache, the flagless default, the FASTA error cases, the no-FASTA warning with a check that explicit flags and `select()` stay silent, and the plugin columns with and without `fields=`, including value identity between the two on the fixture plugin cache).
- ruff check/format clean on the changed code; the file's remaining findings are pre-existing.
- chr22/chr1 value identity and timings above, with the engine call instrumented to confirm the flags it received; chr22 flagless `collect()` equals `everything=True` exactly, and the FASTA-less one equals the seven co-located flags spelled out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F6y34WjrWGvL9hS5Eg95Y8
