### PR TITLE
docs: document --allow_non_variant and put the CLI after the Polars path

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ results as a `polars.LazyFrame` or a VCF with `CSQ` in the `INFO` column.
 | | |
 |---|---|
 | [Quick start](https://biodatageeks.org/vepyr/quickstart/) | Install, get a cache, annotate |
+| [Polars DataFrames](https://biodatageeks.org/vepyr/dataframes/) | Schema, region filters, `filter_vep` in Polars |
 | [Command line](https://biodatageeks.org/vepyr/cli/) | `vepyr annotate`, VCF in, VCF out |
 | [Download Ensembl VEP and plugin caches](https://biodatageeks.org/vepyr/downloads/) | Prebuilt release-116 caches |
 | [Caches](https://biodatageeks.org/vepyr/caches/) | Cache types, entity schemas, CSQ output fields |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -42,6 +42,7 @@ directory.
 | `--everything` | Enable all annotation features (80-field CSQ). |
 | `--hgvsc` | Add HGVS coding-sequence notation. Requires `--fasta`. |
 | `--fork N`, `--workers N` | Annotation pipelines to run. Default 1. |
+| `--allow_non_variant` | Keep `ALT=.` records instead of dropping them, as VEP does. |
 | `--cache_version N` | Assert the cache version in the Parquet metadata. |
 | `--plugin_cache_root DIR` | Root of a plugin cache tree. |
 | `--plugin NAME` | Restrict to this plugin. Repeatable; order is CSQ block order. |
@@ -91,6 +92,12 @@ with a `.tbi` or `.csi` beside it, or the run fails. Results are identical to
 
 **No index is written.** The output is bgzf but unindexed; run `tabix` afterwards
 if you need one.
+
+**Records with no alternate allele are dropped.** A record whose first `ALT` is
+`.` carries no alternate allele, and — as Ensembl VEP does — it is left out of
+the output entirely, silently. `--allow_non_variant` writes it through instead,
+with its original `ALT` and no `CSQ` key. Only the first `ALT` is tested, so
+`ALT=.,C` is non-variant while `ALT=C,.` is an ordinary record.
 
 **Unknown flags are an error.** A VEP flag this interface does not implement — say
 `--pick` — fails the run rather than being ignored, so a stale command line can

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,9 +21,9 @@ vepyr is a Python library backed by a native Rust engine that provides:
 
 - **Python-first API** — build complete or targeted caches with
   `build_cache()`, then annotate with `annotate()`
+- **Polars integration** — annotation results returned as `polars.LazyFrame` for efficient downstream analysis
 - **Command line** — `vepyr annotate` covers the VCF-in / VCF-out path from a
   shell or a workflow engine, with Ensembl VEP's own flag spelling
-- **Polars integration** — annotation results returned as `polars.LazyFrame` for efficient downstream analysis
 - **VCF output** — write annotated VCFs with CSQ in the INFO column, compatible with downstream tools
 - **Streaming engine** — built on Apache Arrow and DataFusion for memory-efficient processing of large datasets
 - **Point-lookup Parquet cache** — partitioned, page-indexed Parquet shards for fast co-located variant lookups

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -167,25 +167,6 @@ the other entities untouched.
 
 ## Annotating variants
 
-### From the command line
-
-The quickest path from a VCF to an annotated VCF needs no Python at all:
-
-```bash
-vepyr annotate \
-    -i input.vcf.gz \
-    -o annotated.vcf.gz \
-    --dir_cache ~/vepyr_cache/116_GRCh38_merged \
-    --fasta GRCh38.fa \
-    --everything \
-    --fork 8
-```
-
-The flags follow Ensembl VEP's own spelling. The command covers the VCF-in /
-VCF-out path only; the LazyFrame path below is Python-side. See
-[Command line](cli.md) for the full flag set, the plugin flags and the exit
-codes.
-
 ### Writing annotated VCF output
 
 Write results directly to a VCF file with a `CSQ` INFO field:
@@ -260,3 +241,22 @@ df = vepyr.annotate(
 
 Filtering the LazyFrame on `chrom`, `start` or `end` is pushed into the
 engine before annotation; see [Polars DataFrames](dataframes.md#region-filters).
+
+### From the command line
+
+The quickest path from a VCF to an annotated VCF needs no Python at all:
+
+```bash
+vepyr annotate \
+    -i input.vcf.gz \
+    -o annotated.vcf.gz \
+    --dir_cache ~/vepyr_cache/116_GRCh38_merged \
+    --fasta GRCh38.fa \
+    --everything \
+    --fork 8
+```
+
+The flags follow Ensembl VEP's own spelling. The command covers the VCF-in /
+VCF-out path only; the LazyFrame path above is Python-side. See
+[Command line](cli.md) for the full flag set, the plugin flags and the exit
+codes.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,11 +12,11 @@ nav:
   - Home:
       - Home: index.md
       - Quick start: quickstart.md
-      - Command line: cli.md
       - Architecture: architecture.md
       - Caches: caches.md
       - Plugins: plugins.md
       - Polars DataFrames: dataframes.md
+      - Command line: cli.md
       - API: api.md
       - Performance: performance.md
       - Testing vs Ensembl VEP: testing-vep.md

--- a/nf-core-module/README.md
+++ b/nf-core-module/README.md
@@ -76,13 +76,13 @@ Treat any *third* failure as a genuine regression.
 
 ## Scope
 
-Eleven flags, covering the configuration validated against Ensembl VEP
+Twelve flags, covering the configuration validated against Ensembl VEP
 (`--everything` with `--fasta`) plus what a workflow engine needs. The pick family,
 HGVS sub-flags, AF sub-flags and `--fields` are all additive later and need no
 engine work — see `docs/superpowers/specs/2026-09-07-nf-core-vepyr-module-design.md`.
 
 Note that unknown flags are a hard error, so an `ext.args` string copied from an
-`ensemblvep/vep` config will fail the task if it carries a flag outside that eleven.
+`ensemblvep/vep` config will fail the task if it carries a flag outside that twelve.
 
 `--fork` is the one flag `ext.args` cannot set. The module emits it after `${args}`
 so its computed value always wins: `--fork`/`--workers` are a single argparse


### PR DESCRIPTION
## Why

PR #104 added `--allow_non_variant` to the CLI and `allow_non_variant=` to `annotate()`, but updated no docs. The Python kwarg was already covered — `docs/api.md` is mkdocstrings over the docstring — so the gap was CLI-side only. Every other flag from #89 is in the table already.

Separately, the command line was presented ahead of the Polars path in four places; it now follows it in all of them.

## The flag

- **`docs/cli.md`** — `--allow_non_variant` added to the Options table, plus a Notes entry. The entry matters more than the table row: the *default* silently drops data. A record whose first `ALT` is `.` is left out of the output entirely, as Ensembl VEP does, and the flag writes it through with no `CSQ`. Only the first ALT is tested (`ALT=.,C` is non-variant, `ALT=C,.` is not). None of that was documented anywhere user-facing.
- **`nf-core-module/README.md`** — the Scope section said "Eleven flags" and warned about an `ext.args` flag "outside that eleven". Both are now twelve.

## The ordering

- **`mkdocs.yml`** — Command line moves below Polars DataFrames in the nav.
- **`docs/index.md`** — same swap in Key features. The Quick example tabs were already Python-first.
- **`docs/quickstart.md`** — *From the command line* moves from the top of *Annotating variants* to the end, after *Full `--everything` mode* rather than directly after the LazyFrame section, so the three Python examples stay one continuous flow (they build on the same `lf = vepyr.annotate(...)` and the `workers` paragraph). Its closing "the LazyFrame path **below** is Python-side" becomes "above". Nothing linked `#from-the-command-line`, so the heading move breaks no anchors.
- **`README.md`** — the doc table had no Polars row to order against, so it gains one (that page was not linked from the README at all) with the CLI under it.

## Verification

`mkdocs build --strict` passes. Docs only — no code, no tests touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AiRYKXFUwfxvqCgMT4XYoG
