### PR TITLE
docs: link plugin numeric casting guidance

### DIFF
--- a/docs/dataframes.md
+++ b/docs/dataframes.md
@@ -162,6 +162,10 @@ type come from the plugin's manifest, not from the CSQ text it travels in:
   exactly, which is why `CADD_PHRED` is a string; cast it when you need a
   number.
 
+See [String scores and numeric casts in the vepyr-plugins README](https://github.com/biodatageeks/vepyr-plugins/blob/master/README.md#string-scores-and-numeric-casts)
+for per-field numeric types and Polars examples covering scalar columns,
+consequence-aligned lists and multiple scores inside a dbNSFP element.
+
 The engine only runs the plugin lookup, and only builds the CSQ string the
 values are carried in, when a query reads one of those columns:
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -119,6 +119,10 @@ shaped by its `match_columns`: one value per row for a per-variant plugin
 computes, plugin lookup included. See
 [Polars DataFrames](dataframes.md#plugin-columns).
 
+For why some scores remain strings to preserve VCF body MD5 matches, which
+numeric types retain each field's precision, and Polars casting examples,
+see [String scores and numeric casts in the vepyr-plugins README](https://github.com/biodatageeks/vepyr-plugins/blob/master/README.md#string-scores-and-numeric-casts).
+
 ### Choosing which plugins run
 
 By default every plugin under `<plugin_cache_root>/plugin/` is applied. There


### PR DESCRIPTION
Link the plugin and DataFrame documentation to the numeric casting guide in the `vepyr-plugins` README on `master`. The guide explains why some scores remain strings for exact VCF output and gives per-field types and Polars examples for scalar, consequence-aligned and nested dbNSFP values.

This PR targets `feat/projection-driven-flags`, the branch for [#79](https://github.com/biodatageeks/vepyr/pull/79). The reference points from vepyr's documentation to the plugins README; the README no longer points back to unreleased PR documentation.

The linked section is being added by [vepyr-plugins #16](https://github.com/biodatageeks/vepyr-plugins/pull/16) and will be available on `master` once that PR merges.

Validation: `git diff --check` passes; both links use the requested `vepyr-plugins/master` URL and match the README section heading in plugins PR #16. Documentation only; no runtime changes.
