### PR TITLE
feat(annotate): show a progress bar on the LazyFrame path

### DIFF
--- a/src/vepyr/__init__.py
+++ b/src/vepyr/__init__.py
@@ -1844,6 +1844,15 @@ def annotate(
                     pbar.update(batch.num_rows)
                     pbar.refresh()
                     yield batch
+                # Exhausted, so the rows seen are all there were. A LIMIT is
+                # only an upper bound: without this a `.head(1000)` over a
+                # 2-record input would close at 2/1000 and report a finished
+                # run as 0.2%. Deliberately outside the `finally` -- a stream
+                # that raised has not seen all its rows, and must not be
+                # presented as complete.
+                if pbar.total is not None:
+                    pbar.total = pbar.n
+                    pbar.refresh()
             finally:
                 # Reached on normal exhaustion and when Polars abandons the
                 # outer generator once a limit is satisfied.

--- a/src/vepyr/__init__.py
+++ b/src/vepyr/__init__.py
@@ -1293,8 +1293,11 @@ def annotate(
         INFO, so byte agreement with it needs this on. Only used when
         ``output_vcf`` is set.
     show_progress : bool
-        Show a progress bar on stderr during VCF output (default: True).
-        Only used when ``output_vcf`` is set.
+        Show a progress bar while annotating (default: True). On the VCF
+        output path it is a determinate bar over the pre-counted input. On
+        the ``LazyFrame`` path it counts the variants the engine yields on
+        each ``collect()``, with a total only when a limit (``.head(n)``)
+        reaches the source unfiltered.
     compression : str or None
         VCF output compression. ``"bgzf"`` (block-gzip, tabix-compatible),
         ``"gzip"``, ``"plain"``, or ``None`` (auto-detect from extension).
@@ -1722,11 +1725,12 @@ def annotate(
 
     # Each collect() creates a fresh streaming annotator so the LazyFrame
     # is re-runnable (not single-use). Captures vcf/cache_dir/options by value.
-    _vcf, _cache_dir, _opts, _engine_skip = (
+    _vcf, _cache_dir, _opts, _engine_skip, _show_progress = (
         vcf,
         cache_dir,
         dict(opts),
         engine_skip_csq,
+        show_progress,
     )
     plugin_columns = set(plugin_field_names)
 
@@ -1810,8 +1814,43 @@ def annotate(
             not csq_needed,
             n_rows,
         )
+        # Progress bar, one per collect(). It counts the variants the engine
+        # yields, before the predicate applied below: a selective filter would
+        # otherwise leave the bar at zero while the engine works through the
+        # file. A total is only known when a LIMIT reaches the source with no
+        # predicate to shrink what it counts -- unlike the VCF path, nothing
+        # here pre-counts the input, so the bar is otherwise open-ended.
+        pbar = None
+        if _show_progress:
+            try:
+                from tqdm.auto import tqdm
+
+                pbar = tqdm(
+                    total=n_rows if predicate is None else None,
+                    unit=" variants",
+                    desc=f"Annotating {os.path.basename(_vcf)}",
+                    miniters=1,
+                    mininterval=0,
+                )
+            except ImportError:
+                pass
+
+        def tracked(batches):
+            if pbar is None:
+                yield from batches
+                return
+            try:
+                for batch in batches:
+                    pbar.update(batch.num_rows)
+                    pbar.refresh()
+                    yield batch
+            finally:
+                # Reached on normal exhaustion and when Polars abandons the
+                # outer generator once a limit is satisfied.
+                pbar.close()
+
         remaining = n_rows
-        for py_batch in annotator:
+        for py_batch in tracked(annotator):
             batch_df = pl.from_arrow(py_batch)
             if plugin_field_names and "CSQ" in batch_df.columns:
                 n_plugin = len(plugin_field_names)

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -2209,11 +2209,13 @@ class TestLazyFrameProgress:
             def __init__(self, **kwargs):
                 self.kwargs = kwargs
                 self.total = kwargs.get("total")
+                self.n = 0
                 self.updates: list[int] = []
                 self.closed = False
                 bars.append(self)
 
             def update(self, n):
+                self.n += n
                 self.updates.append(n)
 
             def refresh(self):
@@ -2251,6 +2253,37 @@ class TestLazyFrameProgress:
             vcf_path, cache_dir, options_json, skip_csq=True, limit=None
         ):
             return FakeAnnotator()
+
+        return fake_create_annotator
+
+    @staticmethod
+    def _failing_annotator(batches, exc):
+        """Like ``_fake_annotator`` but the stream dies after the batches."""
+        import pyarrow as pa
+
+        schema = pa.schema(
+            [pa.field("chrom", pa.string()), pa.field("pos", pa.int64())]
+        )
+
+        class FailingAnnotator:
+            def __init__(self):
+                self.schema = schema
+
+            def __iter__(self):
+                for chroms, positions in batches:
+                    yield pa.record_batch(
+                        {
+                            "chrom": pa.array(chroms, pa.string()),
+                            "pos": pa.array(positions, pa.int64()),
+                        },
+                        schema=schema,
+                    )
+                raise exc
+
+        def fake_create_annotator(
+            vcf_path, cache_dir, options_json, skip_csq=True, limit=None
+        ):
+            return FailingAnnotator()
 
         return fake_create_annotator
 
@@ -2326,3 +2359,39 @@ class TestLazyFrameProgress:
 
         assert len(bars) == 2
         assert all(sum(bar.updates) == 2 for bar in bars)
+
+    def test_limit_beyond_the_input_closes_at_the_observed_count(self, monkeypatch):
+        """A LIMIT is an upper bound, not a promise of that many rows.
+
+        Without this the bar closes at 2/1000 and reports a finished run as
+        0.2% complete.
+        """
+        lf, bars = self._annotate(monkeypatch, [(["1", "1"], [1, 2])])
+
+        lf.head(1000).collect()
+
+        assert bars[0].n == 2
+        assert bars[0].total == 2
+
+    def test_a_failed_stream_does_not_snap_the_total_to_the_rows_seen(
+        self, monkeypatch
+    ):
+        """Only exhaustion means "that was all of it" -- a crash does not."""
+        import vepyr
+
+        bar_cls, bars = self._recording_tqdm()
+        monkeypatch.setattr("tqdm.auto.tqdm", bar_cls)
+        monkeypatch.setattr(
+            vepyr,
+            "_create_annotator",
+            self._failing_annotator(
+                [(["1", "1"], [1, 2])], RuntimeError("Annotation stream error")
+            ),
+        )
+        lf = vepyr.annotate(INPUT_VCF, CACHE_DIR)
+
+        with pytest.raises(Exception, match="Annotation stream error"):
+            lf.head(1000).collect()
+
+        assert bars[0].total == 1000
+        assert bars[0].closed

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -2190,3 +2190,139 @@ class TestPluginMatchTemplates:
         )
         with pytest.raises(Exception, match="HGVSc.*reference_fasta"):
             lf.select("chrom", "BYHGVS_score").collect()
+
+
+class TestLazyFrameProgress:
+    """The LazyFrame path shows the same kind of tqdm bar as the VCF path.
+
+    The bar counts variants as the engine yields them, before any Polars
+    predicate: a selective filter would otherwise leave it at zero while the
+    engine grinds through the file.
+    """
+
+    @staticmethod
+    def _recording_tqdm():
+        """A tqdm stand-in that records every bar built and each update."""
+        bars: list = []
+
+        class RecordingBar:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+                self.total = kwargs.get("total")
+                self.updates: list[int] = []
+                self.closed = False
+                bars.append(self)
+
+            def update(self, n):
+                self.updates.append(n)
+
+            def refresh(self):
+                pass
+
+            def close(self):
+                self.closed = True
+
+        return RecordingBar, bars
+
+    @staticmethod
+    def _fake_annotator(batches):
+        """A ``_create_annotator`` stand-in yielding fixed Arrow batches."""
+        import pyarrow as pa
+
+        schema = pa.schema(
+            [pa.field("chrom", pa.string()), pa.field("pos", pa.int64())]
+        )
+
+        class FakeAnnotator:
+            def __init__(self):
+                self.schema = schema
+
+            def __iter__(self):
+                for chroms, positions in batches:
+                    yield pa.record_batch(
+                        {
+                            "chrom": pa.array(chroms, pa.string()),
+                            "pos": pa.array(positions, pa.int64()),
+                        },
+                        schema=schema,
+                    )
+
+        def fake_create_annotator(
+            vcf_path, cache_dir, options_json, skip_csq=True, limit=None
+        ):
+            return FakeAnnotator()
+
+        return fake_create_annotator
+
+    def _annotate(self, monkeypatch, batches, **kwargs):
+        import vepyr
+
+        bar_cls, bars = self._recording_tqdm()
+        monkeypatch.setattr("tqdm.auto.tqdm", bar_cls)
+        monkeypatch.setattr(vepyr, "_create_annotator", self._fake_annotator(batches))
+        return vepyr.annotate(INPUT_VCF, CACHE_DIR, **kwargs), bars
+
+    def test_bar_counts_variants_the_engine_yields(self, monkeypatch):
+        lf, bars = self._annotate(
+            monkeypatch, [(["1", "1", "2"], [1, 2, 3]), (["2", "3"], [4, 5])]
+        )
+
+        lf.collect()
+
+        assert len(bars) == 1
+        assert sum(bars[0].updates) == 5
+
+    def test_bar_counts_rows_before_the_pushed_down_predicate(self, monkeypatch):
+        lf, bars = self._annotate(
+            monkeypatch, [(["1", "1", "2"], [1, 2, 3]), (["2", "3"], [4, 5])]
+        )
+
+        df = lf.filter(pl.col("pos") > 4).collect()
+
+        assert df.height == 1
+        assert sum(bars[0].updates) == 5
+
+    def test_show_progress_false_builds_no_bar(self, monkeypatch):
+        lf, bars = self._annotate(
+            monkeypatch, [(["1", "2"], [1, 2])], show_progress=False
+        )
+
+        lf.collect()
+
+        assert bars == []
+
+    def test_limit_without_predicate_sets_the_bar_total(self, monkeypatch):
+        lf, bars = self._annotate(
+            monkeypatch, [(["1", "1", "2"], [1, 2, 3]), (["2", "3"], [4, 5])]
+        )
+
+        lf.head(3).collect()
+
+        assert bars[0].total == 3
+
+    def test_predicate_leaves_the_bar_total_unset(self, monkeypatch):
+        lf, bars = self._annotate(
+            monkeypatch, [(["1", "1", "2"], [1, 2, 3]), (["2", "3"], [4, 5])]
+        )
+
+        lf.filter(pl.col("pos") > 4).collect()
+
+        assert bars[0].total is None
+
+    def test_bar_closes_when_polars_stops_early(self, monkeypatch):
+        lf, bars = self._annotate(
+            monkeypatch, [(["1", "1", "2"], [1, 2, 3]), (["2", "3"], [4, 5])]
+        )
+
+        lf.head(1).collect()
+
+        assert bars[0].closed
+
+    def test_each_collect_builds_its_own_bar(self, monkeypatch):
+        lf, bars = self._annotate(monkeypatch, [(["1", "2"], [1, 2])])
+
+        lf.collect()
+        lf.collect()
+
+        assert len(bars) == 2
+        assert all(sum(bar.updates) == 2 for bar in bars)


### PR DESCRIPTION
## Why

`show_progress` only ever reached the VCF-output path, so a `LazyFrame` annotated in silence — the docstring even said "Only used when `output_vcf` is set."

## What

A `tqdm.auto` bar per `collect()`, built inside `_batch_source`. A small `tracked()` generator wraps the batch iterator so `pbar.close()` runs in a `finally`, covering both normal exhaustion and Polars abandoning the source once a limit is satisfied.

Two deliberate differences from the VCF bar:

- **Count-only, no percentage.** The VCF bar's denominator comes from the engine running a full `SELECT COUNT(*)` over the input before annotating (`vcf_sink.rs`, gated on `need_count`). `StreamingAnnotator` has no equivalent, so a determinate bar would need an engine PR *and* an extra full input scan on every `collect()`. A `total` is set only when a limit reaches the source with no predicate — free, and covers `.head(n)`. Measured: `.head(n)` arrives as `n_rows` with `predicate=None`, while `filter(...).head(n)` pushes the predicate and drops `n_rows` entirely.
- **Counts pre-filter engine rows.** A selective predicate would otherwise leave the bar at zero while the engine grinds through the file.

No background thread here, unlike the VCF path — Polars already calls back into Python per batch.

## Behaviour change

`show_progress` defaults to `True`, so existing LazyFrame callers who saw no bar will now see one. `show_progress=False` disables it.

## Testing

`TestLazyFrameProgress`, 7 tests: row counting, counting ahead of a pushed-down predicate, the `show_progress=False` guard, `total` set for a bare limit and left unset under a predicate, close-on-early-termination, and a fresh bar per `collect()`. Watched 6 of them fail before implementing.

- Full suite: **1365 passed, 2 skipped** (pre-existing cache skips), clean output.
- `pre-commit`: ruff check and ruff format pass.
- **Jupyter, verified not assumed:** plain `collect()` drives the source on `MainThread`; `sink_parquet` and `collect(engine="streaming")` drive it on a Polars worker. A probe notebook executed through `jupyter nbconvert --execute` emitted `application/vnd.jupyter.widget-view+json` on both cells, so the widget bar flushes from either thread and no stderr fallback is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CaYGAYHGV5JAkcAaGgo71j
