### PR TITLE
ci(docs): install docs deps from pyproject's docs extra

### DIFF
--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -21,8 +21,17 @@ jobs:
           python-version: "3.12"
 
       - name: Install docs dependencies
+        # Read the list from pyproject's `docs` extra instead of repeating it
+        # here. A plugin added to the extra but not to this step breaks the
+        # deploy with "the ... plugin is not installed", and only on a tag.
         run: |
-          pip install mkdocs mkdocs-material mkdocstrings mkdocstrings-python
+          python - <<'PY' > /tmp/docs-requirements.txt
+          import pathlib, tomllib
+          cfg = tomllib.loads(pathlib.Path("pyproject.toml").read_text())
+          print("\n".join(cfg["project"]["optional-dependencies"]["docs"]))
+          PY
+          cat /tmp/docs-requirements.txt
+          pip install -r /tmp/docs-requirements.txt
 
       - name: Install vepyr (stub for mkdocstrings)
         run: pip install -e . || echo "Native build skipped — mkdocstrings will use stubs"


### PR DESCRIPTION
## The docs site is currently not publishing

The `0.5.0` docs deploy [failed](https://github.com/biodatageeks/vepyr/actions/workflows/publish_documentation.yml):

```
ERROR   -  Config value 'plugins': The "glightbox" plugin is not installed
Aborted with a configuration error!
##[error]Process completed with exit code 1.
```

#86 added `mkdocs-glightbox` to `mkdocs.yml` and to `pyproject.toml`'s `docs` extra, but this workflow repeated its dependency list inline:

```yaml
pip install mkdocs mkdocs-material mkdocstrings mkdocstrings-python
```

so the deploy installed the older set and aborted during config validation. The site still serves the pre-`0.5.0` build.

## Fix

Read the requirements from `pyproject.toml`'s `docs` extra instead of repeating them, so the two cannot drift again. The step also prints the resolved list, making the next such failure obvious from the log.

## Why it was not caught

This workflow runs only on `push: tags` and `workflow_dispatch`. Nothing exercises the docs config on a PR or a push to `master`, so a config-breaking change lands green and fails at release time.

Worth a follow-up: an `mkdocs build` step in `ci.yml` would catch this on PRs. `--strict` is not usable as-is — it fails on 30 pre-existing broken relative links in `docs/superpowers/` plan files, which would need fixing or excluding first.

## Verification

Reproduced and confirmed locally in an isolated environment.

- With the workflow's old four packages: `Config value 'plugins': The "glightbox" plugin is not installed` — same error as CI
- With the list this PR derives from `pyproject.toml`: no plugin or configuration error

## After merging

The `0.5.0` tag's deploy already failed, so merging this does not republish on its own — the docs workflow needs a manual `workflow_dispatch` run (or the next tag) to push the current site.

## Note

Unrelated to this fix, the next step reads:

```yaml
run: pip install -e . || echo "Native build skipped — mkdocstrings will use stubs"
```

There are no stubs. If that install fails, `mkdocs` does not degrade — it aborts with `Could not collect 'vepyr.build_cache'` → `Aborted with a BuildError!`, one step later and with a misleading cause. Left alone here to keep this PR to the publishing fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151nTvKth4TU81ed6Ng5yiV
