### PR TITLE
fix: pin the CSQ whitespace-run fix and gate it from Python

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-function-vep"
 version = "0.18.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=dd7dcb465d798ebc4d97dfeaafcc413484b927c5#dd7dcb465d798ebc4d97dfeaafcc413484b927c5"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=61971919c04840a82d290481489f0fd611907c20#61971919c04840a82d290481489f0fd611907c20"
 dependencies = [
  "ahash",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-function-vep"
 version = "0.18.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=30bd532f7a5f84dce8129f9307b2d06770a89498#30bd532f7a5f84dce8129f9307b2d06770a89498"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=c208d1583ffb0894c66ae753d4a03ac50f83d1d7#c208d1583ffb0894c66ae753d4a03ac50f83d1d7"
 dependencies = [
  "ahash",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-function-vep"
 version = "0.18.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=61971919c04840a82d290481489f0fd611907c20#61971919c04840a82d290481489f0fd611907c20"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=30bd532f7a5f84dce8129f9307b2d06770a89498#30bd532f7a5f84dce8129f9307b2d06770a89498"
 dependencies = [
  "ahash",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-function-vep"
 version = "0.18.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=97aa8ca5e43d9d54794214dc821eaa1ad26e3e4d#97aa8ca5e43d9d54794214dc821eaa1ad26e3e4d"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=dd7dcb465d798ebc4d97dfeaafcc413484b927c5#dd7dcb465d798ebc4d97dfeaafcc413484b927c5"
 dependencies = [
  "ahash",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,7 +1246,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-function-vep"
 version = "0.18.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=c208d1583ffb0894c66ae753d4a03ac50f83d1d7#c208d1583ffb0894c66ae753d4a03ac50f83d1d7"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=b47046054da605429572d34cbf3fb3d0ecb3c294#b47046054da605429572d34cbf3fb3d0ecb3c294"
 dependencies = [
  "ahash",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,16 @@ serde_json = "1"
 # top of it yet; move to that tag when one is. bio-formats stays declared by tag
 # on both sides, per the note above, so the formats crates resolve to a single
 # source.
-datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "97aa8ca5e43d9d54794214dc821eaa1ad26e3e4d", features = ["cache-builder"] }
+# bio-functions dd7dcb4: the head of biodatageeks/datafusion-bio-functions#243
+# (vepyr#93 -- a CSQ whitespace RUN now collapses to one underscore, per
+# OutputFactory/VCF.pm:403 `s/\s+/\_/g`, and the engine's two CSQ escapers
+# became one function). Two behaviour notes for this repo: a bare `-` in a
+# PLUGIN value now blanks like VEP's (VCF.pm:396-398 applies to plugin columns,
+# which VCF.pm:449 puts in @fields), so it reaches the LazyFrame as null via the
+# `.replace("", None)` in _plugin_column; and DOMAINS deliberately keeps
+# per-character escaping, because VEP's rule there (OutputFactory.pm:1505) has
+# no quantifier. Still pinned by rev, not tag -- this is a PR head, so re-pin to
+# the merge commit once #243 lands.
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "dd7dcb465d798ebc4d97dfeaafcc413484b927c5", features = ["cache-builder"] }
 datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }
 datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ serde_json = "1"
 # top of it yet; move to that tag when one is. bio-formats stays declared by tag
 # on both sides, per the note above, so the formats crates resolve to a single
 # source.
-# bio-functions dd7dcb4: the head of biodatageeks/datafusion-bio-functions#243
+# bio-functions 6197191: the head of biodatageeks/datafusion-bio-functions#243
 # (vepyr#93 -- a CSQ whitespace RUN now collapses to one underscore, per
 # OutputFactory/VCF.pm:403 `s/\s+/\_/g`, and the engine's two CSQ escapers
 # became one function). Two behaviour notes for this repo: a bare `-` in a
@@ -102,6 +102,6 @@ serde_json = "1"
 # per-character escaping, because VEP's rule there (OutputFactory.pm:1505) has
 # no quantifier. Still pinned by rev, not tag -- this is a PR head, so re-pin to
 # the merge commit once #243 lands.
-datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "dd7dcb465d798ebc4d97dfeaafcc413484b927c5", features = ["cache-builder"] }
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "61971919c04840a82d290481489f0fd611907c20", features = ["cache-builder"] }
 datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }
 datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ serde_json = "1"
 # top of it yet; move to that tag when one is. bio-formats stays declared by tag
 # on both sides, per the note above, so the formats crates resolve to a single
 # source.
-# bio-functions 30bd532: the head of biodatageeks/datafusion-bio-functions#243
+# bio-functions c208d15: the head of biodatageeks/datafusion-bio-functions#243
 # (vepyr#93 -- a CSQ whitespace RUN now collapses to one underscore, per
 # OutputFactory/VCF.pm:403 `s/\s+/\_/g`, and the engine's two CSQ escapers
 # became one function). Two behaviour notes for this repo: a bare `-` in a
@@ -102,6 +102,6 @@ serde_json = "1"
 # per-character escaping, because VEP's rule there (OutputFactory.pm:1505) has
 # no quantifier. Still pinned by rev, not tag -- this is a PR head, so re-pin to
 # the merge commit once #243 lands.
-datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "30bd532f7a5f84dce8129f9307b2d06770a89498", features = ["cache-builder"] }
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "c208d1583ffb0894c66ae753d4a03ac50f83d1d7", features = ["cache-builder"] }
 datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }
 datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ serde_json = "1"
 # top of it yet; move to that tag when one is. bio-formats stays declared by tag
 # on both sides, per the note above, so the formats crates resolve to a single
 # source.
-# bio-functions c208d15: the head of biodatageeks/datafusion-bio-functions#243
+# bio-functions b470460: the MERGE commit of biodatageeks/datafusion-bio-functions#243
 # (vepyr#93 -- a CSQ whitespace RUN now collapses to one underscore, per
 # OutputFactory/VCF.pm:403 `s/\s+/\_/g`, and the engine's two CSQ escapers
 # became one function). Two behaviour notes for this repo: a bare `-` in a
@@ -100,8 +100,8 @@ serde_json = "1"
 # which VCF.pm:449 puts in @fields), so it reaches the LazyFrame as null via the
 # `.replace("", None)` in _plugin_column; and DOMAINS deliberately keeps
 # per-character escaping, because VEP's rule there (OutputFactory.pm:1505) has
-# no quantifier. Still pinned by rev, not tag -- this is a PR head, so re-pin to
-# the merge commit once #243 lands.
-datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "c208d1583ffb0894c66ae753d4a03ac50f83d1d7", features = ["cache-builder"] }
+# no quantifier. Pinned by rev rather than tag because no release has been cut
+# on top of the merge yet; move to that tag when one is.
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "b47046054da605429572d34cbf3fb3d0ecb3c294", features = ["cache-builder"] }
 datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }
 datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ serde_json = "1"
 # top of it yet; move to that tag when one is. bio-formats stays declared by tag
 # on both sides, per the note above, so the formats crates resolve to a single
 # source.
-# bio-functions 6197191: the head of biodatageeks/datafusion-bio-functions#243
+# bio-functions 30bd532: the head of biodatageeks/datafusion-bio-functions#243
 # (vepyr#93 -- a CSQ whitespace RUN now collapses to one underscore, per
 # OutputFactory/VCF.pm:403 `s/\s+/\_/g`, and the engine's two CSQ escapers
 # became one function). Two behaviour notes for this repo: a bare `-` in a
@@ -102,6 +102,6 @@ serde_json = "1"
 # per-character escaping, because VEP's rule there (OutputFactory.pm:1505) has
 # no quantifier. Still pinned by rev, not tag -- this is a PR head, so re-pin to
 # the merge commit once #243 lands.
-datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "61971919c04840a82d290481489f0fd611907c20", features = ["cache-builder"] }
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "30bd532f7a5f84dce8129f9307b2d06770a89498", features = ["cache-builder"] }
 datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }
 datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }

--- a/docs/superpowers/plans/2026-09-10-csq-escaping-whitespace-run-parity.md
+++ b/docs/superpowers/plans/2026-09-10-csq-escaping-whitespace-run-parity.md
@@ -1,0 +1,351 @@
+# CSQ escaping: collapse whitespace runs, and reconcile the escapers
+
+**Issue:** `biodatageeks/vepyr#93`
+**Date:** 2026-09-10
+**Status:** awaiting human go-ahead (runbook step 1d)
+**Baseline commit:** vepyr `fedc945` (= `origin/master` head; no `[patch]`, lock resolves
+functions `97aa8ca5`, formats `v1.12.1` = `419be98`)
+
+## The defect
+
+VEP applies four substitutions to every CSQ field value, in order, at
+`ensembl-vep release/116.0 modules/Bio/EnsEMBL/VEP/OutputFactory/VCF.pm:401-404`:
+
+```perl
+$data =~ s/\,/\&/g;      $data =~ s/\;/\%3B/g;
+$data =~ s/\s+/\_/g;     $data =~ s/\|/\&/g;
+```
+
+`s/\s+/_/g` is **quantified**: a run of whitespace collapses to exactly one
+underscore. The engine's `csq_escape`
+(`datafusion-bio-functions@97aa8ca5 datafusion/bio-function-vep/src/annotate_provider.rs:2535-2565`)
+substitutes per character, so `A  G` becomes `A__G` where VEP writes `A_G`.
+
+**Record shape that triggers it:** any CSQ-destined string value containing two
+or more consecutive whitespace characters, or a tab, in `CLIN_SIG`, `PUBMED`,
+`SWISSPROT`, `TREMBL`, or a `Utf8` plugin field.
+
+## Ownership
+
+| Repo | Verdict | Change |
+|---|---|---|
+| `datafusion-bio-formats` | **carrier, write side only** | **none** — not even a pin bump |
+| `datafusion-bio-functions` | **owner** | the fix |
+| `vepyr` | **carrier** | pin bump only (`Cargo.toml:95`) |
+
+**formats owns nothing here.** It has no CSQ escaper, no whitespace normaliser
+and no INFO escaping/unescaping at all. All four VCF record loops — including the
+indexed/tabix path at `physical_exec.rs:2939` that a `read_record` grep misses —
+funnel INFO values through one helper, `load_infos_single_pass`
+(`physical_exec.rs:713-809`), whose string arm at `:767-769` appends verbatim.
+The write side (`serializer.rs:942-986`) emits the pre-escaped bytes untouched;
+its only substitution on any written value is ALT's pipe→comma at `:670`.
+`origin/master` **is** `v1.12.1` (zero commits between), so vepyr keeps its tag pin.
+
+**vepyr owns nothing here** either. Its only touch of CSQ is
+`SELECT * EXCLUDE ("CSQ")` at `src/annotate.rs:504-508`; `no_escape` is pure
+passthrough (`src/vepyr/__init__.py:1384-1385` → `src/annotate.rs:212-213`).
+There is no unescape anywhere in the repo.
+
+## What the analysis changed about the issue
+
+The issue is right about the defect and wrong about the fix in two ways. Both
+were found by reading the Ensembl source (runbook step 1a-bis), not by comparing
+outputs.
+
+### A. There are not two escapers. There are four, and one must NOT collapse runs.
+
+| # | Site | Rule today | VEP counterpart | Correct action |
+|---|---|---|---|---|
+| 1 | `annotate_provider.rs:2535` `csq_escape` | per-char ws | `VCF.pm:401-404` — `\s+` **run** | **collapse** |
+| 2 | `plugin_cache/csq.rs:16-28` `escape_csq_value` | per-char ws, `+ '='→%3D` | same | **collapse**; `=` — see B |
+| 3 | `annotate_provider.rs:8358` DOMAINS | `.replace(' ')`, `';'`, `'='` | `OutputFactory.pm:1505` `s/[\s;=]/_/g` — **no quantifier** | **leave per-char**; fix the tab gap |
+| 4 | `annotate_provider.rs:3567` `format_prediction` | `.replace(' ')` + `"_-_"→"_"` | `OutputFactory.pm:1819-1820` `s/\s+/_/g` then `s/\_\-\_/\_/g` | **collapse** |
+
+Escaper #3 is the trap. VEP's DOMAINS rule is genuinely per-character, so
+collapsing runs there would **create** a mismatch. Its real bug is the opposite
+one: `.replace(' ', "_")` misses a tab that VEP's `[\s;=]` catches.
+
+Structural finding the issue misses: **there is no general per-field escaping
+pass in this engine.** The CSQ chunk is raw interpolation
+(`annotate_provider.rs:6795-6830`), so SYMBOL, BIOTYPE, EXON, HGVSc,
+Consequence reach the output unescaped, each value relying on its producing
+site. VEP escapes *every* column at `VCF.pm:400-405`. `csq_escape` is not the
+general escaper the issue takes it for — it has exactly four call sites
+(`:2241` PUBMED, `:2244`/`:2246` CLIN_SIG, `:6620` SWISSPROT, `:6622` TREMBL).
+
+### B. Dropping the `=` arm would regress a measured parity gate
+
+The issue's step 2 says to drop `'=' => "%3D"` from the plugin escaper "to match
+VEP". VEP 116 indeed has no such rule — its only `=`→`%3D` is HGVSp at
+`OutputFactory.pm:1757`, and it is `no_escape`-gated. **But** the arm is recorded
+in `docs/superpowers/handovers/2026-08-26-plugin-golden-vep-parity.md:20-36` as a
+measured fix: without it, **556 `ClinVar_CLNVI` entries across 7 records**
+mismatched (chr13 ×6, chr17 ×1), all BIC `base_change=…` values. It is what got
+the plugin profile to 22/22 strict.
+
+The likely root cause is elsewhere: VCF 4.3 requires `=` in an INFO value to be
+`%3D`-encoded, so VEP probably passes ClinVar's already-encoded bytes through
+verbatim while something on our side decodes them. That is a different fix in a
+possibly different repo, and it is **not** in scope here.
+
+### C. Perl `\s` and Rust `char::is_whitespace` disagree
+
+`VCF.pm` has `use strict; use warnings;` and **no** `use utf8` (verified: no
+`use open`/`binmode`/`:encoding` anywhere under `modules/Bio/EnsEMBL/VEP/`), so
+`\s` uses byte semantics. Measured on perl 5.28.3:
+
+| codepoint | Perl `\s` | Rust `is_whitespace` |
+|---|---|---|
+| U+0009–U+000D, U+0020 | yes | yes |
+| **U+0085 NEL** | **no** | **yes** |
+| **U+00A0 NBSP** | **no** | **yes** |
+
+All four Rust escapers currently over-match on NBSP and NEL. Both are plausible
+in free-text ClinVar/phenotype strings.
+
+### D. Ancillary facts worth recording
+
+- Substitution **order is unobservable**: the outputs `&`, `%3B`, `_` contain no
+  `;`, whitespace or `|`, and no rule produces a `,`. The four commute. The
+  issue's emphasis on order is a non-issue, but both `,`→`&` and `|`→`&` must land.
+- The POD table at `VCF.pm:76-78` is wrong **twice**: it claims `= ==> %3B`
+  (a typo for `;`) and omits the `|`→`&` rule entirely. Issue's typo claim confirmed.
+- **No trim.** Leading/trailing runs each collapse to one `_`; `"  x  "` → `"_x_"`.
+- `VCF.pm:390` tests **truthiness**. `'0'` is rescued at `:410-412` and pushed
+  **unescaped**; other falsy values become `''` at `:415`.
+- `-`→`''` blanking (`VCF.pm:396-398`) applies to every column **except** `Allele`,
+  and runs **before** escaping — including plugin columns. So the plugin-side
+  comment at `plugin_cache/csq.rs:11-15` is at odds with VEP 116, though
+  unreachable in practice.
+- **115.2 vs 116.0**: `VCF.pm` differs by one line — the copyright year. Both revs
+  `rev-parse`d before diffing (`release/116.0` = `57ea5c52`, `release/115.2` =
+  `2beada0d`), so the empty result is real, not a null comparison.
+- `ensembl-variation origin/release/116` (`2fb834b9`) has mirror copies in the
+  **legacy** `Utils/VEP.pm`, not on the 116 execution path.
+- Ported assertions at `t/OutputFactory_VCF.t:244-248` and `:329-334` — the issue
+  transcribed both correctly.
+
+## Exposure: currently zero, genome-wide
+
+Measured, not assumed:
+
+| Corpus | Result |
+|---|---|
+| Real VEP 116 reference `vep_chr1_merged.vcf` (2.4 GB, 323,430 records) | `grep -c '__'` → **0** |
+| chr22 cache: variation 15.1M rows, transcript, motif, regulatory, 141,621 protein features | **0** runs, **0** tabs, **0** `=` |
+| Plugin caches chr22: cadd 119M, spliceai 52.7M, dbnsfp 1.8M, alphamissense 1.5M, clinvar 96K rows | **0** runs, **0** tabs, **0** `=` |
+| Whole-genome strict md5, 22/22 contigs, 4,096,123 records | passing today |
+
+The single-space path *is* heavily exercised and correct: 60,815 `DOMAINS`
+analysis values on chr22 alone carry one space (`AFDB-ENSP mappings`,
+`PROSITE profiles`, …), and the 22/22 strict pass proves each renders as VEP does.
+`ClinVar_CLNDN` already ships with `_` for spaces (ClinVar's own convention), so
+the free-text case the issue predicts as riskiest is empty in practice.
+
+**Consequence: this is a correctness/future-proofing fix with no expected output
+change on the current corpus** — and a refactor touching a path that is load-bearing
+for genome-wide byte parity.
+
+## Failing tests
+
+**Blind spots first.** All seven golden fixtures (`golden`, `golden_merged`,
+`golden_merged_pick_allele`, `golden_merged_flag_pick_allele`,
+`golden_merged_pick_allele_gene`, `golden_merged_per_gene`, `golden_mnv`) have
+**zero** `__`, zero `=` in CSQ, zero tabs — and `DOMAINS` and `CLIN_SIG` are
+**empty on every entry of every one**. The golden gate cannot see this defect or
+protect the refactor. **Strict md5 is the regression detector.**
+
+### Engine (`datafusion-bio-functions`)
+
+In the `annotate_provider.rs` test module, alongside the five existing
+single-character tests at `:19782-19815`:
+
+- `csq_escape("A  G") == "A_G"` — `t/OutputFactory_VCF.t:245`
+- `csq_escape("ENST00,00  03|07;301") == "ENST00&00_03&07%3B301"` — `:329-334`
+- `csq_escape("a\t  b") == "a_b"` — mixed run
+- `csq_escape("A G") == "A_G"` — **positive control**, already passes
+- `csq_escape("  x  ") == "_x_"` — no trim
+- `csq_escape("a=b") == "a=b"` — built-in does not escape `=` (D2)
+- `format_scalar(Str("a=b")) == "a%3Db"` — plugin path still does (D2)
+- `format_scalar(Str("-")) == ""` — plugin `-` now blanks (D1); **flips today's
+  behaviour**, so this test is the record of the decision
+- **negative control for #3:** DOMAINS keeps per-character semantics —
+  `"a  b"` stays `"a__b"`
+- **new for #3:** a tab in a domain label becomes `_`
+- **#4:** `format_prediction` collapses a run
+- **D3 predicate, all four escapers:** `\x0B` **is** escaped; NBSP (U+00A0) and
+  NEL (U+0085) are **not**. This is the test that fails under both
+  `is_whitespace` and `is_ascii_whitespace`, so it pins the explicit predicate.
+- **borrowed-`Cow` fast path preserved** (`annotate_provider.rs:19809`)
+
+### vepyr
+
+Per the vepyr analysis, the issue's proposed helpers `_write_plugin_hit_vcf` and
+`_first_csq_group` **do not exist**. They are also unnecessary: the existing
+`demo_plugin_cache` fixture (`tests/test_annotate.py:128-154`) already keys rows
+to golden `INPUT_VCF` variants (chr1:604358 G>C, 604360 T>C). Needed scaffolding
+is a `Utf8` manifest variant (current `_FULL_MANIFEST` at
+`tests/test_build_plugin_cache.py:12-35` casts to `Float32`) and a source row
+whose value is `two  spaces`. Assert through the LazyFrame —
+`frame["DEMO"][0] == "two_spaces"` — which is simpler and equally diagnostic.
+A tab cannot be used: the source is tab-delimited.
+
+**Hazard to guard:** `src/vepyr/__init__.py:1825` does `.replace("", None)`, so an
+empty CSQ token becomes `null`. If `csq_escape`'s `-`→`""` arm leaks onto the
+plugin path during unification, every legitimate `-` plugin value silently
+becomes `null`. No existing test catches this.
+
+## Change, in dependency order
+
+1. **formats** — none.
+2. **functions** —
+   a. `csq_escape`: collapse runs via a `prev_ws` flag, single pass, no extra allocation.
+   b. `csq_escape` → `pub(crate)`; `plugin_cache/csq.rs` imports it and
+      `escape_csq_value` is deleted. Per the analysis this is the *entire*
+      visibility change — `lib.rs:42` and `:65` already declare both modules
+      `pub mod`, so no module move, no re-export, no cycle. **No `bool`
+      parameter**: `-`→`""` now applies on both paths (D1), and the plugin `=`
+      step is applied by `format_scalar` around the shared call as a named,
+      issue-tracked deviation (D2).
+   f. Replace `char::is_whitespace` with the explicit `is_vep_space` predicate
+      across all four escapers (D3).
+   e. **Spec**: add a "CSQ value escaping" subsection under §5 of
+      `docs/superpowers/specs/2026-07-05-custom-vep-plugin-caches-design.md` (D1),
+      and correct `plugin_cache/csq.rs:1`, which cites §5.2 for rules §5.2 does
+      not contain.
+   c. `format_prediction` (#4): collapse runs, matching `OutputFactory.pm:1819-1820`.
+   d. DOMAINS (#3): keep per-character; widen `' '` to whitespace so tabs are caught.
+3. **vepyr** — `Cargo.toml:95` rev bump + pin-comment rationale (repo convention,
+   `Cargo.toml:45-94`); `Cargo.lock:1249` regenerates. **formats stays declared by
+   TAG** — `Cargo.toml:84-87` records that cargo keys a git source on its
+   *reference*, so a `rev=` of the same commit is a distinct source and the formats
+   crates would compile twice (E0308 across `CacheBuilder`).
+
+## Pin cascade
+
+formats: unchanged at `v1.12.1`. functions PR: no formats bump. vepyr PR: pins
+the functions PR head. Two PRs, not three.
+
+## Expected gate movement
+
+| Gate | Expectation |
+|---|---|
+| strict md5, 22/22 | **unchanged, still 22/22** — zero exposure measured above |
+| golden (7 fixtures) | **unchanged** — blind to this path |
+| perf: phase durations | **unchanged** — one branch in a per-character loop already running |
+| perf: wall, peak RSS | **unchanged** |
+
+Any md5 movement means the refactor broke the single-space path that 60,815
+chr22 DOMAINS values depend on — that is the signal to watch, not the new tests.
+
+## Decisions taken
+
+### D1 — plugin `-` follows VEP and is blanked (resolved 2026-09-10)
+
+Unifying the escapers collided with `csq_escape` blanking `-` unconditionally
+while the plugin path deliberately preserved it
+(`plugin_cache/csq.rs:11-15`: *"the built-in `-`→empty convention is deliberately
+NOT applied to plugin values, so a legitimate `-` is preserved"*).
+
+**Decision: follow VEP. `-` is blanked for plugin values too, and the unified
+`csq_escape` takes no parameter.**
+
+Evidence:
+
+- **VEP blanks plugin `-`, confirmed at the source, not inferred.**
+  `OutputFactory/VCF.pm:449` pushes `map {$_->[0]} @{$self->get_plugin_headers}`
+  into `@fields`, so plugin columns run through the same
+  `for my $col (@{$self->fields})` loop at `:387` — including the `-`→`''`
+  blanking at `:396-398`.
+- **Unreachable today**, so nothing measurable is at risk either way. All five
+  published plugin caches scanned on chr22 for a bare or whitespace-padded `-`
+  across every `Utf8` column:
+
+  | cache | rows | Utf8 cols | bare/ws `-` |
+  |---|---:|---:|---|
+  | alphamissense | 1,466,988 | 4 | none |
+  | cadd | 119,170,699 | 4 | none |
+  | clinvar | 96,223 | 8 | none |
+  | dbnsfp | 1,799,075 | 22 | none |
+  | spliceai | 52,715,028 | 8 | none |
+
+- **The green-gate argument for preserving was void.** The 22/22 strict pass
+  cannot defend the old behaviour, because the case never arises in the corpus —
+  the gate measured nothing there.
+- **It makes the unification real.** A single function with no parameter is what
+  the issue asks for; one function plus a `blank_dash: bool` would re-encode the
+  very split the issue wants removed.
+
+Accepted cost: `PluginScalar::Null` already maps to `""` (`csq.rs:36`), so a
+meaningful `-` becomes indistinguishable from a cache miss — and in vepyr,
+`src/vepyr/__init__.py:1825` `.replace("", None)` lands both as `null` in the
+LazyFrame. **VEP has the identical conflation**, so parity is preserved; a
+future plugin whose `-` carries meaning would lose it in VEP too.
+
+**Spec documentation is part of this change.** `plugin_cache/csq.rs:1` cites
+"spec §5.2", but `docs/superpowers/specs/2026-07-05-custom-vep-plugin-caches-design.md`
+§5.2 covers only the per-buffer/per-transcript lookup flow and **documents no
+escaping rules at all** — the `-` convention existed solely as a code comment.
+Add a subsection under §5 ("CSQ value escaping") stating: the four VEP
+substitutions with `\s+` as a run, that `-`→`""` applies to plugin values as it
+does to built-ins, per `VCF.pm:396-398` and `:449`; that `Null` and `-` therefore
+both render empty; and that one function serves both paths. Cite `VCF.pm` line
+numbers so the next reader does not have to re-derive them.
+
+Pinned by a unit test, since no gate can reach it.
+
+### D2 — the plugin `=` arm stays (resolved 2026-09-10)
+
+`'=' => "%3D"` is **kept** on the plugin path. VEP 116 has no such rule — its only
+`=`→`%3D` is HGVSp at `OutputFactory.pm:1757`, `no_escape`-gated — but the arm is
+load-bearing: without it, 556 `ClinVar_CLNVI` entries across 7 records mismatch
+(`docs/superpowers/handovers/2026-08-26-plugin-golden-vep-parity.md:20-36`).
+
+The root cause is almost certainly upstream: VCF 4.3 requires `=` in an INFO value
+to be `%3D`-encoded, so VEP passes ClinVar's already-encoded bytes through while
+something on our side decodes them. **File that as a separate issue** against
+whichever layer is decoding; do not chase it here.
+
+Consequence for the shape of the fix: `csq_escape` implements VEP's rules exactly
+and the `=` step is applied **only** on the plugin path, as a named deviation
+rather than a `bool` parameter — a parameter would say "these are two variants of
+one rule", when in fact one is VEP and one is a compensating workaround with a
+tracking issue. Composition is safe in either order: no VEP substitution emits an
+`=`, and none of `&`, `%3B`, `_` contains one, so a post-pass cannot corrupt them.
+Preserve the borrowed-`Cow` fast path (`annotate_provider.rs:19809` asserts it).
+
+### D3 — whitespace predicate matches Perl byte-semantics exactly (resolved 2026-09-10)
+
+**Neither Rust stdlib predicate is correct.** Measured, perl 5.28.3 vs rustc:
+
+| codepoint | Perl `\s` | `is_whitespace` | `is_ascii_whitespace` |
+|---|---|---|---|
+| U+0009, 000A, 000C, 000D, 0020 | yes | true | true |
+| **U+000B** vertical tab | **yes** | true | **false** |
+| **U+0085** NEL | **no** | **true** | false |
+| **U+00A0** NBSP | **no** | **true** | false |
+
+Today's `is_whitespace` over-matches NEL and NBSP. The tempting swap to
+`is_ascii_whitespace` would fix those and **introduce a new divergence** by
+dropping vertical tab. Use an explicit predicate on all four escapers:
+
+```rust
+const fn is_vep_space(c: char) -> bool {
+    matches!(c, ' ' | '\t' | '\n' | '\x0B' | '\x0C' | '\r')
+}
+```
+
+`VCF.pm` has no `use utf8` and no `use open`/`binmode`/`:encoding` anywhere under
+`modules/Bio/EnsEMBL/VEP/`, so `\s` is byte-semantics — this set, exactly.
+
+### D4 — all four escapers are in scope (resolved 2026-09-10)
+
+Including the two the issue never mentions: #3 DOMAINS (stays **per-character**
+per `OutputFactory.pm:1505` `s/[\s;=]/_/g`, but widens `' '` to `is_vep_space` so
+a tab is caught) and #4 `format_prediction` (**collapses** runs per
+`OutputFactory.pm:1819-1820`). One coherent escaping change.
+
+## Open questions
+
+None. All four resolved above; awaiting the step 1d go-ahead.

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -155,6 +155,102 @@ def demo_plugin_cache(metadata_cache_dir, tmp_path_factory):
 
 
 @pytest.fixture(scope="module")
+def text_plugin_cache(metadata_cache_dir, tmp_path_factory):
+    """A one-plugin cache whose ``DEMO`` value is text carrying a whitespace run.
+
+    The escapers are not reachable from Python, and no cache or golden fixture
+    contains a multi-character whitespace run, so a plugin string value is the
+    only CSQ path whose input bytes are under test control (vepyr#93).
+    """
+    from tests.test_build_plugin_cache import _UTF8_MANIFEST, _init_full_repo
+
+    import vepyr
+
+    root = tmp_path_factory.mktemp("text_plugin")
+    repo = _init_full_repo(root, manifest=_UTF8_MANIFEST)
+    source = root / "demo.tsv"
+    # Two spaces, and a tab+space run. The source is tab-delimited, so the tab
+    # goes in via the second row's value only after the column split.
+    source.write_text("1\t604358\tG\tC\ttwo  spaces\n1\t604360\tT\tC\ta-b\n")
+    plugin_root = root / "pc"
+    built = vepyr.build_plugin_cache(
+        "demo",
+        "v0.1.0",
+        source_path=str(source),
+        cache_dir=metadata_cache_dir,
+        plugin_cache_root=str(plugin_root),
+        plugins_repo=str(repo),
+        chroms=["1"],
+    )
+    assert built == [("chr1", 2, 0, 2)]
+    return str(plugin_root)
+
+
+class TestCsqValueEscaping:
+    """vepyr#93 -- a whitespace RUN in a CSQ value collapses to ONE underscore.
+
+    Ensembl VEP's rule is ``s/\\s+/\\_/g`` (``OutputFactory/VCF.pm:403``), which
+    is quantified. The engine escaped per character, so ``two  spaces`` came out
+    as ``two__spaces``. The golden gate cannot see this: no golden value holds a
+    whitespace run, and DOMAINS -- the field whose source values do carry spaces
+    -- is empty on every entry of every golden fixture.
+    """
+
+    def test_whitespace_run_collapses_to_one_underscore_in_vcf(
+        self, text_plugin_cache, metadata_cache_dir, tmp_path
+    ):
+        import vepyr
+
+        output = tmp_path / "escaping.vcf"
+        vepyr.annotate(
+            INPUT_VCF,
+            metadata_cache_dir,
+            fields="core",
+            plugin_cache_root=text_plugin_cache,
+            plugins=["demo"],
+            output_vcf=str(output),
+            show_progress=False,
+        )
+        # DEMO is the last CSQ sub-field, so the plugin value is the last token
+        # of each entry. Take the entries that actually hit the plugin.
+        values = set()
+        for line in output.read_text().splitlines():
+            if line.startswith("#"):
+                continue
+            info = line.split("\t")[7]
+            csq = next(
+                (f[len("CSQ=") :] for f in info.split(";") if f.startswith("CSQ=")),
+                None,
+            )
+            if csq is None:
+                continue
+            for entry in csq.split(","):
+                token = entry.split("|")[-1]
+                if token:
+                    values.add(token)
+
+        assert "two_spaces" in values, sorted(values)
+        assert "two__spaces" not in values, "whitespace run was not collapsed"
+
+    def test_whitespace_run_collapses_in_the_lazyframe(
+        self, text_plugin_cache, metadata_cache_dir
+    ):
+        import vepyr
+
+        frame = vepyr.annotate(
+            INPUT_VCF,
+            metadata_cache_dir,
+            fields="core",
+            plugin_cache_root=text_plugin_cache,
+            plugins=["demo"],
+        ).collect()
+        values = set(frame["DEMO"].drop_nulls().to_list())
+        assert "two_spaces" in values, sorted(values)
+        # A `-` inside a value is untouched -- only a value that IS `-` blanks.
+        assert "a-b" in values, sorted(values)
+
+
+@pytest.fixture(scope="module")
 def partial_plugin_cache(demo_plugin_cache, tmp_path_factory):
     """The plugin-cache analogue of ``partial_cache_dir``: ``manifest.json``
     lists contigs whose shards were never downloaded, ahead of the one that was.

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -169,9 +169,20 @@ def text_plugin_cache(metadata_cache_dir, tmp_path_factory):
     root = tmp_path_factory.mktemp("text_plugin")
     repo = _init_full_repo(root, manifest=_UTF8_MANIFEST)
     source = root / "demo.tsv"
-    # Two spaces, and a tab+space run. The source is tab-delimited, so the tab
-    # goes in via the second row's value only after the column split.
-    source.write_text("1\t604358\tG\tC\ttwo  spaces\n1\t604360\tT\tC\ta-b\n")
+    # Three values, one per golden variant:
+    #   604358  a plain two-space run
+    #   604360  a MIXED run -- space + vertical tab + space. A literal tab
+    #           cannot be used: the source is tab-delimited, so it would split
+    #           the column. U+000B is Perl `\s` and is not a delimiter, and it
+    #           is also the character `char::is_ascii_whitespace` omits, so this
+    #           row fails if the engine ever swaps to that predicate.
+    #   611317  the control: a `-` INSIDE a value is untouched (only a value
+    #           that IS `-` blanks).
+    source.write_text(
+        "1\t604358\tG\tC\ttwo  spaces\n"
+        "1\t604360\tT\tC\tmixed \x0b run\n"
+        "1\t611317\tA\tG\ta-b\n"
+    )
     plugin_root = root / "pc"
     built = vepyr.build_plugin_cache(
         "demo",
@@ -182,7 +193,7 @@ def text_plugin_cache(metadata_cache_dir, tmp_path_factory):
         plugins_repo=str(repo),
         chroms=["1"],
     )
-    assert built == [("chr1", 2, 0, 2)]
+    assert built == [("chr1", 3, 0, 3)]
     return str(plugin_root)
 
 
@@ -231,6 +242,10 @@ class TestCsqValueEscaping:
 
         assert "two_spaces" in values, sorted(values)
         assert "two__spaces" not in values, "whitespace run was not collapsed"
+        # A mixed run collapses to ONE underscore too -- `\s+` is one rule over
+        # the whole set, not a per-character rule applied repeatedly.
+        assert "mixed_run" in values, sorted(values)
+        assert "mixed__run" not in values, "mixed whitespace run was not collapsed"
 
     def test_whitespace_run_collapses_in_the_lazyframe(
         self, text_plugin_cache, metadata_cache_dir
@@ -246,6 +261,7 @@ class TestCsqValueEscaping:
         ).collect()
         values = set(frame["DEMO"].drop_nulls().to_list())
         assert "two_spaces" in values, sorted(values)
+        assert "mixed_run" in values, sorted(values)
         # A `-` inside a value is untouched -- only a value that IS `-` blanks.
         assert "a-b" in values, sorted(values)
 

--- a/tests/test_build_plugin_cache.py
+++ b/tests/test_build_plugin_cache.py
@@ -34,6 +34,12 @@ csq_field = "DEMO"
 type = "Float32"
 """
 
+# A manifest whose value column is Utf8 rather than Float32, so a plugin value
+# can carry text -- the only CSQ path whose input bytes are under test control.
+_UTF8_MANIFEST = _FULL_MANIFEST.replace(
+    "CAST(score AS FLOAT) AS demo_score", "score AS demo_score"
+).replace('type = "Float32"', 'type = "Utf8"')
+
 # A manifest whose sole [[source]] carries a part -- the shape a {part: path}
 # mapping addresses.
 _PARTED_MANIFEST = _FULL_MANIFEST.replace(
@@ -66,15 +72,18 @@ def _init_full_repo(
     multi_source: bool = False,
     parted: bool = False,
     md5: str | None = None,
+    manifest: str | None = None,
 ) -> Path:
     """A plugins repo whose demo manifest the Rust builder can load.
 
     ``md5`` adds the provenance keys (``url`` + ``md5``) to the sole
     ``[[source]]`` so the build verifies the file ``source_path`` resolves to.
+    ``manifest`` overrides the body outright, for a plugin whose value column is
+    not the default ``Float32``.
     """
     repo = root / "vepyr-plugins-full"
     (repo / "plugins" / "demo").mkdir(parents=True)
-    base = _PARTED_MANIFEST if parted else _FULL_MANIFEST
+    base = manifest or (_PARTED_MANIFEST if parted else _FULL_MANIFEST)
     if md5 is not None:
         base = base.replace(
             'path = "placeholder.tsv.gz"\n',


### PR DESCRIPTION
## What

Pins `biodatageeks/datafusion-bio-functions#243` and gates it from Python.

The engine collapsed a CSQ whitespace **run** per character instead of per run, so a value
with two consecutive spaces came out `two__spaces` where Ensembl VEP writes `two_spaces`
(`OutputFactory/VCF.pm:403` is `s/\s+/\_/g`, quantified). The same PR folds the engine's
two divergent CSQ escapers into one function.

Fixes #93.

## Pin

| | |
|---|---|
| `datafusion-bio-function-vep` | `97aa8ca5` → `dd7dcb46` (head of functions#243) |
| `datafusion-bio-format-*` | **unchanged** at `v1.12.1` |

The formats repo needs nothing — it has no CSQ escaper at all, all four VCF record loops
funnel INFO values through one verbatim helper (`physical_exec.rs:713-809`), and its
`origin/master` *is* `v1.12.1`. Still declared by **tag** on both sides, per the existing
note at `Cargo.toml:84-87`: cargo keys a git source on its reference, so a `rev =` of the
same commit is a second source and the formats crates would compile twice (E0308).

⚠️ **Re-pin to the merge commit after functions#243 lands** — this points at a PR head.

## Behaviour changes reaching this side

**A bare `-` in a plugin value now blanks**, as VEP does. `VCF.pm:396-398` applies to
plugin columns because `VCF.pm:449` pushes `get_plugin_headers` into `@fields`. It
therefore arrives as `null` in the LazyFrame via the `.replace("", None)` in
`_plugin_column`. Unreachable in every published cache — **0 hits across ~175M rows** in
all five (cadd, clinvar, dbnsfp, spliceai, alphamissense) — so no digest moves.

**DOMAINS keeps per-character escaping**, deliberately. VEP's rule there
(`OutputFactory.pm:1505`) has no quantifier, so collapsing would *create* a mismatch on
the ~60k chr22 values that pass byte-for-byte today.

## Test

The escapers are not reachable from Python, and no cache or golden fixture contains a
whitespace run — `DOMAINS` is empty on **every entry of all seven** golden fixtures, so a
green golden gate is not evidence here. The gate therefore drives a **plugin string
value**, the one CSQ path whose input bytes are under test control.

That needs a `Utf8` value column; the existing demo plugin casts to `Float32`, which
cannot carry text. Hence `_UTF8_MANIFEST` and a `manifest` override on `_init_full_repo`.

Both tests fail against the pre-fix engine and pass after:

```
AssertionError: ['a-b', 'two__spaces']
assert 'two_spaces' in {'a-b', 'two__spaces'}
```

covering the VCF output and the LazyFrame, with `a-b` as the control that a `-` *inside* a
value is untouched — only a value that *is* `-` blanks.

## Verification

```
uv run pytest                          1516 passed, 2 skipped
cargo test -p ...-vep --lib            1089 passed, 0 failed   (functions#243)
cargo clippy --all-targets -D warnings exit 0                  (functions#243)
```

Strict md5 across 22 autosomes and the worker-scaling comparison are re-run on this
stacked branch against a pre-change baseline before this leaves draft. Baseline captured
at `fedc945` (= `origin/master`, no `[patch]`, lock on `97aa8ca5`/`v1.12.1`):

| gate | baseline |
|---|---|
| strict md5 | PASS 22/22, 4,096,123 records |
| perf, 8 workers | 78.15 s, 9,463,904 kB |
| perf, 1 worker | 314.84 s, 4,008,720 kB |

## Expected movement

None. Exposure is zero on the current corpus, measured not assumed: 0 `__` in the 2.4 GB
real VEP 116 chr1 reference, and 0 whitespace runs / tabs / `=` across the chr22 cache and
~175M plugin rows. If a digest *does* move, it means the refactor broke the single-space
path that 60,815 chr22 DOMAINS values depend on — that is the signal to watch, not the new
tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NpqEN8igDt9NUABDYvuTFz