### PR TITLE
feat: PhenotypeOrthologous plugin via a GFF source and interval lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1273,7 +1273,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-function-vep"
 version = "0.18.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=a07f940932138d0d01499cb1b12771be1c2e392c#a07f940932138d0d01499cb1b12771be1c2e392c"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=5386bfdc9f34f6d73a0889d6044116c1fc220e18#5386bfdc9f34f6d73a0889d6044116c1fc220e18"
 dependencies = [
  "ahash",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1273,7 +1273,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-function-vep"
 version = "0.18.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=5386bfdc9f34f6d73a0889d6044116c1fc220e18#5386bfdc9f34f6d73a0889d6044116c1fc220e18"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=00c64b0d2bbf9b1f2138c30623ee57f0b83c8f35#00c64b0d2bbf9b1f2138c30623ee57f0b83c8f35"
 dependencies = [
  "ahash",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1213,6 +1213,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-bio-format-gff"
+version = "1.12.1"
+source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.1#419be98562b3fdbebbfdbd5a236205247ec56a67"
+dependencies = [
+ "async-compression",
+ "async-stream",
+ "async-trait",
+ "bytes",
+ "datafusion",
+ "datafusion-bio-format-core",
+ "env_logger",
+ "flate2",
+ "futures",
+ "futures-util",
+ "log",
+ "noodles-bgzf 0.49.0",
+ "noodles-core 0.20.0",
+ "noodles-csi",
+ "noodles-gff",
+ "noodles-tabix",
+ "opendal",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "datafusion-bio-format-vcf"
 version = "1.12.1"
 source = "git+https://github.com/biodatageeks/datafusion-bio-formats.git?tag=v1.12.1#419be98562b3fdbebbfdbd5a236205247ec56a67"
@@ -1246,7 +1273,7 @@ dependencies = [
 [[package]]
 name = "datafusion-bio-function-vep"
 version = "0.18.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=4b0bd00b5f4c5a40a40886cd6c0d230bb91a5554#4b0bd00b5f4c5a40a40886cd6c0d230bb91a5554"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=a07f940932138d0d01499cb1b12771be1c2e392c#a07f940932138d0d01499cb1b12771be1c2e392c"
 dependencies = [
  "ahash",
  "async-trait",
@@ -1257,6 +1284,7 @@ dependencies = [
  "datafusion-bio-format-bed",
  "datafusion-bio-format-core",
  "datafusion-bio-format-ensembl-cache",
+ "datafusion-bio-format-gff",
  "datafusion-bio-format-vcf",
  "flate2",
  "futures",
@@ -3278,6 +3306,24 @@ dependencies = [
  "memchr",
  "noodles-bgzf 0.36.0",
  "noodles-core 0.16.0",
+]
+
+[[package]]
+name = "noodles-gff"
+version = "0.59.0"
+source = "git+https://github.com/biodatageeks/noodles.git?rev=42a3c0165617b7b8f9f5c5905287968eef92e31e#42a3c0165617b7b8f9f5c5905287968eef92e31e"
+dependencies = [
+ "bstr",
+ "futures",
+ "indexmap",
+ "lexical-core",
+ "log",
+ "memchr",
+ "noodles-bgzf 0.49.0",
+ "noodles-core 0.20.0",
+ "noodles-csi",
+ "percent-encoding",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1272,8 +1272,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-bio-function-vep"
-version = "0.18.1"
-source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=00c64b0d2bbf9b1f2138c30623ee57f0b83c8f35#00c64b0d2bbf9b1f2138c30623ee57f0b83c8f35"
+version = "0.19.0"
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=9f74fd9caa0682d4706f0d0f7e83bfa38eface94#9f74fd9caa0682d4706f0d0f7e83bfa38eface94"
 dependencies = [
  "ahash",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,6 @@ serde_json = "1"
 # (biodatageeks/datafusion-bio-formats#252), which change no src logic, so
 # v1.12.1 still describes the artifact.) Pinned by rev rather than tag because
 # no release has been cut on top of the merge yet; move to that tag when one is.
-datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "00c64b0d2bbf9b1f2138c30623ee57f0b83c8f35", features = ["cache-builder"] }
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "9f74fd9caa0682d4706f0d0f7e83bfa38eface94", features = ["cache-builder"] }
 datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }
 datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,6 @@ serde_json = "1"
 # (biodatageeks/datafusion-bio-formats#252), which change no src logic, so
 # v1.12.1 still describes the artifact.) Pinned by rev rather than tag because
 # no release has been cut on top of the merge yet; move to that tag when one is.
-datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "a07f940932138d0d01499cb1b12771be1c2e392c", features = ["cache-builder"] }
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "5386bfdc9f34f6d73a0889d6044116c1fc220e18", features = ["cache-builder"] }
 datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }
 datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,6 @@ serde_json = "1"
 # (biodatageeks/datafusion-bio-formats#252), which change no src logic, so
 # v1.12.1 still describes the artifact.) Pinned by rev rather than tag because
 # no release has been cut on top of the merge yet; move to that tag when one is.
-datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "5386bfdc9f34f6d73a0889d6044116c1fc220e18", features = ["cache-builder"] }
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "00c64b0d2bbf9b1f2138c30623ee57f0b83c8f35", features = ["cache-builder"] }
 datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }
 datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,6 @@ serde_json = "1"
 # (biodatageeks/datafusion-bio-formats#252), which change no src logic, so
 # v1.12.1 still describes the artifact.) Pinned by rev rather than tag because
 # no release has been cut on top of the merge yet; move to that tag when one is.
-datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "4b0bd00b5f4c5a40a40886cd6c0d230bb91a5554", features = ["cache-builder"] }
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "a07f940932138d0d01499cb1b12771be1c2e392c", features = ["cache-builder"] }
 datafusion-bio-format-ensembl-cache = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }
 datafusion-bio-format-vcf = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ results as a `polars.LazyFrame` or a VCF with `CSQ` in the `INFO` column.
 | [Command line](https://biodatageeks.org/vepyr/cli/) | `vepyr annotate`, VCF in, VCF out |
 | [Download Ensembl VEP and plugin caches](https://biodatageeks.org/vepyr/downloads/) | Prebuilt release-116 caches |
 | [Caches](https://biodatageeks.org/vepyr/caches/) | Cache types, entity schemas, CSQ output fields |
-| [Plugins](https://biodatageeks.org/vepyr/plugins/) | CADD, SpliceAI, AlphaMissense, ClinVar, dbNSFP |
+| [Plugins](https://biodatageeks.org/vepyr/plugins/) | CADD, SpliceAI, AlphaMissense, ClinVar, dbNSFP, PhenotypeOrthologous |
 | [API reference](https://biodatageeks.org/vepyr/api/) | `build_cache()`, `annotate()`, … |
 | [Performance](https://biodatageeks.org/vepyr/performance/) | Benchmarks vs Ensembl VEP |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -39,7 +39,7 @@ The heavy lifting happens here:
 
 - **Cache conversion** (`convert.rs`): reads Ensembl's Storable/Sereal `.gz` files via `EnsemblCacheTableProvider`, runs DataFusion SQL queries, and writes sorted Parquet files with tuned row groups.
 - **Annotation** (`annotate.rs`): registers VCF and cache table providers with DataFusion, builds SQL queries with `annotate_vep()` / `lookup_variants()` UDFs, and streams results as Arrow `RecordBatch`es. `plugin_cache_root` and `plugins` are passed through to the engine, which appends the selected plugins' CSQ fields to the output.
-- **Plugin caches**: no vepyr-side module — the build and the lookup both live in `datafusion-bio-function-vep`'s `plugin_cache` module (`builder`, `source_manifest`, `source_verify`, `lookup`). `src/lib.rs` only drives it and installs the result.
+- **Plugin caches**: no vepyr-side module — the build and the lookup (point probes and interval trees) both live in `datafusion-bio-function-vep`'s `plugin_cache` module (`builder`, `source_manifest`, `source_verify`, `lookup`). `src/lib.rs` only drives it and installs the result.
 
 ### Upstream crates
 

--- a/docs/dataframes.md
+++ b/docs/dataframes.md
@@ -156,7 +156,9 @@ type come from the plugin's manifest, not from the CSQ text it travels in:
 - A plugin keyed on a transcript feature, such as SpliceAI (by gene symbol)
   or AlphaMissense (by protein change), gives one value per consequence
   entry, aligned with `Consequence`: `SpliceAI_pred_DP_AG: List(Int32)`,
-  `am_pathogenicity: List(Float32)`.
+  `am_pathogenicity: List(Float32)`. Interval plugins such as
+  PhenotypeOrthologous (gene span + `Gene`) are lists too, empty on entries
+  whose transcript lies outside the matching span.
 - The element type is the manifest's `type`: `Utf8`, `Int32` or `Float32`.
   CADD's scores are declared `Utf8` so the VCF reproduces the source digits
   exactly, which is why `CADD_PHRED` is a string; cast it when you need a

--- a/docs/downloads.md
+++ b/docs/downloads.md
@@ -182,7 +182,7 @@ print(lf.head().collect())
 
 ## Plugin caches
 
-Four plugin caches are published on Hugging Face, built against the release-116
+Five plugin caches are published on Hugging Face, built against the release-116
 GRCh38 variation cache above. They are the exact output
 [`build_plugin_cache`](api.md#vepyr.build_plugin_cache) would have produced —
 see [Plugins](plugins.md) for what a plugin cache is and how the values reach
@@ -194,13 +194,16 @@ the CSQ output.
 | SpliceAI | [`vepyr_116_GRCh38_plugin_spliceai`](https://huggingface.co/datasets/biodatageeks/vepyr_116_GRCh38_plugin_spliceai) | 24 G | Ensembl 110 masked SNV MANE (model v1.3.1) |
 | AlphaMissense | [`vepyr_116_GRCh38_plugin_alphamissense`](https://huggingface.co/datasets/biodatageeks/vepyr_116_GRCh38_plugin_alphamissense) | 545 M | hg38 canonical, 2023 release |
 | ClinVar | [`vepyr_116_GRCh38_plugin_clinvar`](https://huggingface.co/datasets/biodatageeks/vepyr_116_GRCh38_plugin_clinvar) | 77 M | GRCh38 weekly, `fileDate=2026-07-06` |
+| PhenotypeOrthologous | [`vepyr_116_GRCh38_plugin_phenotypeorthologous`](https://huggingface.co/datasets/biodatageeks/vepyr_116_GRCh38_plugin_phenotypeorthologous) | < 10 M | Ensembl release-116 GFF3 (`…_112_GRCh38.gff3.gz`) |
 
 Each repository holds `chr1.parquet` … `chr22.parquet` plus the plugin
-`manifest.json`. **Autosomes only** — chrX, chrY and chrM are not covered. Every
-dataset card documents its full source provenance, schema, CSQ field mapping and
-licence.
+`manifest.json`. The four score caches are **autosomes only** — chrX, chrY and
+chrM are not covered; the PhenotypeOrthologous cache also carries `chrX` and
+`chrMT` (its source has no chrY rows, which the manifest lists with 0 rows).
+Every dataset card documents its full source provenance, schema, CSQ field
+mapping and licence.
 
-!!! warning "Three of the four are non-commercial only"
+!!! warning "Three of the five are non-commercial only"
     **CADD**, **SpliceAI** and **AlphaMissense** restrict use to academic /
     non-profit research; commercial use needs a licence from the respective
     provider. Only the ClinVar cache is unrestricted (NCBI public domain). Each

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -191,26 +191,28 @@ source and map it to CSQ fields.
 |---|---|---|---|
 | `plugin_name` | string | yes | Plugin identifier; also the cache directory name. |
 | `coordinate_system` | `1-based` \| `0-based-half-open` | yes | How `ingest_sql` reads positions. Drives the build-time shift to the variation cache's 1-based convention, and for `vcf`/`bed` sources it also sets the provider's own flag so both agree. |
-| `ingest_sql` | string | yes | `SELECT` over the raw source table(s). MUST project `chrom`, `start`, `end`, `allele_string` (`ref/alt`), plus any discriminator and value columns. |
+| `ingest_sql` | string | yes | `SELECT` over the raw source table(s). MUST project `chrom`, `start`, `end`, `allele_string` (`ref/alt`), plus any discriminator and value columns. With `lookup = "interval"` there is no `allele_string`. |
 | `[[source]]` | table array | yes, 1+ | The raw file(s) — see below. |
 | `[[value_columns]]` | table array | yes, 1+ | The emitted CSQ fields — see below. |
 | `[[match_column]]` | table array | no (default none) | Per-transcript discriminator(s) — see below. Omit for per-variant plugins. |
 | `allele_match` | `exact` \| `minimised` | no (default `exact`) | Which comparison the plugin's own Ensembl implementation uses. See [Allele matching](#allele-matching-exact-vs-minimised) — it is a statement about upstream, not a tuning knob. |
 | `field_order` | `declared` \| `alphabetical` | no (default `declared`) | Order of this plugin's fields in CSQ. `declared` mirrors Ensembl `--custom`, `alphabetical` mirrors `--plugin`. |
 | `assume_unique` | bool | no (default `false`) | Declare that the source never repeats a probe key, skipping the dedup pass. The build **samples the data to check the claim** rather than trusting it. |
+| `lookup` | `point` \| `interval` | no (default `point`) | `point`: exact probe on `(start, allele_string, discriminators)` with variation-inherited tiering. `interval`: rows are genomic spans with no allele; a row matches when its `[start, end]` overlaps the variant's VEP-normalised span (insertion coordinates swapped, as Ensembl's tabix plugins do) and every discriminator agrees; the first row in file order wins. Use it for gene or region tracks (PhenotypeOrthologous). `allele_match` is rejected with `interval`. |
 
 ### `[[source]]`
 
 | Key | Type | Required | Description |
 |---|---|---|---|
-| `provider` | `csv` \| `tsv` \| `parquet` \| `vcf` \| `bed` | yes | Reader for this file. All five work — see [Table providers](#build-pipeline-table-providers-tables-views). |
+| `provider` | `csv` \| `tsv` \| `parquet` \| `vcf` \| `bed` \| `gff` | yes | Reader for this file — see [Table providers](#build-pipeline-table-providers-tables-views). `gff` needs a `[source.gff]` table. |
 | `path` | string | yes | Placeholder; **always** overridden at build time by `source_path`. |
 | `url` | string | yes | Provenance: the canonical **upstream** download URL of this raw file (the publisher's FTP/bucket, never a mirror or a Drive share). Pin a dated release where the top-level file moves (e.g. ClinVar's weekly `clinvar.vcf.gz`). When the built input is a local re-compression of the upstream file (e.g. a BGZF+tabix rebuild of a plain gzip), `url` still names the upstream file. Never fetched; copied into the built cache's `manifest.json` and quoted in verification errors. |
 | `md5` | string | yes | Provenance: 32 lowercase hex MD5 of the file at `url`. Take it from the publisher's checksum file where one exists (CADD `MD5SUMs`, ClinVar `.md5`, GCS object metadata), otherwise compute it on the downloaded copy and say so in a comment. This is the digest the build [verifies](#source-verification) `source_path` against. A manifest keeps this one digest; when the build input is a derived artifact of `url` (AlphaMissense's BGZF+tabix re-compression of the upstream plain gzip) the preprocessing is documented in the plugin's README and the build runs with `verify_source="warn"` or `False`. |
 | `part` | string | no | Names this source when a manifest declares several. Registers as `plugin_<name>_src_<part>`, and makes `source_path` take a `{part: path}` mapping. |
-| `index` | `tabix` | no | Random-access index. Explicit rather than inferred from a `.gz` suffix, because ordinary gzip is not seekable. On `csv`/`tsv` it **requires** `compression = "gzip"` (i.e. BGZF) — a plain gzip source with `index = "tabix"` is rejected at parse time. |
+| `index` | `tabix` | no | Random-access index. Explicit rather than inferred from a `.gz` suffix, because ordinary gzip is not seekable. Valid for `csv`/`tsv`/`vcf`/`gff`; on `csv`/`tsv` it **requires** `compression = "gzip"` (i.e. BGZF) — a plain gzip source with `index = "tabix"` is rejected at parse time. |
 | `record_layout` | bool | no (default `false`) | `vcf` sources only: carry the raw record layout through the provider. |
-| `[source.csv]` | table | for `csv`/`tsv` | Parsing options — see below. Not used by `parquet`/`vcf`/`bed`. |
+| `[source.csv]` | table | for `csv`/`tsv` | Parsing options — see below. Not used by `parquet`/`vcf`/`bed`/`gff`. |
+| `[source.gff]` | table | for `gff` | Attribute projection — see below. |
 
 ### `[source.csv]`
 
@@ -221,6 +223,12 @@ source and map it to CSQ fields.
 | `comment` | string | none | Lines starting with this are skipped (e.g. `"#"`). |
 | `compression` | string | none | `"gzip"` is the recognised value. gzip inputs are decompressed to a temp file first, since DataFusion is built without the `compression` feature. |
 | `schema` | array of `{name, type}` | empty | Ordered column list for headerless or explicitly typed input. `type` is `Utf8`, `Float32` or `Int32` — declaring everything `Utf8` and casting in `ingest_sql` is the common pattern. |
+
+### `[source.gff]`
+
+| Key | Type | Required | Description |
+|---|---|---|---|
+| `attributes` | array of strings | yes | GFF3 attribute keys exposed as flat nullable `Utf8` columns named exactly like the key (quote them in SQL: `"Rat_gene_id"`). Values are percent-decoded and not trimmed; an absent key is NULL. The fixed columns are `chrom, start, end, type, source, score, strand, phase`. With `index = "tabix"` the BGZF file is sliced per chromosome; plain or gzip GFF is read whole. |
 
 ### `[[match_column]]`
 
@@ -625,6 +633,12 @@ then a derived **`tier`** column (Int8: `0` = warm, `1` = cold). The variation
 frequency columns used to compute the tier are **not** stored — only the tier
 survives.
 
+For `lookup = "interval"` caches `allele_string` is absent and `tier` is always
+`1`: interval rows have no allele to inherit a tier from, so the variation join
+is skipped and rows are written in `(start, file order)`. At runtime the whole
+per-chromosome shard is loaded into one interval tree per discriminator value
+and probed with the variant's span.
+
 
 --8<-- "includes/cache-internals.md"
 
@@ -681,8 +695,8 @@ own convention, so `ingest_sql` always sees the system the manifest declares.
 
 ## Supported plugins
 
-All five plugins below are implemented and validated against the golden Ensembl
-VEP 116 reference. Four have a **prebuilt cache** published on Hugging Face —
+All six plugins below are implemented and validated against the golden Ensembl
+VEP 116 reference. Five have a **prebuilt cache** published on Hugging Face —
 see [Plugin caches](downloads.md#plugin-caches) for the download commands.
 
 | Plugin | CSQ fields | Discriminator | Allele match | Prebuilt cache | Source |
@@ -692,6 +706,7 @@ see [Plugin caches](downloads.md#plugin-caches) for the download commands.
 | **AlphaMissense** | 2 | `{ref_aa}{Protein_position}{alt_aa}` | `minimised` | [`…plugin_alphamissense`](downloads.md#plugin-caches) | [Zenodo](https://zenodo.org/records/8208688) |
 | **ClinVar** | 6 | — (per variant) | `minimised` | [`…plugin_clinvar`](downloads.md#plugin-caches) | [ncbi.nlm.nih.gov/clinvar](https://www.ncbi.nlm.nih.gov/clinvar/) |
 | **dbNSFP** | 19 | `{ref_aa}/{alt_aa}` | `exact` | **not published** — build locally | [dbNSFP](https://www.dbnsfp.org/) |
+| **PhenotypeOrthologous** | 4 | `{Gene}` + gene-span overlap (`lookup = "interval"`) | — | [`…plugin_phenotypeorthologous`](downloads.md#plugin-caches) | [Ensembl FTP](https://ftp.ensembl.org/pub/release-116/variation/PhenotypeOrthologous/) |
 
 The CSQ fields each plugin emits, **in emitted order**:
 
@@ -702,6 +717,7 @@ The CSQ fields each plugin emits, **in emitted order**:
 | AlphaMissense | `am_class`, `am_pathogenicity` |
 | ClinVar | `ClinVar`, `ClinVar_CLNSIG`, `ClinVar_CLNREVSTAT`, `ClinVar_CLNDN`, `ClinVar_CLNVC`, `ClinVar_CLNVI` |
 | dbNSFP | `CADD_phred`, `CADD_raw`, `GERP++_RS`, `MetaLR_pred`, `MetaLR_score`, `MetaSVM_pred`, `MetaSVM_score`, `MutationTaster_pred`, `MutationTaster_score`, `PROVEAN_pred`, `PROVEAN_score`, `Polyphen2_HDIV_score`, `Polyphen2_HVAR_score`, `REVEL_score`, `SIFT4G_pred`, `SIFT4G_score`, `VEST4_score`, `phastCons100way_vertebrate`, `phyloP100way_vertebrate` |
+| PhenotypeOrthologous | `PhenotypeOrthologous_Mouse_geneid`, `PhenotypeOrthologous_Mouse_phenotype`, `PhenotypeOrthologous_Rat_geneid`, `PhenotypeOrthologous_Rat_phenotype` |
 
 !!! note "Emitted order is not manifest order"
     A manifest's `field_order` decides this, and it is not the order the
@@ -712,7 +728,7 @@ The CSQ fields each plugin emits, **in emitted order**:
     | `declared` (default) | manifest declaration order | Ensembl `--custom` |
     | `alphabetical` | sorted by CSQ field name | Ensembl `--plugin` |
 
-    Four of the five are `alphabetical`, because Ensembl loads them with
+    Five of the six are `alphabetical`, because Ensembl loads them with
     `--plugin`. ClinVar is `declared`, because it is loaded with `--custom` —
     which is why it is the one plugin whose emitted order matches how its
     manifest reads. `dbNSFP` carries its own `CADD_phred`/`CADD_raw`, distinct
@@ -729,5 +745,6 @@ The CSQ fields each plugin emits, **in emitted order**:
 !!! warning "Licence terms differ per plugin"
     **CADD**, **SpliceAI** and **AlphaMissense** restrict use to academic /
     non-profit research; commercial use needs a licence from the respective
-    provider. **ClinVar** is unrestricted (NCBI public domain). Each Hugging
+    provider. **ClinVar** is unrestricted (NCBI public domain) and
+    **PhenotypeOrthologous** is Ensembl data, free for any use. Each Hugging
     Face dataset card carries the specific terms.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -688,8 +688,9 @@ a short chain of SQL objects:
 | `parquet` | Built-in DataFusion Parquet reader. |
 | `vcf` | `VcfTableProvider` from bio-formats. Every INFO field the header declares is exposed and `ingest_sql` projects down to what it needs; set `record_layout` on the source to carry the raw record through. |
 | `bed` | `BedTableProvider` from bio-formats, BED4 only — `chrom`, `start`, `end`, `name`, whatever the file's variant. |
+| `gff` | `GffTableProvider` from bio-formats — the eight fixed GFF3 columns plus one flat `Utf8` column per key in `[source.gff].attributes` (percent-decoded, never trimmed). `index = "tabix"` slices per chromosome. |
 
-All five are implemented. `vcf` and `bed` take their zero/one-based
+All six are implemented. `vcf`, `bed` and `gff` take their zero/one-based
 interpretation from the manifest's `coordinate_system` rather than the file's
 own convention, so `ingest_sql` always sees the system the manifest declares.
 

--- a/docs/superpowers/plans/2026-05-20-annotation-target-partitions.md
+++ b/docs/superpowers/plans/2026-05-20-annotation-target-partitions.md
@@ -1,0 +1,922 @@
+# Annotation Target Partitions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Adopt upstream `datafusion-bio-functions` PR #163 in vepyr and expose safe fjall annotation parallelism through `vepyr.annotate(target_partitions=N)`.
+
+**Architecture:** The upstream crate owns the core execution change: partition-local fjall lookup sinks, bounded worker tasks, and ordered partition draining. vepyr should bump to the upstream PR revision, expose `target_partitions` as a Python/Rust bridge argument, and apply it only when `use_fjall=True`; parquet/non-fjall annotation must stay single-partition to avoid the data-loss regression identified in the upstream PR review.
+
+**Tech Stack:** Rust 2021, PyO3 0.25, DataFusion 50.3, `datafusion-bio-function-vep`, Python wrapper in `src/vepyr/__init__.py`, pytest, cargo, maturin.
+
+---
+
+## Current Upstream Facts
+
+- Upstream PR: https://github.com/biodatageeks/datafusion-bio-functions/pull/163
+- Current PR head inspected on 2026-05-20: `3d6befd2817b43dd16bedc05e2f34eaeff692e16`
+- Current local pin in `Cargo.toml`: `datafusion-bio-function-vep` rev `9b60f86de4765096538547f320dbbc476ea37031`
+- The PR adds `AnnotateVcfConfig::target_partitions`, partition-local colocated sinks, fjall lookup partition workers, ordered receiver draining, and partition-invariance tests.
+- The PR states `target_partitions` is a DataFusion `SessionConfig` setting, not an `annotate_vep()` JSON option.
+- The PR currently has a P1 review finding: applying `target_partitions > 1` to the non-fjall/parquet path can drop rows because that path still executes only partition 0. vepyr must guard this even if upstream later fixes it.
+
+## File Structure
+
+- Modify `Cargo.toml`: bump `datafusion-bio-function-vep` to PR #163 head `3d6befd2817b43dd16bedc05e2f34eaeff692e16`.
+- Modify `Cargo.lock`: regenerate after the dependency bump.
+- Modify `src/vepyr/__init__.py`: add public `target_partitions`, validate it, keep it out of `options_json`, and pass it separately to native calls.
+- Modify `src/lib.rs`: add `target_partitions` to the PyO3 `annotate_vcf` and `create_annotator` signatures.
+- Modify `src/annotate.rs`: add native `target_partitions` parameters, apply them to `SessionConfig` and `AnnotateVcfConfig`, and clamp non-fjall execution to 1.
+- Modify `src/vepyr/_core.pyi`: update native stubs.
+- Modify `tests/test_annotate.py`: add public API/validation/routing tests and update fake native call signatures.
+- Modify `tests/test_build_cache.py`: add a small built-cache fjall invariance test using `target_partitions=1` and `target_partitions=2`.
+- Modify `e2e-testing/scripts/run_annotation_fast.py` and `e2e-testing/scripts/run_annotation_fast_all.py`: add a benchmark CLI flag for target partitions.
+- Modify `tests/test_run_annotation_fast.py`: cover the new e2e CLI flag.
+- Modify `README.md`, `docs/quickstart.md`, `docs/performance.md`, and `e2e-testing/README.md`: document fjall-only annotation parallelism.
+
+## Compatibility Decision
+
+Expose one public Python parameter:
+
+```python
+target_partitions: int = 1
+```
+
+Rules:
+
+```text
+target_partitions == 1             -> valid for parquet and fjall
+target_partitions > 1 + use_fjall  -> valid and enables upstream ordered fjall lookup workers
+target_partitions > 1 + parquet    -> ValueError
+target_partitions <= 0 or bool     -> ValueError
+```
+
+Do not serialize `target_partitions` into `options_json`. Pass it as a separate native argument so `annotate_vep()` receives only supported annotation options.
+
+---
+
+### Task 1: Add Failing Python API Tests
+
+**Files:**
+- Modify: `tests/test_annotate.py`
+
+- [ ] **Step 1: Add a signature test**
+
+Add this test to `TestAnnotate`:
+
+```python
+def test_has_target_partitions_param(self):
+    import vepyr
+
+    sig = inspect.signature(vepyr.annotate)
+    p = sig.parameters["target_partitions"]
+    assert p.default == 1
+```
+
+- [ ] **Step 2: Add validation tests**
+
+Add these tests near the existing `buffer_size` validation tests:
+
+```python
+@pytest.mark.parametrize("value", [0, -1, True])
+def test_target_partitions_rejects_invalid_values(self, value):
+    import vepyr
+
+    with pytest.raises(
+        ValueError, match="target_partitions must be a positive integer"
+    ):
+        vepyr.annotate(
+            INPUT_VCF,
+            CACHE_DIR,
+            output_vcf="unused.vcf",
+            show_progress=False,
+            target_partitions=value,
+        )
+
+def test_target_partitions_requires_fjall_when_greater_than_one(self):
+    import vepyr
+
+    with pytest.raises(
+        ValueError, match="target_partitions > 1 requires use_fjall=True"
+    ):
+        vepyr.annotate(
+            INPUT_VCF,
+            CACHE_DIR,
+            output_vcf="unused.vcf",
+            show_progress=False,
+            target_partitions=2,
+        )
+```
+
+- [ ] **Step 3: Add a VCF-output routing test**
+
+Add this test near `test_buffer_size_forwards_to_vcf_writer`:
+
+```python
+def test_target_partitions_forwards_to_vcf_writer_outside_options(self, monkeypatch):
+    import vepyr
+
+    seen = {}
+
+    def fake_annotate_vcf(
+        vcf_path,
+        cache_dir,
+        output_path,
+        options_json,
+        show_progress,
+        compression,
+        on_batch_written,
+        target_partitions,
+    ):
+        seen["options"] = json.loads(options_json)
+        seen["target_partitions"] = target_partitions
+        return 0
+
+    monkeypatch.setattr(vepyr, "_annotate_vcf", fake_annotate_vcf)
+
+    with tempfile.NamedTemporaryFile(suffix=".vcf", delete=False) as f:
+        out_path = f.name
+
+    try:
+        result = vepyr.annotate(
+            INPUT_VCF,
+            CACHE_DIR,
+            output_vcf=out_path,
+            show_progress=False,
+            use_fjall=True,
+            target_partitions=4,
+        )
+        assert result == out_path
+        assert seen["target_partitions"] == 4
+        assert seen["options"]["use_fjall"] is True
+        assert "target_partitions" not in seen["options"]
+    finally:
+        os.unlink(out_path)
+```
+
+- [ ] **Step 4: Add a LazyFrame routing test**
+
+Add this test near the basic LazyFrame tests:
+
+```python
+def test_target_partitions_forwards_to_streaming_annotator(self, monkeypatch):
+    import pyarrow as pa
+    import vepyr
+
+    seen = []
+
+    class FakeAnnotator:
+        schema = pa.schema([pa.field("chrom", pa.string())])
+
+        def __iter__(self):
+            return iter(())
+
+    def fake_create_annotator(
+        vcf_path,
+        cache_dir,
+        options_json,
+        skip_csq=True,
+        limit=None,
+        target_partitions=1,
+    ):
+        seen.append((json.loads(options_json), target_partitions, limit))
+        return FakeAnnotator()
+
+    monkeypatch.setattr(vepyr, "_create_annotator", fake_create_annotator)
+
+    lf = vepyr.annotate(
+        INPUT_VCF,
+        CACHE_DIR,
+        use_fjall=True,
+        target_partitions=4,
+    )
+
+    assert isinstance(lf, pl.LazyFrame)
+    assert seen[0][1] == 4
+    assert seen[0][2] is None
+    assert seen[0][0]["use_fjall"] is True
+    assert "target_partitions" not in seen[0][0]
+```
+
+- [ ] **Step 5: Run the new tests and confirm they fail**
+
+Run:
+
+```bash
+uv run pytest \
+  tests/test_annotate.py::TestAnnotate::test_has_target_partitions_param \
+  tests/test_annotate.py::TestAnnotate::test_target_partitions_forwards_to_vcf_writer_outside_options \
+  tests/test_annotate.py::TestAnnotate::test_target_partitions_forwards_to_streaming_annotator \
+  -q
+```
+
+Expected: tests fail because `vepyr.annotate()` has no `target_partitions` parameter yet.
+
+---
+
+### Task 2: Implement The Python Public API
+
+**Files:**
+- Modify: `src/vepyr/__init__.py`
+- Modify: `tests/test_annotate.py`
+
+- [ ] **Step 1: Add the public parameter**
+
+In `vepyr.annotate`, add `target_partitions` under engine tuning:
+
+```python
+# Engine tuning
+cache_size_mb: int = 1024,
+target_partitions: int = 1,
+skip_csq: bool = True,
+```
+
+- [ ] **Step 2: Document the parameter**
+
+Add this docstring entry near `cache_size_mb`:
+
+```python
+target_partitions : int
+    DataFusion target partitions for fjall annotation lookup workers
+    (default: 1). Values greater than 1 require ``use_fjall=True`` and
+    preserve VCF/input row order by draining upstream lookup partitions in
+    order.
+```
+
+- [ ] **Step 3: Add validation**
+
+Place this after the `buffer_size` validation:
+
+```python
+if (
+    isinstance(target_partitions, bool)
+    or not isinstance(target_partitions, int)
+    or target_partitions <= 0
+):
+    raise ValueError("target_partitions must be a positive integer")
+if target_partitions > 1 and not use_fjall:
+    raise ValueError("target_partitions > 1 requires use_fjall=True")
+```
+
+- [ ] **Step 4: Keep `target_partitions` out of annotation options**
+
+Leave this block unchanged except for not adding `target_partitions`:
+
+```python
+opts: dict = {
+    "extended_probes": extended_probes,
+    "buffer_size": buffer_size,
+}
+```
+
+- [ ] **Step 5: Pass `target_partitions` to native VCF output**
+
+Change the `_annotate_vcf` call to append the separate argument:
+
+```python
+_result[0] = _annotate_vcf(
+    vcf,
+    cache_dir,
+    output_vcf,
+    options_json,
+    False,
+    comp,
+    callback,
+    target_partitions,
+)
+```
+
+- [ ] **Step 6: Pass `target_partitions` to streaming annotator creation**
+
+Change the probe call:
+
+```python
+probe = _create_annotator(vcf, cache_dir, options_json, skip_csq, None, target_partitions)
+```
+
+Change the closure captures:
+
+```python
+_vcf, _cache_dir, _opts, _skip, _target_partitions = (
+    vcf,
+    cache_dir,
+    options_json,
+    skip_csq,
+    target_partitions,
+)
+```
+
+Change the per-collect annotator call:
+
+```python
+annotator = _create_annotator(
+    _vcf,
+    _cache_dir,
+    _opts,
+    _skip,
+    n_rows,
+    _target_partitions,
+)
+```
+
+- [ ] **Step 7: Update existing fake `_annotate_vcf` functions**
+
+Every fake `_annotate_vcf` in `tests/test_annotate.py` must accept the appended argument:
+
+```python
+def fake_annotate_vcf(
+    vcf_path,
+    cache_dir,
+    output_path,
+    options_json,
+    show_progress,
+    compression,
+    on_batch_written,
+    target_partitions,
+):
+    seen.append(json.loads(options_json))
+    return 0
+```
+
+For fake callbacks that currently assert progress behavior, keep their existing body and only add the `target_partitions` parameter to the signature.
+
+- [ ] **Step 8: Run focused Python tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_annotate.py -q
+```
+
+Expected: pure Python tests should pass except failures caused by the native `_core` signatures not yet accepting the new argument.
+
+---
+
+### Task 3: Adopt Upstream PR #163 And Update The Native Bridge
+
+**Files:**
+- Modify: `Cargo.toml`
+- Modify: `Cargo.lock`
+- Modify: `src/lib.rs`
+- Modify: `src/annotate.rs`
+- Modify: `src/vepyr/_core.pyi`
+
+- [ ] **Step 1: Bump `datafusion-bio-function-vep`**
+
+Change the dependency in `Cargo.toml` to:
+
+```toml
+datafusion-bio-function-vep = { git = "https://github.com/biodatageeks/datafusion-bio-functions.git", rev = "3d6befd2817b43dd16bedc05e2f34eaeff692e16", features = ["cache-builder"] }
+```
+
+Leave the `datafusion-bio-format-*` pins unchanged unless `cargo update` proves the upstream crate requires a compatible format revision.
+
+- [ ] **Step 2: Regenerate the lockfile**
+
+Run:
+
+```bash
+cargo update -p datafusion-bio-function-vep
+```
+
+Expected: `Cargo.lock` records:
+
+```text
+source = "git+https://github.com/biodatageeks/datafusion-bio-functions.git?rev=3d6befd2817b43dd16bedc05e2f34eaeff692e16#3d6befd2817b43dd16bedc05e2f34eaeff692e16"
+```
+
+- [ ] **Step 3: Add native target-partition helper**
+
+In `src/annotate.rs`, add near the runtime static:
+
+```rust
+fn effective_target_partitions(use_fjall: bool, target_partitions: usize) -> usize {
+    if use_fjall {
+        target_partitions.max(1)
+    } else {
+        1
+    }
+}
+```
+
+- [ ] **Step 4: Extend `annotate_to_vcf_file`**
+
+Change the function signature in `src/annotate.rs`:
+
+```rust
+pub fn annotate_to_vcf_file(
+    py: Python<'_>,
+    vcf_path: &str,
+    cache_dir: &str,
+    output_path: &str,
+    options_json: &str,
+    show_progress: bool,
+    compression: &str,
+    on_batch_written: Option<PyObject>,
+    target_partitions: usize,
+) -> PyResult<usize> {
+```
+
+Replace the backend derivation with reusable booleans:
+
+```rust
+let use_fjall = opts
+    .get("use_fjall")
+    .and_then(|v| v.as_bool())
+    .unwrap_or(false);
+let backend = if use_fjall { "fjall" } else { "parquet" };
+let target_partitions = effective_target_partitions(use_fjall, target_partitions);
+```
+
+Add the new upstream field to `AnnotateVcfConfig`:
+
+```rust
+target_partitions,
+```
+
+- [ ] **Step 5: Extend `create_streaming_annotator`**
+
+Change the function signature in `src/annotate.rs`:
+
+```rust
+pub fn create_streaming_annotator(
+    py: Python<'_>,
+    vcf_path: &str,
+    cache_dir: &str,
+    options_json: &str,
+    skip_csq: bool,
+    limit: Option<usize>,
+    target_partitions: usize,
+) -> PyResult<StreamingAnnotator> {
+```
+
+Inside the async block passed to `rt.block_on`, parse options before creating the session:
+
+```rust
+let opts: Value = serde_json::from_str(options_json).map_err(|e| {
+    pyo3::exceptions::PyValueError::new_err(format!("Invalid options JSON: {e}"))
+})?;
+let use_fjall = opts
+    .get("use_fjall")
+    .and_then(|v| v.as_bool())
+    .unwrap_or(false);
+let backend = if use_fjall { "fjall" } else { "parquet" };
+let target_partitions = effective_target_partitions(use_fjall, target_partitions);
+
+let config = SessionConfig::new().with_target_partitions(target_partitions);
+let ctx = SessionContext::new_with_config(config);
+register_vep_functions(&ctx);
+```
+
+Remove the later duplicate `let opts: Value` parse and duplicate backend derivation.
+
+- [ ] **Step 6: Extend PyO3 wrapper functions**
+
+Change `annotate_vcf` in `src/lib.rs`:
+
+```rust
+#[pyo3(signature = (vcf_path, cache_dir, output_path, options_json, show_progress=true, compression="", on_batch_written=None, target_partitions=1))]
+#[allow(clippy::too_many_arguments)]
+fn annotate_vcf(
+    py: Python<'_>,
+    vcf_path: &str,
+    cache_dir: &str,
+    output_path: &str,
+    options_json: &str,
+    show_progress: bool,
+    compression: &str,
+    on_batch_written: Option<PyObject>,
+    target_partitions: usize,
+) -> PyResult<usize> {
+    annotate::annotate_to_vcf_file(
+        py,
+        vcf_path,
+        cache_dir,
+        output_path,
+        options_json,
+        show_progress,
+        compression,
+        on_batch_written,
+        target_partitions,
+    )
+}
+```
+
+Change `create_annotator` in `src/lib.rs`:
+
+```rust
+#[pyfunction]
+#[pyo3(signature = (vcf_path, cache_dir, options_json, skip_csq=true, limit=None, target_partitions=1))]
+fn create_annotator(
+    py: Python<'_>,
+    vcf_path: &str,
+    cache_dir: &str,
+    options_json: &str,
+    skip_csq: bool,
+    limit: Option<usize>,
+    target_partitions: usize,
+) -> PyResult<annotate::StreamingAnnotator> {
+    annotate::create_streaming_annotator(
+        py,
+        vcf_path,
+        cache_dir,
+        options_json,
+        skip_csq,
+        limit,
+        target_partitions,
+    )
+}
+```
+
+- [ ] **Step 7: Update native stubs**
+
+In `src/vepyr/_core.pyi`, change `annotate_vcf`:
+
+```python
+def annotate_vcf(
+    vcf_path: str,
+    cache_dir: str,
+    output_path: str,
+    options_json: str,
+    show_progress: bool = True,
+    compression: str = "",
+    on_batch_written: Callable[[int, int, int], None] | None = None,
+    target_partitions: int = 1,
+) -> int:
+```
+
+Change `create_annotator`:
+
+```python
+def create_annotator(
+    vcf_path: str,
+    cache_dir: str,
+    options_json: str,
+    skip_csq: bool = True,
+    limit: int | None = None,
+    target_partitions: int = 1,
+) -> StreamingAnnotator:
+```
+
+- [ ] **Step 8: Run native verification**
+
+Run:
+
+```bash
+cargo check
+```
+
+Expected: build passes with `target_partitions` present in the `AnnotateVcfConfig` struct literal.
+
+- [ ] **Step 9: Commit boundary**
+
+Run:
+
+```bash
+git add Cargo.toml Cargo.lock src/lib.rs src/annotate.rs src/vepyr/_core.pyi
+git commit -m "feat: expose fjall annotation target partitions"
+```
+
+---
+
+### Task 4: Add A Small Fjall Partition-Invariance Test
+
+**Files:**
+- Modify: `tests/test_build_cache.py`
+
+- [ ] **Step 1: Add helpers to compare VCF data lines**
+
+Add near the top of `tests/test_build_cache.py`:
+
+```python
+def read_vcf_data_lines(path: Path) -> list[str]:
+    with open(path) as handle:
+        return [line for line in handle if not line.startswith("#")]
+```
+
+- [ ] **Step 2: Add the built-cache annotation test**
+
+Add this test inside `TestBuildCacheIntegration` after the fjall store tests:
+
+```python
+def test_fjall_annotation_target_partitions_preserves_vcf_output(
+    self, built_cache, tmp_path
+):
+    out, _, _, _ = built_cache
+    input_vcf = ENSEMBL_CACHE_DIR / "sample.vcf"
+    serial_vcf = tmp_path / "serial.vcf"
+    parallel_vcf = tmp_path / "parallel.vcf"
+
+    vepyr.annotate(
+        str(input_vcf),
+        out,
+        check_existing=True,
+        use_fjall=True,
+        output_vcf=str(serial_vcf),
+        show_progress=False,
+        target_partitions=1,
+    )
+    vepyr.annotate(
+        str(input_vcf),
+        out,
+        check_existing=True,
+        use_fjall=True,
+        output_vcf=str(parallel_vcf),
+        show_progress=False,
+        target_partitions=2,
+    )
+
+    assert read_vcf_data_lines(parallel_vcf) == read_vcf_data_lines(serial_vcf)
+```
+
+- [ ] **Step 3: Run the focused integration test**
+
+Run:
+
+```bash
+uv run maturin develop
+uv run pytest tests/test_build_cache.py::TestBuildCacheIntegration::test_fjall_annotation_target_partitions_preserves_vcf_output -q
+```
+
+Expected: test passes and confirms vepyr's Python API produces identical VCF data lines for fjall target partitions 1 and 2 on the small fixture cache.
+
+---
+
+### Task 5: Add E2E Benchmark CLI Controls
+
+**Files:**
+- Modify: `e2e-testing/scripts/run_annotation_fast.py`
+- Modify: `e2e-testing/scripts/run_annotation_fast_all.py`
+- Modify: `tests/test_run_annotation_fast.py`
+
+- [ ] **Step 1: Add `--target-partitions` to `run_annotation_fast.py`**
+
+In `parse_args()`, add after `--backend`:
+
+```python
+p.add_argument(
+    "--target-partitions",
+    type=int,
+    default=1,
+    help="Fjall annotation target partitions (default: %(default)s)",
+)
+```
+
+After `args = p.parse_args()`, add:
+
+```python
+if args.target_partitions <= 0:
+    p.error("--target-partitions must be a positive integer")
+if args.target_partitions > 1 and args.backend != "fjall":
+    p.error("--target-partitions > 1 requires --backend fjall")
+```
+
+- [ ] **Step 2: Pass the CLI value to `vepyr.annotate`**
+
+Change the annotation call in `run_annotation_fast.py`:
+
+```python
+vepyr.annotate(
+    chrom_vcf_gz,
+    args.cache_dir,
+    everything=True,
+    reference_fasta=args.fasta,
+    use_fjall=(args.backend == "fjall"),
+    output_vcf=output_vcf,
+    target_partitions=args.target_partitions,
+    **args.annotate_kwargs,
+)
+```
+
+- [ ] **Step 3: Add `--target-partitions` to `run_annotation_fast_all.py`**
+
+Add the parser argument:
+
+```python
+p.add_argument(
+    "--target-partitions",
+    type=int,
+    default=1,
+    help="Fjall annotation target partitions forwarded to run_annotation_fast.py (default: %(default)s)",
+)
+```
+
+Validate it after parsing:
+
+```python
+args = p.parse_args()
+if args.target_partitions <= 0:
+    p.error("--target-partitions must be a positive integer")
+if args.target_partitions > 1 and args.backend != "fjall":
+    p.error("--target-partitions > 1 requires --backend fjall")
+return args
+```
+
+- [ ] **Step 4: Forward the value through `run_chromosome`**
+
+Change the function signature:
+
+```python
+def run_chromosome(
+    chrom_num, cache="ensembl", backend="fjall", target_partitions=1, force=False
+):
+```
+
+Append to the command:
+
+```python
+"--target-partitions",
+str(target_partitions),
+```
+
+Change the caller:
+
+```python
+ok = run_chromosome(
+    n,
+    cache=cache,
+    backend=backend,
+    target_partitions=args.target_partitions,
+    force=not args.no_force,
+)
+```
+
+- [ ] **Step 5: Add CLI parser tests**
+
+In `tests/test_run_annotation_fast.py`, add:
+
+```python
+def test_parse_args_accepts_target_partitions(monkeypatch):
+    module = load_run_annotation_fast()
+    monkeypatch.setattr(
+        "sys.argv",
+        ["run_annotation_fast.py", "chr1", "--backend", "fjall", "--target-partitions", "4"],
+    )
+
+    args = module.parse_args()
+
+    assert args.target_partitions == 4
+
+def test_parse_args_rejects_parallel_parquet(monkeypatch):
+    module = load_run_annotation_fast()
+    monkeypatch.setattr(
+        "sys.argv",
+        ["run_annotation_fast.py", "chr1", "--backend", "parquet", "--target-partitions", "2"],
+    )
+
+    with pytest.raises(SystemExit):
+        module.parse_args()
+```
+
+Also add `import pytest` at the top of the file.
+
+- [ ] **Step 6: Run script tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_run_annotation_fast.py -q
+```
+
+Expected: tests pass.
+
+---
+
+### Task 6: Update User-Facing Documentation
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/quickstart.md`
+- Modify: `docs/performance.md`
+- Modify: `e2e-testing/README.md`
+
+- [ ] **Step 1: Document Python usage**
+
+Add this example near the fjall backend example in `README.md` and `docs/quickstart.md`:
+
+```python
+df = vepyr.annotate(
+    "input.vcf.gz",
+    "/data/vep/parquet/115_GRCh38_ensembl",
+    use_fjall=True,
+    target_partitions=4,
+).collect()
+```
+
+Add this sentence:
+
+```text
+`target_partitions` controls fjall lookup workers during annotation. Values greater than 1 require `use_fjall=True`; parquet annotation remains single-partition to preserve correctness.
+```
+
+- [ ] **Step 2: Update performance tuning table**
+
+In `docs/performance.md`, add:
+
+```markdown
+| `target_partitions` | `1` | Fjall annotation lookup parallelism. Use with `use_fjall=True`; parquet annotation ignores this path and is guarded to 1. |
+```
+
+- [ ] **Step 3: Document e2e benchmark usage**
+
+In `e2e-testing/README.md`, add:
+
+```bash
+uv run python run_annotation_fast.py chr22 --backend fjall --target-partitions 4
+uv run python run_annotation_fast_all.py --backend fjall --target-partitions 4
+```
+
+- [ ] **Step 4: Run doc-adjacent checks**
+
+Run:
+
+```bash
+uv run pytest tests/test_run_annotation_fast.py -q
+```
+
+Expected: script docs and parser behavior remain aligned.
+
+---
+
+### Task 7: Final Verification
+
+**Files:**
+- Verify all touched files.
+
+- [ ] **Step 1: Format Rust**
+
+Run:
+
+```bash
+cargo fmt
+```
+
+Expected: no formatting errors.
+
+- [ ] **Step 2: Format Python**
+
+Run:
+
+```bash
+uv run ruff format src/vepyr tests e2e-testing/scripts
+```
+
+Expected: files formatted.
+
+- [ ] **Step 3: Build native extension**
+
+Run:
+
+```bash
+uv run maturin develop
+```
+
+Expected: extension builds against `datafusion-bio-function-vep` rev `3d6befd2817b43dd16bedc05e2f34eaeff692e16`.
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+uv run pytest tests/test_annotate.py tests/test_build_cache.py::TestBuildCacheIntegration::test_fjall_annotation_target_partitions_preserves_vcf_output tests/test_run_annotation_fast.py -q
+```
+
+Expected: tests pass.
+
+- [ ] **Step 5: Run Rust checks**
+
+Run:
+
+```bash
+cargo check
+```
+
+Expected: check passes.
+
+- [ ] **Step 6: Run optional full Python suite**
+
+Run:
+
+```bash
+uv run pytest -q
+```
+
+Expected: full test suite passes or only skips tests for unavailable external genomic fixtures.
+
+- [ ] **Step 7: Run optional real-data benchmark smoke test**
+
+Run from `e2e-testing/scripts` when the external data paths in `e2e-testing/README.md` are available:
+
+```bash
+uv run python run_annotation_fast.py chr22 --backend fjall --target-partitions 4 --force
+```
+
+Expected: generated VCF has the same comparison result as `--target-partitions 1`, with improved annotation throughput on multi-core machines.
+
+---
+
+## Self-Review
+
+- Spec coverage: covers dependency adoption, Python API, native bridge, fjall-only safety guard, tests, e2e scripts, docs, and verification.
+- Placeholder scan: no placeholder tokens or unspecified file paths remain.
+- Type consistency: public `target_partitions` is `int` in Python and `usize` in Rust; it is passed separately from `options_json`.
+- Risk callout: parquet/non-fjall paths reject `target_partitions > 1` at the Python layer and clamp to 1 at the Rust layer.

--- a/docs/superpowers/plans/2026-06-21-single-workers-knob.md
+++ b/docs/superpowers/plans/2026-06-21-single-workers-knob.md
@@ -1,0 +1,1020 @@
+# Single `--workers` Concurrency Knob Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Collapse vepyr's three concurrency knobs (`--forks`, `--workers`, `--threads`) into a single `--workers` knob that maps to the engine's proven within-contig fused pipeline.
+
+**Architecture:** The engine (`datafusion-bio-functions`) already exposes exactly one within-contig parallelism knob: `AnnotateVcfConfig.threads` (drives lookup partitions + annotate workers + VCF format concurrency; byte-identical to serial). All knob proliferation lives in **vepyr**, which layers cross-contig `forks` + per-contig `workers` + within-contig `threads` on top. This plan removes `forks` and the old per-contig `workers` semantics from vepyr's public API, PyO3 bindings, CLI drivers, and docs, and redefines `workers` as the name of the within-contig knob (i.e. vepyr `workers` → engine `threads`). **No `datafusion-bio-functions` code changes are required.**
+
+**Tech Stack:** Python 3 (PyO3 extension `vepyr._core`), Rust (pyo3, tokio, datafusion), pytest, cargo test, maturin.
+
+## Global Constraints
+
+- **Engine is unchanged.** Do not modify `datafusion-bio-functions`. vepyr's single `workers` knob maps onto the existing `AnnotateVcfConfig.threads` field by setting `threads = workers`, `forks = Some(0)`, `workers = 1`, `target_partitions = 1` in the Rust config struct vepyr builds.
+- **Semantics of the new knob:** `workers` (default `1`) = number of within-contig fused annotation pipelines. `workers > 1` requires a tabix-indexed (bgzip + `.tbi`) input VCF — this is enforced by the engine (`vcf_sink.rs` validation); vepyr does not pre-check the index.
+- **Removed outright (no deprecation shims):** the `forks` parameter, the `threads` parameter, and the old per-contig-lookup meaning of `workers`. Passing `forks=`, `threads=`, `chrom_parallelism=`, or `target_partitions=` to `vepyr.annotate()` must raise `TypeError` (they are simply not parameters).
+- **PyO3 ABI changes in lockstep:** the Rust `annotate_vcf`/`create_annotator` signatures and the Python callers + `.pyi` stub must all change together; rebuild with `maturin develop` before running Python tests.
+- After all tasks: `cargo test` green, `cargo clippy -- -D warnings` clean, `cargo fmt -- --check` clean, `pytest tests/` green (modulo pre-existing skips for missing golden cache).
+- `partitions` (cache-build knob, `build_cache`) is **out of scope** — it is unrelated to annotation concurrency. Do not touch it.
+
+---
+
+## File Structure
+
+Files modified (all in `/Users/mwiewior/research/git/vepyr`):
+
+- `src/annotate.rs` — Rust glue: drop `forks`/`workers` params, derive tokio runtime size from the `threads` JSON value, simplify the options-normalization helper, build `AnnotateVcfConfig` with the single-knob mapping. Owns the Rust unit tests for this logic.
+- `src/lib.rs` — PyO3 `#[pyfunction]` signatures for `annotate_vcf` / `create_annotator`: drop `forks`/`workers` args.
+- `src/vepyr/_core.pyi` — type stubs: drop `forks`/`workers` from `annotate_vcf` / `create_annotator`.
+- `src/vepyr/__init__.py` — public `annotate()`: drop `forks`/`threads` params, redefine `workers`, rewrite validation + options-dict construction + native call sites.
+- `tests/test_annotate.py` — rewrite the forks/workers/threads tests to the single-knob contract.
+- `tests/test_build_cache.py` — convert `test_annotation_forks_preserves_vcf_output` to a `workers`-based parity test.
+- `e2e-testing/scripts/run_annotation_fast.py` — drop `--forks`/`--threads` CLI args; keep `--workers`.
+- `e2e-testing/scripts/run_annotation_fast_all.py` — drop `--forks` CLI arg; keep `--workers`.
+- `README.md`, `docs/quickstart.md`, `docs/performance.md` — doc updates.
+
+---
+
+## Task 1: Rust glue — single-knob mapping in `annotate.rs` + `lib.rs` + `.pyi`
+
+**Files:**
+- Modify: `src/annotate.rs` (helpers ~15-105, `annotate_to_vcf_file` ~166-350, `create_streaming_annotator` ~353-433, tests ~435-492)
+- Modify: `src/lib.rs:89-144`
+- Modify: `src/vepyr/_core.pyi:17-44`
+- Test: Rust unit tests inside `src/annotate.rs` (`#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Produces (Rust → Python boundary):
+  - `_core.annotate_vcf(vcf_path, cache_dir, output_path, options_json, show_progress=True, compression="", on_batch_written=None) -> int`
+  - `_core.create_annotator(vcf_path, cache_dir, options_json, skip_csq=True, limit=None) -> StreamingAnnotator`
+  - Both read the within-contig knob from the `"threads"` key of `options_json` (default `1`). No `forks`/`workers` positional args remain.
+
+- [ ] **Step 1: Rewrite the Rust unit tests to express the new contract**
+
+In `src/annotate.rs`, replace the entire `#[cfg(test)] mod tests { ... }` block (currently lines ~435-492) with:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::{normalize_options, worker_thread_count};
+
+    #[test]
+    fn normalize_preserves_threads_and_cache_format() {
+        let (json, fmt) =
+            normalize_options(r#"{"cache_format":"lance","threads":4}"#).unwrap();
+        let opts: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(fmt, "lance");
+        assert_eq!(opts["threads"], 4);
+        assert_eq!(opts["cache_format"], "lance");
+    }
+
+    #[test]
+    fn default_cache_format_when_absent() {
+        let (_json, fmt) = normalize_options(r#"{}"#).unwrap();
+        assert_eq!(fmt, "indexed_parquet");
+    }
+
+    #[test]
+    fn invalid_cache_format_is_rejected() {
+        pyo3::Python::initialize();
+        let err = normalize_options(r#"{"cache_format":"fjall"}"#).unwrap_err();
+        assert!(err.to_string().contains("cache_format"));
+    }
+
+    #[test]
+    fn worker_thread_count_is_at_least_one() {
+        assert_eq!(worker_thread_count(0), 1);
+        assert_eq!(worker_thread_count(1), 1);
+        assert_eq!(worker_thread_count(8), 8);
+    }
+}
+```
+
+- [ ] **Step 2: Run the Rust tests to verify they fail (symbols not defined yet)**
+
+Run: `cd /Users/mwiewior/research/git/vepyr && cargo test --lib annotate 2>&1 | tail -20`
+Expected: FAIL — compile error `cannot find function normalize_options` / `worker_thread_count`.
+
+- [ ] **Step 3: Replace the helper functions at the top of `annotate.rs`**
+
+In `src/annotate.rs`, replace the four helper functions `effective_session_partitions`, `effective_runtime_threads`, `runtime_for_parallelism`, and `options_json_with_parallelism` (currently lines ~15-105) with the following three functions:
+
+```rust
+/// Number of tokio worker threads to provision. The DataFusion plan uses
+/// `block_in_place()` while resolving table metadata, so a multi-thread
+/// scheduler is required even for the single-pipeline (`threads=1`) case.
+fn worker_thread_count(threads: usize) -> usize {
+    threads.max(1)
+}
+
+fn runtime_for_threads(threads: usize) -> PyResult<Arc<Runtime>> {
+    let runtime = Builder::new_multi_thread()
+        .worker_threads(worker_thread_count(threads))
+        .build()
+        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{e}")))?;
+    Ok(Arc::new(runtime))
+}
+
+/// Validate and normalize the options JSON. Ensures `cache_format` is present
+/// and supported; returns `(normalized_json, cache_format)`. The within-contig
+/// parallelism knob travels as the `"threads"` key and is read by the caller.
+fn normalize_options(options_json: &str) -> PyResult<(String, String)> {
+    let mut opts: Value = serde_json::from_str(options_json).map_err(|e| {
+        pyo3::exceptions::PyValueError::new_err(format!("Invalid options JSON: {e}"))
+    })?;
+    let object = opts
+        .as_object_mut()
+        .ok_or_else(|| pyo3::exceptions::PyValueError::new_err("options JSON must be an object"))?;
+    let cache_format = object
+        .get("cache_format")
+        .and_then(|v| v.as_str())
+        .unwrap_or("indexed_parquet")
+        .to_string();
+    if !matches!(
+        cache_format.as_str(),
+        "indexed_parquet" | "legacy_fjall" | "lance"
+    ) {
+        return Err(pyo3::exceptions::PyValueError::new_err(
+            "cache_format must be 'indexed_parquet', 'legacy_fjall', or 'lance'",
+        ));
+    }
+    object.insert("cache_format".to_string(), Value::from(cache_format.clone()));
+    let options_json = serde_json::to_string(&opts).map_err(|e| {
+        pyo3::exceptions::PyValueError::new_err(format!("Invalid options JSON: {e}"))
+    })?;
+    Ok((options_json, cache_format))
+}
+
+/// Read the within-contig parallelism knob from the options JSON `"threads"`
+/// key. Defaults to 1; values <= 0 are treated as 1.
+fn threads_from_options(opts: &Value) -> usize {
+    opts.get("threads")
+        .and_then(|v| v.as_u64())
+        .and_then(|n| usize::try_from(n).ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(1)
+}
+```
+
+- [ ] **Step 4: Update `annotate_to_vcf_file` signature and body**
+
+In `src/annotate.rs`, change the `annotate_to_vcf_file` function. Replace its signature (lines ~166-178) — remove the `forks: usize` and `workers: usize` parameters:
+
+```rust
+#[allow(clippy::too_many_arguments)]
+pub fn annotate_to_vcf_file(
+    py: Python<'_>,
+    vcf_path: &str,
+    cache_dir: &str,
+    output_path: &str,
+    options_json: &str,
+    show_progress: bool,
+    compression: &str,
+    on_batch_written: Option<Py<PyAny>>,
+) -> PyResult<usize> {
+```
+
+Then replace the options/runtime preamble (currently lines ~187-197, from `let (options_json, cache_format) = options_json_with_parallelism(...)` through `let rt = runtime_for_parallelism(...)?;`) with:
+
+```rust
+    let (options_json, cache_format) = normalize_options(options_json)?;
+    let opts: Value = serde_json::from_str(&options_json).map_err(|e| {
+        pyo3::exceptions::PyValueError::new_err(format!("Invalid options JSON: {e}"))
+    })?;
+    let threads = threads_from_options(&opts);
+
+    let backend = cache_format.as_str();
+    let rt = runtime_for_threads(threads)?;
+```
+
+Then in the `AnnotateVcfConfig { ... }` literal, replace the four parallelism fields (currently lines ~314-325: `forks: Some(forks)`, `workers,`, the `threads:` block, and `target_partitions:`) with:
+
+```rust
+        // Single within-contig parallelism knob. vepyr's `workers` maps onto
+        // the engine's `threads` (the proven byte-identical fused pipeline).
+        // The forks/per-contig-workers cross-contig path is intentionally
+        // pinned off.
+        forks: Some(0),
+        workers: 1,
+        threads,
+        target_partitions: 1,
+```
+
+- [ ] **Step 5: Update `create_streaming_annotator` signature and body**
+
+In `src/annotate.rs`, change `create_streaming_annotator`. Replace its signature (lines ~353-363) — remove `forks`/`workers`:
+
+```rust
+#[allow(clippy::too_many_arguments)]
+pub fn create_streaming_annotator(
+    py: Python<'_>,
+    vcf_path: &str,
+    cache_dir: &str,
+    options_json: &str,
+    skip_csq: bool,
+    limit: Option<usize>,
+) -> PyResult<StreamingAnnotator> {
+```
+
+Replace the preamble (currently lines ~364-376, from `let (options_json, cache_format) = options_json_with_parallelism(...)` through `let session_partitions = effective_session_partitions(...);` inside the async block) so it reads:
+
+```rust
+    let (options_json, cache_format) = normalize_options(options_json)?;
+    let opts: Value = serde_json::from_str(&options_json).map_err(|e| {
+        pyo3::exceptions::PyValueError::new_err(format!("Invalid options JSON: {e}"))
+    })?;
+    let threads = threads_from_options(&opts);
+    let rt = runtime_for_threads(threads)?;
+
+    let (stream, schema) = rt.block_on(async {
+        let backend = cache_format.as_str();
+        let session_partitions = worker_thread_count(threads);
+```
+
+(Leave the rest of the async block — `SessionConfig::new().with_target_partitions(session_partitions)` onward — unchanged. Note the previously-unused `_opts` binding is now the real `opts` used above, so delete the old `let _opts: Value = ...` line that followed the options call.)
+
+- [ ] **Step 6: Update PyO3 signatures in `lib.rs`**
+
+In `src/lib.rs`, replace `annotate_vcf` (lines ~91-118) with:
+
+```rust
+/// Annotate a VCF and write results directly to a VCF file.
+/// Returns the number of rows written.
+#[pyfunction]
+#[pyo3(signature = (vcf_path, cache_dir, output_path, options_json, show_progress=true, compression="", on_batch_written=None))]
+#[allow(clippy::too_many_arguments)]
+fn annotate_vcf(
+    py: Python<'_>,
+    vcf_path: &str,
+    cache_dir: &str,
+    output_path: &str,
+    options_json: &str,
+    show_progress: bool,
+    compression: &str,
+    on_batch_written: Option<Py<PyAny>>,
+) -> PyResult<usize> {
+    annotate::annotate_to_vcf_file(
+        py,
+        vcf_path,
+        cache_dir,
+        output_path,
+        options_json,
+        show_progress,
+        compression,
+        on_batch_written,
+    )
+}
+```
+
+And replace `create_annotator` (lines ~120-144) with:
+
+```rust
+/// Create a streaming VEP annotator that yields PyArrow RecordBatches.
+#[pyfunction]
+#[pyo3(signature = (vcf_path, cache_dir, options_json, skip_csq=true, limit=None))]
+fn create_annotator(
+    py: Python<'_>,
+    vcf_path: &str,
+    cache_dir: &str,
+    options_json: &str,
+    skip_csq: bool,
+    limit: Option<usize>,
+) -> PyResult<annotate::StreamingAnnotator> {
+    annotate::create_streaming_annotator(py, vcf_path, cache_dir, options_json, skip_csq, limit)
+}
+```
+
+- [ ] **Step 7: Update the type stub `_core.pyi`**
+
+In `src/vepyr/_core.pyi`, replace the `annotate_vcf` stub (lines 17-32) to drop `forks`/`workers`:
+
+```python
+def annotate_vcf(
+    vcf_path: str,
+    cache_dir: str,
+    output_path: str,
+    options_json: str,
+    show_progress: bool = True,
+    compression: str = "",
+    on_batch_written: Callable[[int, int, int], None] | None = None,
+) -> int:
+    """Annotate a VCF and write results directly to a VCF file.
+
+    Returns the number of rows written.
+    """
+    ...
+```
+
+And replace the `create_annotator` stub (lines 34-44):
+
+```python
+def create_annotator(
+    vcf_path: str,
+    cache_dir: str,
+    options_json: str,
+    skip_csq: bool = True,
+    limit: int | None = None,
+) -> StreamingAnnotator:
+    """Create a streaming VEP annotator that yields PyArrow RecordBatches."""
+    ...
+```
+
+- [ ] **Step 8: Run the Rust tests to verify they pass**
+
+Run: `cd /Users/mwiewior/research/git/vepyr && cargo test --lib annotate 2>&1 | tail -20`
+Expected: PASS — `normalize_preserves_threads_and_cache_format`, `default_cache_format_when_absent`, `invalid_cache_format_is_rejected`, `worker_thread_count_is_at_least_one` all pass.
+
+- [ ] **Step 9: Verify clippy + fmt are clean**
+
+Run: `cd /Users/mwiewior/research/git/vepyr && cargo clippy --lib -- -D warnings 2>&1 | tail -15 && cargo fmt -- --check`
+Expected: no warnings, no diff. (If `fmt --check` reports a diff, run `cargo fmt` and re-check.)
+
+- [ ] **Step 10: Commit**
+
+```bash
+cd /Users/mwiewior/research/git/vepyr
+git add src/annotate.rs src/lib.rs src/vepyr/_core.pyi
+git commit -m "refactor(vepyr): single within-contig workers knob in Rust glue
+
+Drop forks/workers PyO3 args; the within-contig knob travels via the
+options-JSON 'threads' key (vepyr workers -> engine threads). Pin the
+cross-contig forks path off in AnnotateVcfConfig."
+```
+
+---
+
+## Task 2: Python `annotate()` — collapse to a single `workers` knob
+
+**Files:**
+- Modify: `src/vepyr/__init__.py` (signature ~452-454, validation ~647-652, options dict ~662-671 and ~735-738, native call sites ~789-799, ~838-846, ~854-873)
+- Test: `tests/test_annotate.py`
+
+**Interfaces:**
+- Consumes: the rebuilt `_core.annotate_vcf` / `_core.create_annotator` from Task 1 (no `forks`/`workers` args).
+- Produces: `vepyr.annotate(..., workers: int = 1)`. `workers > 1` sets `options_json["threads"] = workers`. `forks`/`threads`/`chrom_parallelism`/`target_partitions` are not parameters (passing them → `TypeError`).
+
+- [ ] **Step 1: Rebuild the extension so Python sees the new binding**
+
+Run: `cd /Users/mwiewior/research/git/vepyr && maturin develop 2>&1 | tail -5`
+Expected: build succeeds, `vepyr._core` reinstalled.
+
+- [ ] **Step 2: Rewrite the affected tests in `tests/test_annotate.py`**
+
+Make the following edits.
+
+(a) Replace `test_has_forks_and_workers_params` (lines 47-56) with:
+
+```python
+    def test_has_workers_param_only(self):
+        import vepyr
+
+        sig = inspect.signature(vepyr.annotate)
+        assert "forks" not in sig.parameters
+        assert "threads" not in sig.parameters
+        assert "target_partitions" not in sig.parameters
+        assert "chrom_parallelism" not in sig.parameters
+        workers = sig.parameters["workers"]
+        assert workers.default == 1
+```
+
+(b) Replace `test_parallelism_forwards_to_streaming_annotator` (lines 69-111) with:
+
+```python
+    def test_workers_forward_to_streaming_annotator(self, monkeypatch):
+        import pyarrow as pa
+        import vepyr
+
+        seen = []
+
+        class FakeAnnotator:
+            schema = pa.schema([pa.field("chrom", pa.string())])
+
+            def __iter__(self):
+                return iter(())
+
+        def fake_create_annotator(
+            vcf_path,
+            cache_dir,
+            options_json,
+            skip_csq=True,
+            limit=None,
+        ):
+            seen.append((json.loads(options_json), limit))
+            return FakeAnnotator()
+
+        monkeypatch.setattr(vepyr, "_create_annotator", fake_create_annotator)
+
+        lf = vepyr.annotate(
+            INPUT_VCF,
+            CACHE_DIR,
+            workers=4,
+        )
+
+        assert isinstance(lf, pl.LazyFrame)
+        assert seen[0][1] is None
+        assert seen[0][0]["cache_format"] == "lance"
+        assert seen[0][0]["threads"] == 4
+        assert "forks" not in seen[0][0]
+        assert "contig_parallelism" not in seen[0][0]
+        assert "annotation_workers" not in seen[0][0]
+```
+
+(c) Replace `test_single_chrom_workers_do_not_enable_chunked_lookup` (lines 113-151) with:
+
+```python
+    def test_workers_one_omits_threads_key(self, monkeypatch):
+        import pyarrow as pa
+        import vepyr
+
+        seen = []
+
+        class FakeAnnotator:
+            schema = pa.schema([pa.field("chrom", pa.string())])
+
+            def __iter__(self):
+                return iter(())
+
+        def fake_create_annotator(
+            vcf_path,
+            cache_dir,
+            options_json,
+            skip_csq=True,
+            limit=None,
+        ):
+            seen.append(json.loads(options_json))
+            return FakeAnnotator()
+
+        monkeypatch.setattr(vepyr, "_create_annotator", fake_create_annotator)
+
+        lf = vepyr.annotate(INPUT_VCF, CACHE_DIR, workers=1)
+
+        assert isinstance(lf, pl.LazyFrame)
+        assert "threads" not in seen[0]
+        assert "forks" not in seen[0]
+```
+
+(d) Delete `test_multi_chrom_single_worker_enables_chunked_lookup` entirely (lines 153-191) — the multi-fork / chunked-lookup behavior no longer exists.
+
+(e) In `test_pick_options_forward_to_vcf_writer`, update the `fake_annotate_vcf` signature (lines 378-388) — remove the trailing `forks,` and `workers,`:
+
+```python
+        def fake_annotate_vcf(
+            vcf_path,
+            cache_dir,
+            output_path,
+            options_json,
+            show_progress,
+            compression,
+            on_batch_written,
+        ):
+            seen["options"] = json.loads(options_json)
+            return 0
+```
+
+(f) In `test_buffer_size_forwards_to_vcf_writer`, apply the identical signature change to its `fake_annotate_vcf` (lines 430-440): remove the trailing `forks,` and `workers,`.
+
+(g) Replace `test_forks_forwards_to_vcf_writer` (lines 472-517) with:
+
+```python
+    def test_workers_forward_to_vcf_writer(self, monkeypatch):
+        import vepyr
+
+        seen = {}
+
+        def fake_annotate_vcf(
+            vcf_path,
+            cache_dir,
+            output_path,
+            options_json,
+            show_progress,
+            compression,
+            on_batch_written,
+        ):
+            seen["options"] = json.loads(options_json)
+            return 0
+
+        monkeypatch.setattr(vepyr, "_annotate_vcf", fake_annotate_vcf)
+
+        with tempfile.NamedTemporaryFile(suffix=".vcf", delete=False) as f:
+            out_path = f.name
+
+        try:
+            result = vepyr.annotate(
+                INPUT_VCF,
+                CACHE_DIR,
+                output_vcf=out_path,
+                show_progress=False,
+                workers=4,
+            )
+            assert result == out_path
+            assert seen["options"]["cache_format"] == "lance"
+            assert seen["options"]["threads"] == 4
+            assert "forks" not in seen["options"]
+            assert "contig_parallelism" not in seen["options"]
+        finally:
+            os.unlink(out_path)
+```
+
+(h) Replace `test_forks_rejects_invalid_values` (lines 543-554) and `test_workers_gt_one_requires_forks` (lines 581-591) with these two tests (the old rules are gone; `forks`/`threads` must now be rejected as unknown kwargs):
+
+```python
+    @pytest.mark.parametrize("removed", ["forks", "threads"])
+    def test_removed_knobs_rejected(self, removed):
+        import vepyr
+
+        with pytest.raises(TypeError, match=removed):
+            vepyr.annotate(
+                INPUT_VCF,
+                CACHE_DIR,
+                output_vcf="unused.vcf",
+                show_progress=False,
+                **{removed: 2},
+            )
+```
+
+(i) In `test_notebook_progress_updates_on_main_thread`, update its `fake_annotate_vcf` signature (lines 627-637): remove the trailing `forks,` and `workers,`.
+
+(Leave `test_workers_rejects_invalid_values` at lines 568-579 unchanged — it still asserts `workers <= 0` raises. Leave `test_chrom_parallelism_removed_from_public_api` unchanged.)
+
+- [ ] **Step 3: Run the rewritten tests to verify they fail against the current Python `annotate()`**
+
+Run: `cd /Users/mwiewior/research/git/vepyr && python -m pytest tests/test_annotate.py -k "workers or removed_knobs" -x 2>&1 | tail -25`
+Expected: FAIL — e.g. `test_removed_knobs_rejected` fails because `annotate()` still accepts `forks=`/`threads=`; `test_workers_forward_to_vcf_writer` fails because the options dict still contains `forks`/`contig_parallelism` and no `threads`.
+
+- [ ] **Step 4: Update the `annotate()` signature in `__init__.py`**
+
+In `src/vepyr/__init__.py`, replace the three lines (452-454):
+
+```python
+    forks: int = 0,
+    workers: int = 1,
+    threads: int = 1,
+```
+
+with:
+
+```python
+    workers: int = 1,
+```
+
+- [ ] **Step 5: Update validation in `__init__.py`**
+
+Replace the validation block (lines 647-652):
+
+```python
+    if isinstance(forks, bool) or not isinstance(forks, int) or forks < 0:
+        raise ValueError("forks must be a non-negative integer")
+    if isinstance(workers, bool) or not isinstance(workers, int) or workers <= 0:
+        raise ValueError("workers must be a positive integer")
+    if workers > 1 and forks <= 0:
+        raise ValueError("workers > 1 requires forks > 0")
+```
+
+with:
+
+```python
+    if isinstance(workers, bool) or not isinstance(workers, int) or workers <= 0:
+        raise ValueError("workers must be a positive integer")
+```
+
+- [ ] **Step 6: Remove the forks block from options-dict construction**
+
+Replace the forks if/else block (lines 662-671):
+
+```python
+    if forks > 0:
+        opts["contig_parallelism"] = forks
+        opts["annotation_workers"] = workers
+        opts["forks"] = workers
+        opts["inline_lookup"] = False
+        if forks > 1:
+            opts["chunked_buffer_lookup"] = True
+    else:
+        opts["forks"] = 0
+        opts["inline_lookup"] = True
+```
+
+with (nothing — delete the whole block). The engine defaults to the strict single-lane inline path when no `forks`/`contig_parallelism` keys are present.
+
+- [ ] **Step 7: Map `workers` onto the within-contig `threads` key**
+
+Replace the threads block (lines 735-738):
+
+```python
+    if threads and threads > 1:
+        # Single within-contig parallelism knob: N per-partition annotation
+        # pipelines. Requires a tabix-indexed (bgzip+.tbi) input VCF.
+        opts["threads"] = threads
+```
+
+with:
+
+```python
+    if workers > 1:
+        # Single within-contig parallelism knob: N per-partition annotation
+        # pipelines. Requires a tabix-indexed (bgzip+.tbi) input VCF.
+        opts["threads"] = workers
+```
+
+- [ ] **Step 8: Drop `forks`/`workers` from the native call sites**
+
+(a) In the `_annotate_vcf(...)` call inside `_run` (lines 789-799), remove the trailing `forks,` and `workers,` arguments so it ends:
+
+```python
+                    _result[0] = _annotate_vcf(
+                        vcf,
+                        cache_dir,
+                        output_vcf,
+                        options_json,
+                        False,
+                        comp,
+                        callback,
+                    )
+```
+
+(b) In the probe call (lines 838-846), remove the trailing `forks,` and `workers,`:
+
+```python
+    probe = _create_annotator(
+        vcf,
+        cache_dir,
+        options_json,
+        skip_csq,
+        None,
+    )
+```
+
+(c) Replace the capture tuple (lines 854-861):
+
+```python
+    _vcf, _cache_dir, _opts, _skip, _forks, _workers = (
+        vcf,
+        cache_dir,
+        options_json,
+        skip_csq,
+        forks,
+        workers,
+    )
+```
+
+with:
+
+```python
+    _vcf, _cache_dir, _opts, _skip = (
+        vcf,
+        cache_dir,
+        options_json,
+        skip_csq,
+    )
+```
+
+(d) In `_batch_source` (lines 865-873), remove the trailing `_forks,` and `_workers,`:
+
+```python
+        annotator = _create_annotator(
+            _vcf,
+            _cache_dir,
+            _opts,
+            _skip,
+            n_rows,
+        )
+```
+
+- [ ] **Step 9: Update the docstring parameter list**
+
+In the `annotate()` docstring, find the `forks` / `workers` parameter descriptions (under "Engine tuning") and replace them with a single `workers` entry. Use exactly:
+
+```
+    workers : int
+        Number of within-contig fused annotation pipelines (``1`` = serial).
+        The single concurrency knob. Values greater than 1 require a
+        tabix-indexed (bgzip + ``.tbi``) input VCF.
+```
+
+(Remove any `forks`/`threads` lines from the docstring. If the exact prose differs, match on the parameter name and replace the whole paragraph.)
+
+- [ ] **Step 10: Run the full `test_annotate.py` suite**
+
+Run: `cd /Users/mwiewior/research/git/vepyr && python -m pytest tests/test_annotate.py 2>&1 | tail -25`
+Expected: PASS (golden-cache integration tests may `skip` if the cache is absent — that is fine; the monkeypatched + signature + validation tests must pass).
+
+- [ ] **Step 11: Commit**
+
+```bash
+cd /Users/mwiewior/research/git/vepyr
+git add src/vepyr/__init__.py tests/test_annotate.py
+git commit -m "refactor(vepyr): collapse annotate() to a single workers knob
+
+Remove forks/threads params; workers>1 now sets the within-contig
+'threads' option. Drop forks/workers from native call sites."
+```
+
+---
+
+## Task 3: CLI drivers — single `--workers` flag
+
+**Files:**
+- Modify: `e2e-testing/scripts/run_annotation_fast.py` (args 163-184, validation 221-226, call 726-728)
+- Modify: `e2e-testing/scripts/run_annotation_fast_all.py` (arg 138-147, validation 172-177, `run_chromosome` 191-218, call 729-737)
+
+**Interfaces:**
+- Consumes: `vepyr.annotate(..., workers=...)` from Task 2.
+- Produces: both scripts expose only `--workers` (default `1`). `--forks` and `--threads` are removed.
+
+- [ ] **Step 1: `run_annotation_fast.py` — remove `--forks` and `--threads`, keep `--workers`**
+
+Replace the three argparse blocks (lines 163-184) — `--forks`, `--workers`, `--threads` — with just `--workers`:
+
+```python
+    p.add_argument(
+        "--workers",
+        type=int,
+        default=1,
+        help="Within-contig parallel annotation pipelines; >1 requires a "
+        "tabix-indexed input (default: %(default)s)",
+    )
+```
+
+- [ ] **Step 2: `run_annotation_fast.py` — simplify validation**
+
+Replace the validation block (lines 221-226):
+
+```python
+    if args.forks < 0:
+        p.error("--forks must be a non-negative integer")
+    if args.workers <= 0:
+        p.error("--workers must be a positive integer")
+    if args.workers > 1 and args.forks <= 0:
+        p.error("--workers > 1 requires --forks > 0")
+```
+
+with:
+
+```python
+    if args.workers <= 0:
+        p.error("--workers must be a positive integer")
+```
+
+- [ ] **Step 3: `run_annotation_fast.py` — fix the `annotate()` call**
+
+Replace the call args (lines 726-728):
+
+```python
+            forks=args.forks,
+            workers=args.workers,
+            threads=args.threads,
+```
+
+with:
+
+```python
+            workers=args.workers,
+```
+
+- [ ] **Step 4: `run_annotation_fast.py` — verify it parses and reports help correctly**
+
+Run: `cd /Users/mwiewior/research/git/vepyr && python e2e-testing/scripts/run_annotation_fast.py --help 2>&1 | grep -E "\-\-(forks|threads|workers)"`
+Expected: only a `--workers` line appears; no `--forks`, no `--threads`.
+
+- [ ] **Step 5: `run_annotation_fast_all.py` — remove `--forks`**
+
+Delete the `--forks` argparse block (lines 138-147). Leave the `--workers` block that follows it unchanged.
+
+- [ ] **Step 6: `run_annotation_fast_all.py` — simplify validation**
+
+Replace the validation block (lines 172-177):
+
+```python
+    if args.forks < 0:
+        p.error("--forks must be a non-negative integer")
+    if args.workers <= 0:
+        p.error("--workers must be a positive integer")
+    if args.workers > 1 and args.forks <= 0:
+        p.error("--workers > 1 requires --forks > 0")
+```
+
+with:
+
+```python
+    if args.workers <= 0:
+        p.error("--workers must be a positive integer")
+```
+
+- [ ] **Step 7: `run_annotation_fast_all.py` — update `run_chromosome` to drop `forks`**
+
+Replace the `run_chromosome` signature (lines 191-199):
+
+```python
+def run_chromosome(
+    chrom_num,
+    cache="ensembl",
+    backend="lance",
+    forks=0,
+    workers=1,
+    force=False,
+    skip_comparison=False,
+):
+```
+
+with:
+
+```python
+def run_chromosome(
+    chrom_num,
+    cache="ensembl",
+    backend="lance",
+    workers=1,
+    force=False,
+    skip_comparison=False,
+):
+```
+
+Then in the `cmd` list inside `run_chromosome` (lines 210-213), remove the `--forks` pair:
+
+```python
+        "--forks",
+        str(forks),
+        "--workers",
+        str(workers),
+```
+
+becomes:
+
+```python
+        "--workers",
+        str(workers),
+```
+
+- [ ] **Step 8: `run_annotation_fast_all.py` — update the call site**
+
+In the `run_chromosome(...)` call (lines 729-737), remove the `forks=args.forks,` line, leaving `workers=args.workers,`.
+
+- [ ] **Step 9: Verify both scripts import and parse**
+
+Run: `cd /Users/mwiewior/research/git/vepyr && python e2e-testing/scripts/run_annotation_fast_all.py --help 2>&1 | grep -E "\-\-(forks|threads|workers)" && python -m pytest tests/test_run_annotation_fast.py 2>&1 | tail -10`
+Expected: only `--workers` shown for `_all.py`; `test_run_annotation_fast.py` passes (or skips if it needs data, but does not error on import).
+
+- [ ] **Step 10: Commit**
+
+```bash
+cd /Users/mwiewior/research/git/vepyr
+git add e2e-testing/scripts/run_annotation_fast.py e2e-testing/scripts/run_annotation_fast_all.py
+git commit -m "refactor(vepyr): single --workers flag in e2e CLI drivers"
+```
+
+---
+
+## Task 4: Parity test + docs
+
+**Files:**
+- Modify: `tests/test_build_cache.py:762-786`
+- Modify: `README.md:88-112`, `docs/quickstart.md:125-138`, `docs/performance.md:82-83`
+
+**Interfaces:**
+- Consumes: `vepyr.annotate(..., workers=...)` from Task 2.
+
+- [ ] **Step 1: Convert the forks parity test to a workers parity test**
+
+In `tests/test_build_cache.py`, replace `test_annotation_forks_preserves_vcf_output` (lines 762-786) with a `workers`-based parity test. `workers > 1` requires a tabix-indexed input, so build one from `sample.vcf` with pysam; skip the parallel arm if pysam is unavailable:
+
+```python
+    def test_annotation_workers_preserves_vcf_output(self, built_cache, tmp_path):
+        out, _, _, _ = built_cache
+        input_vcf = ENSEMBL_CACHE_DIR / "sample.vcf"
+        serial_vcf = tmp_path / "serial.vcf"
+        parallel_vcf = tmp_path / "parallel.vcf"
+
+        vepyr.annotate(
+            str(input_vcf),
+            out,
+            check_existing=True,
+            output_vcf=str(serial_vcf),
+            show_progress=False,
+            workers=1,
+        )
+
+        # workers>1 needs a tabix-indexed (bgzip+.tbi) input.
+        try:
+            import pysam
+        except ImportError:
+            pytest.skip("pysam not available for tabix-indexed parallel input")
+
+        indexed_vcf = tmp_path / "sample.vcf.gz"
+        pysam.tabix_compress(str(input_vcf), str(indexed_vcf), force=True)
+        pysam.tabix_index(str(indexed_vcf), preset="vcf", force=True)
+
+        vepyr.annotate(
+            str(indexed_vcf),
+            out,
+            check_existing=True,
+            output_vcf=str(parallel_vcf),
+            show_progress=False,
+            workers=2,
+        )
+
+        assert read_vcf_data_lines(parallel_vcf) == read_vcf_data_lines(serial_vcf)
+```
+
+- [ ] **Step 2: Run the parity test**
+
+Run: `cd /Users/mwiewior/research/git/vepyr && python -m pytest tests/test_build_cache.py::TestBuildCache::test_annotation_workers_preserves_vcf_output 2>&1 | tail -15`
+Expected: PASS, or SKIP if the ensembl cache / pysam are unavailable. (If the class name differs, find the test by method name.)
+
+- [ ] **Step 3: Update `README.md`**
+
+Replace lines 88-112 (the `forks` prose + the two `forks=`/`forks=8` examples) with:
+
+```markdown
+`workers` controls how many within-contig annotation pipelines run
+concurrently. `workers=1` is the serial path; `workers > 1` requires a
+tabix-indexed (bgzip + `.tbi`) input VCF.
+
+```python
+df = vepyr.annotate(
+    "input.vcf.gz",
+    cache_dir,
+    workers=4,
+).collect()
+```
+
+`build_cache()` writes variation as `chrN_warm.parquet` and
+`chrN_cold.parquet` files, plus cold-position and variant-bloom indexes.
+Re-running
+`build_cache()` is idempotent by default; pass `overwrite=True` to rebuild
+existing cache outputs.
+
+```python
+out = vepyr.annotate(
+    "input.vcf.gz",
+    cache_dir,
+    workers=8,
+    output_vcf="annotated.vcf",
+)
+```
+```
+
+- [ ] **Step 4: Update `docs/quickstart.md`**
+
+Replace lines 125-138 (the fjall `forks`/`workers` prose + the `forks=1, workers=4` example) with:
+
+```markdown
+`workers` controls how many within-contig annotation pipelines run
+concurrently. `workers=1` is the serial path; `workers > 1` requires a
+tabix-indexed (bgzip + `.tbi`) input VCF.
+
+```python
+df = vepyr.annotate(
+    "input.vcf.gz",
+    "/data/vepyr_cache/parquet/115_GRCh38_ensembl",
+    workers=4,
+).collect()
+```
+```
+
+- [ ] **Step 5: Update `docs/performance.md`**
+
+Replace the two table rows (lines 82-83):
+
+```markdown
+| `forks` | `0` | Active chromosome lanes. `0` uses the strict single-lane path with `workers=1`; values greater than 0 require `use_fjall=True`. |
+| `workers` | `1` | Annotation workers per active chromosome. Values greater than 1 require `forks > 0`. |
+```
+
+with a single row:
+
+```markdown
+| `workers` | `1` | Within-contig annotation pipelines. `1` is serial; values greater than 1 require a tabix-indexed (bgzip + `.tbi`) input VCF. |
+```
+
+- [ ] **Step 6: Final repo-wide sweep for stragglers**
+
+Run: `cd /Users/mwiewior/research/git/vepyr && grep -rnE "forks=|threads=|--forks|--threads" --include="*.py" --include="*.md" . | grep -viE "worker_threads|rt-multi-thread|tabix" | grep -v "/target/"`
+Expected: no matches (every `forks=`/`threads=`/`--forks`/`--threads` reference has been removed or is an unrelated `worker_threads` mention).
+
+- [ ] **Step 7: Full test + lint gate**
+
+Run: `cd /Users/mwiewior/research/git/vepyr && cargo test 2>&1 | tail -10 && cargo clippy -- -D warnings 2>&1 | tail -5 && cargo fmt -- --check && python -m pytest tests/ 2>&1 | tail -15`
+Expected: cargo green, clippy clean, fmt clean, pytest green (pre-existing skips allowed).
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/mwiewior/research/git/vepyr
+git add tests/test_build_cache.py README.md docs/quickstart.md docs/performance.md
+git commit -m "docs+test(vepyr): document single workers knob; workers-based parity test"
+```
+
+---
+
+## Out of Scope / Follow-ups
+
+- **Engine-internal rename `AnnotateVcfConfig.threads` -> `workers`** and deletion of the now-unreachable cross-contig forks / `chromosome_lanes` execution machinery in `datafusion-bio-functions` (`vcf_sink.rs` `VepConcurrencyPlan::from_forks`, the chromosome-lane `JoinSet` path, the per-contig-lookup `workers` field). This is a larger, higher-risk internal refactor and overlaps the existing "Lance-only dead-code removal" track. After this plan, vepyr never triggers the forks path, so those fields are dead from vepyr's perspective but still compile and pass engine tests. Defer.
+- **`partitions`** (cache-build parallelism in `build_cache`) is deliberately untouched — it is not an annotation concurrency knob.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** single `--workers` knob = within-contig fused (Task 1 Rust mapping + Task 2 Python); remove `--forks`/`--threads`/old-`workers` outright (Task 1 bindings, Task 2 params/validation, Task 3 CLI); docs (Task 4). Engine untouched (Global Constraints). Covered.
+- **Type consistency:** `normalize_options` / `worker_thread_count` / `threads_from_options` / `runtime_for_threads` are defined in Task 1 Step 3 and used in Steps 4-5 and tested in Step 1. PyO3 signatures (Task 1 Steps 6-7) match the Python call sites edited in Task 2 Step 8 and the fakes in Task 2 Step 2 (`fake_create_annotator(vcf_path, cache_dir, options_json, skip_csq=True, limit=None)`; `fake_annotate_vcf(vcf_path, cache_dir, output_path, options_json, show_progress, compression, on_batch_written)`).
+- **Placeholder scan:** no TBD/"handle errors"/"similar to" — all steps carry concrete code or exact commands.

--- a/docs/superpowers/plans/2026-07-31-narrow-contig-prefetch-split.md
+++ b/docs/superpowers/plans/2026-07-31-narrow-contig-prefetch-split.md
@@ -1,0 +1,155 @@
+# Narrow Contig-Prefetch Split — Implementation Plan
+
+**Goal:** Split the prefetched unit so the next contig's **context** is built ahead of
+time but its **N lookup workers are not spawned** until the contig actually starts.
+Recovers ~2.5 GB of the prefetch's peak-RSS cost for ~4.2s of its time win.
+
+**Where:** `datafusion-bio-functions`, `datafusion/bio-function-vep/src/annotate_provider.rs`.
+Branch off `perf/parallelize-contig-prelude` (currently `abf19a5`, pushed).
+vepyr consumes it via the temporary `[patch]` already in `vepyr/Cargo.toml`.
+
+---
+
+## Why (all numbers measured on HG002, 4,096,123 variants, merged 116 cache, plain output)
+
+`abf19a5` prefetches the next contig's whole `prepare_contig_context` while the
+current contig annotates. That hid 12.71s of a 24.3s per-contig prelude:
+
+| workers | before prefetch | with prefetch |
+|---|---|---|
+| 1 | 04:20 / 3.88 GB | 04:22 / 3.88 GB (gated off, control) |
+| 2 | 02:31 / 4.66 GB | 02:18 / 6.58 GB |
+| 4 | 01:38 / 5.75 GB | 01:25 / 9.06 GB |
+| 8 | 01:15 / 7.57 GB | 01:04 / 11.38 GB |
+
+The +3.81 GB at w=8 is a clean measurement (both builds annotate all 22 contigs;
+prefetch is the only difference). It decomposes as:
+
+- **~1.7 GB N-independent** — one contig's context. Measured same-phase: chr2's
+  `after_context_load` peak sits 1744 MB above chr1's `after_prepare`.
+- **~0.31 GB per worker** — from (3.81 − 1.92) / 6 workers. Closely matches the
+  independently measured 0.286 GB/worker baseline slope, i.e. prefetch duplicates
+  the *per-worker* startup footprint because `prepare_contig_context` ends by
+  spawning N lookup workers.
+
+`prepare_contig_context` internals, instrumented via the `prepare done` trace event
+added in `86d790a` (WGS w=8, summed over 22 contigs):
+
+| component | per contig | total |
+|---|---|---|
+| context load (shards, parse, indexes, boundary count) | 0.157–0.532s | **8.50s** |
+| provider build + lookup-worker spawn | 0.154–0.281s (flat) | **4.21s** |
+
+So deferring the second component costs 4.21s and should recover the ~0.31 GB × N
+term. Projected at w=8: **~68s at ~8.9 GB**, vs 64s/11.38 GB (full prefetch) and
+75s/7.57 GB (no prefetch) — keeps most of both the prelude win and the page-index
+win from `6d91488`.
+
+> An earlier note in this investigation claimed the deferred part was worth only
+> 736 MB and rejected the split on that basis. That figure came from the
+> `after_sift_load → after_prepare` peak-RSS delta, which understates it because
+> peak RSS is monotonic and cannot separate concurrent contributors. The 0.31 GB/worker
+> figure above supersedes it.
+
+---
+
+## Split point
+
+`prepare_contig_context` starts at `annotate_provider.rs:12580`.
+
+Split at **`:12977`**, where `vcf_has_chr` is resolved and the grid loop begins.
+
+- **Data phase (prefetchable):** everything above `:12977` — identity validation,
+  variation schema read, `load_contig_context` joined with
+  `count_contig_buffer_boundaries`, SIFT store, `SharedContextIndexes`,
+  `transcript_cache_regions`, `compute_overlap_width_bp`.
+- **Deferred phase:** the `if stateful_parallel { … }` block through **`:13030`**
+  (`grid_slices = slices;` plus the `lookup_partitions.len()` profile record), which
+  builds N `LookupProvider`s and calls `spawn_lookup_full_contig_worker`.
+
+### Values the deferred phase captures
+
+Carry these in one `ContigPreparedData` struct returned by the data phase:
+
+1. `session: Arc<SessionContext>`
+2. `config: ContigAnnotationConfig`
+3. `chrom: String`
+4. `var_table` (variation table name)
+5. `grid_vcf_schema`
+6. `grid_cache_schema`
+7. `task_ctx` (or rebuild from `session.task_ctx()` in the deferred phase)
+8. `shared_parquet_lookup_cell: Arc<ParquetVariationLookupCell>` (from `6d91488`)
+9. `vcf_has_chr: bool` (hoisted in `86d790a` — keep it resolved once per contig)
+10. `boundaries` + `overlap_width_bp` (or the already-computed `slices`)
+
+Plus everything currently placed into `ContigReadyState` / `SharedContigAnnotationContext`
+so the deferred phase can finish constructing it.
+
+## Wiring — no state-machine changes needed
+
+Both `PrepareFuture` construction sites live in `StreamState::StartContig`. Compose
+the two phases inside the future at each site:
+
+```rust
+// prefetch path (take_prefetched_prepare)
+Box::pin(async move {
+    let data = handle.await.map_err(|e| DataFusionError::External(Box::new(e)))??;
+    finish_contig_prepare(data).await          // spawns lookups now, not during prefetch
+})
+
+// cold path
+Box::pin(async move {
+    let data = prepare_contig_data(session, cache, chrom, config, full_schema).await?;
+    finish_contig_prepare(data).await
+})
+```
+
+`start_prefetch_next_contig` then spawns only `prepare_contig_data`. `StreamState`,
+`AnnotatingParallel`, shard-id assignment (`next_global_shard_id`, assigned at the
+`PreparingContig → AnnotatingParallel` transition) and the assembler are untouched.
+
+Keep the `prepare done` trace emit at the end of the **deferred** phase so the
+split stays measurable, and consider a second emit at the end of the data phase.
+
+## Gotchas
+
+- `abf19a5` gates prefetch to `annotation_workers > 1` (the call sits inside that
+  branch). Preserve that — at w=1 the prelude is a small share of a much longer
+  contig and a second resident context is not worth the memory.
+- `ephemeral_tables` is `Vec::new()` at `:12622` and never pushed to, so there is no
+  session-table collision between two in-flight contigs. If that ever changes, names
+  must become contig-unique before prefetching anything.
+- The prefetch handle must still be aborted on drop (`cleanup_registered_tables_on_drop`)
+  — with the split it holds no spawned lookup tasks, but abort is still correct.
+
+## Verification
+
+Byte-identical output is the bar; the harness already exists in the session scratchpad.
+
+1. `chr21` @ w=1 and w=8, `chr1` @ w=16 — body MD5 must match
+   `aa686ea955e2c561bda37bc2f1d88092` (chr21) and `230e0c5c792e9ecd5a7c537d9d664219` (chr1).
+2. 5-contig input (chr1, chr2, chr20, chr21, chr22) @ w=16 — extract each contig and
+   compare against its standalone MD5. This is the test that actually exercises
+   prefetch overlap; `subset_md5.sh` does the extraction.
+3. WGS @ w=4 and w=8 via `performance-tests/vepyr/scripts/benchmark_vepyr_once.py`
+   (`--expected-records 4096123`) for peak RSS plus the VEP record-parity check.
+   Output must stay 29,410,585,470 bytes.
+4. `cargo clippy` clean, `cargo test --lib` (900 tests) green, `cargo fmt --check`.
+
+Note `everything=True` implies `check_existing`, so the colocated path is already
+covered by the MD5 checks.
+
+## Measurement discipline (learned the hard way in this investigation)
+
+Peak RSS is monotonic, so a delta between two phase boundaries cannot attribute
+memory to one of several concurrent contributors. Four wrong attributions were made
+that way in this investigation. **Prefer ablation** — vepyr exposes `check_existing`,
+`af_gnomade`, `af_gnomadg`, `max_af`, `hgvs`, `everything` as explicit flags, and a
+two-run A/B on a flag settles ownership in minutes. A one-flag ablation showed the
+co-located + AF path costs ~5 MB, refuting a hypothesis that had produced a whole
+(reverted) commit; that patch is preserved as `colocated_prune.patch` in the session
+scratchpad but should not land.
+
+`dhat-heap` is wired as a global allocator in `vepyr/src/lib.rs:33-35` but **no
+`dhat::Profiler` is ever created**, so the feature currently collects nothing. Closing
+that gap is the prerequisite for real allocation-site attribution.

--- a/docs/superpowers/plans/2026-08-11-contig-prefetch-port-to-master.md
+++ b/docs/superpowers/plans/2026-08-11-contig-prefetch-port-to-master.md
@@ -1,0 +1,420 @@
+# Contig-Prefetch Port to Master Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Overlap contig i+1's context prepare (data phase only, no lookup-worker
+spawn) with contig i's annotation, removing the ~18.7 s (w=8) / ~30.3 s (w=16)
+serial per-contig prelude from the WGS critical path on engine master.
+
+**Architecture:** Split `prepare_contig_context` into a prefetchable
+`prepare_contig_data` (identity check, schema reads, context load, grid count +
+slice planning, SIFT store, shared context build — no VCF lookup workers) and an
+`activate_contig_lookups` (LookupProvider build + plan scan + worker spawn) that
+runs at contig start. `ContigAnnotationStream` spawns the data phase for the
+next contig as a `tokio::spawn` task the moment the current contig enters
+annotation, and consumes it at the next `StartContig`.
+
+**Tech Stack:** Rust, tokio, DataFusion 53 — `datafusion-bio-functions` repo,
+crate `datafusion/bio-function-vep`, single file `src/annotate_provider.rs`
+(plus vepyr for verification).
+
+## Global Constraints
+
+- Base: `origin/master` of `github.com/biodatageeks/datafusion-bio-functions` (ce5c64a). New branch: `perf/contig-prefetch-master`.
+- Working copy: create a dedicated worktree `/Users/mwiewior/research/git/dbf-prefetch` — do NOT reuse the main clone (it sits on `perf/cost-weighted-grid-balance` with untracked files) or `dbf-master` (pinned for baseline builds).
+- Reference implementations (read, do not rebase — they conflict with #209's rewrite): `abf19a5` (prefetch state machine), `2829956` (= squashed `fe7bf66`, narrow data/activate split, defines `ContigPreparedData`, `prepare_contig_data`, `finish_contig_prepare`), `85dc990` (byte-budget spawn deferral).
+- Env gate style must match master: unset/`"1"` = default, `"0"`/`"false"` = off (see `VEP_EARLY_WORKERS` parsing at `annotate_provider.rs:12940`). New gate: `VEP_CONTIG_PREFETCH` — default ON when `config.annotation_workers > 1`, forced ON at any worker count by `"1"`/`"true"`, OFF by `"0"`/`"false"`.
+- Output must stay byte-identical with the gate on and off (prefetch is a scheduling change only; slice boundaries and annotation are untouched).
+- No new crate dependencies. `cargo fmt`, `cargo clippy`, `cargo test -p datafusion-bio-function-vep` must pass after every task.
+- Commit messages follow repo convention: `perf(vep): …` / `test(vep): …`.
+- vepyr consumes the branch via the existing `[patch]` in `vepyr/Cargo.toml` (currently pointing at `/Users/mwiewior/research/git/dbf-master/...`; Task 5 repoints it).
+
+---
+
+### Task 1: Worktree + baseline
+
+**Files:**
+- No source changes. Creates the worktree and proves the baseline is green.
+
+**Interfaces:**
+- Produces: worktree at `/Users/mwiewior/research/git/dbf-prefetch` on branch `perf/contig-prefetch-master`, baseline test/clippy pass recorded.
+
+- [ ] **Step 1: Create branch + worktree off origin/master**
+
+```bash
+cd /Users/mwiewior/research/git/datafusion-bio-functions
+git fetch origin
+git worktree add -b perf/contig-prefetch-master ../dbf-prefetch origin/master
+```
+
+- [ ] **Step 2: Verify the baseline is green**
+
+Run:
+```bash
+cd /Users/mwiewior/research/git/dbf-prefetch/datafusion/bio-function-vep
+cargo test 2>&1 | tail -5
+cargo clippy --all-targets 2>&1 | tail -3
+```
+Expected: all tests pass, no clippy errors. If the baseline is red, STOP and report — do not build on a broken base.
+
+---
+
+### Task 2: Split `prepare_contig_context` into data + activate phases (pure refactor)
+
+**Files:**
+- Modify: `datafusion/bio-function-vep/src/annotate_provider.rs:12715-13298` (`prepare_contig_context`)
+
+**Interfaces:**
+- Consumes: master's `prepare_contig_context(session, cache, chrom, config, full_schema) -> Result<Option<ContigReadyState>>`.
+- Produces (exact signatures Task 3 relies on):
+
+```rust
+struct ContigPreparedData {
+    chrom: String,
+    config: ContigAnnotationConfig,          // post identity-validation (vep_semantics set)
+    cache: Arc<PartitionedAnnotationCache>,
+    pipeline_profile: Option<SharedContigPipelineProfile>,
+    profile_handle: Option<SharedContigPipelineProfile>,
+    ephemeral_tables: Vec<String>,
+    shared_context: Arc<SharedContigAnnotationContext>,
+    grid_slices: Vec<WorkerGridSlice>,
+    stateful_parallel: bool,
+    var_table: String,
+    vcf_schema: Schema,                      // for the byte-budget/serial provider
+    cache_schema: Schema,
+    fallback_coloc_sink: ColocatedSink,
+    t_contig: Instant,                       // kept for downstream contig END timing
+}
+
+async fn prepare_contig_data(
+    session: Arc<SessionContext>,
+    cache: Arc<PartitionedAnnotationCache>,
+    chrom: String,
+    config: ContigAnnotationConfig,
+    full_schema: SchemaRef,
+) -> Result<Option<ContigPreparedData>>;
+
+async fn activate_contig_lookups(
+    session: Arc<SessionContext>,
+    data: ContigPreparedData,
+) -> Result<Option<ContigReadyState>>;
+```
+
+`prepare_contig_context` keeps its signature and becomes the composition, so every existing call site is untouched in this task:
+
+```rust
+async fn prepare_contig_context(
+    session: Arc<SessionContext>,
+    cache: Arc<PartitionedAnnotationCache>,
+    chrom: String,
+    config: ContigAnnotationConfig,
+    full_schema: SchemaRef,
+) -> Result<Option<ContigReadyState>> {
+    match prepare_contig_data(Arc::clone(&session), cache, chrom, config, full_schema).await? {
+        None => Ok(None),
+        Some(data) => activate_contig_lookups(session, data).await,
+    }
+}
+```
+
+**What moves where** (line references are master ce5c64a):
+
+*`prepare_contig_data` keeps:* identity validation (`:12733`), vcf_only_schema, `var_table`, vcf/cache schema reads (`:12779-12796`), `load_contig_transcripts` + `count_contig_buffer_boundaries` (the `tokio::join!` at `:12971`), `tmp_provider` + engine build, SIFT store load (`:13004`), shared-ctx build start, `load_contig_context_rest` (`rest_fut`), **the grid-slice planning** (the weights + `plan_grid_partitions_balanced` / `plan_grid_partitions` part of `grid_fut`, `:13055-13112`), `SharedContextIndexes`, plugin registry, `SharedContigAnnotationContext` construction (`:13237`).
+
+*`activate_contig_lookups` gets everything that spawns or scans lookups:*
+- the up-front `LookupProvider::new` + byte-budget `spawn_lookup_partition_worker` loop and the serial `spawn_lookup_stream_worker` arm (`:12808-12889`) — this is the #208 deferral applied to master;
+- from `grid_fut`: the per-slice `LookupProvider` builds, `shared_parquet_lookup_cell`, the concurrent `wp.scan(...)` plan builds (`VEP_CONCURRENT_PLANS`), and `spawn_lookup_full_contig_worker` (`:13114-13230`);
+- assembly of `ContigReadyState { lookup_partitions, grid_slices, shared_context, ephemeral_tables, chrom, t_contig }` (`:13291`).
+
+**Consequences accepted in this task** (documented in code comments):
+- The `early_workers` interleave (`rest_fut`/`grid_fut` `tokio::join!` at `:13278`) collapses: `prepare_contig_data` awaits `rest_fut` and plans slices; workers spawn strictly after. `VEP_EARLY_WORKERS` becomes a no-op — delete the gate and its comment. Cost is ~0.3 s on the first contig only once Task 3 lands (every later contig's data phase is fully hidden); the reference branch made the same call.
+- Profile attribution: `prepare_contig_data` records its own elapsed into `prepare_total` before returning; `activate_contig_lookups` records its elapsed into `prepare_total` too (use two local `Instant`s; do NOT use `t_contig.elapsed()` in activate — after Task 3 that span contains the previous contig's annotation).
+- The `[VEP_PROFILE] ------ contig {chrom} START ------` eprintln moves from the top of `prepare_contig_data` to the top of `activate_contig_lookups`; the data phase instead emits `pipeline_trace::emit("prefetch", "data_start", ...)` / `("prefetch", "data_done", ...)` with the chrom and elapsed.
+
+- [ ] **Step 1: Perform the split exactly as mapped above**
+
+- [ ] **Step 2: Verify no behavior change**
+
+Run:
+```bash
+cd /Users/mwiewior/research/git/dbf-prefetch/datafusion/bio-function-vep
+cargo test 2>&1 | tail -5 && cargo clippy --all-targets 2>&1 | tail -3 && cargo fmt --check
+```
+Expected: green. This is a pure refactor; any test change is a bug in the split.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add datafusion/bio-function-vep/src/annotate_provider.rs
+git commit -m "refactor(vep): split prepare_contig_context into data and activate phases"
+```
+
+---
+
+### Task 3: Prefetch gate decision + failing unit test
+
+**Files:**
+- Modify: `datafusion/bio-function-vep/src/annotate_provider.rs` (near the other env-gate helpers; tests go in the file's existing `#[cfg(test)] mod tests`)
+
+**Interfaces:**
+- Produces: `fn contig_prefetch_enabled(annotation_workers: usize, env: Option<&str>) -> bool` — pure function taking the raw env value so it is unit-testable; the call site passes `std::env::var("VEP_CONTIG_PREFETCH").ok().as_deref()`.
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[test]
+fn contig_prefetch_gate_decision_table() {
+    // unset: on only for workers>1
+    assert!(!contig_prefetch_enabled(1, None));
+    assert!(contig_prefetch_enabled(2, None));
+    assert!(contig_prefetch_enabled(16, None));
+    // "0"/"false": always off
+    assert!(!contig_prefetch_enabled(8, Some("0")));
+    assert!(!contig_prefetch_enabled(8, Some("false")));
+    // "1"/"true": on even for workers=1 (experiment override)
+    assert!(contig_prefetch_enabled(1, Some("1")));
+    assert!(contig_prefetch_enabled(1, Some("true")));
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test contig_prefetch_gate_decision_table`
+Expected: FAIL — `contig_prefetch_enabled` not defined.
+
+- [ ] **Step 3: Implement**
+
+```rust
+/// VEP_CONTIG_PREFETCH gate: prefetch the next contig's data phase during the
+/// current contig's annotation. Default ON for parallel annotation (workers>1),
+/// where the idle prelude is on the critical path; "1"/"true" forces it on for
+/// workers=1 experiments, "0"/"false" disables it everywhere.
+fn contig_prefetch_enabled(annotation_workers: usize, env: Option<&str>) -> bool {
+    match env {
+        Some(v) if v == "0" || v.eq_ignore_ascii_case("false") => false,
+        Some(v) if v == "1" || v.eq_ignore_ascii_case("true") => true,
+        _ => annotation_workers > 1,
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test contig_prefetch_gate_decision_table`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add datafusion/bio-function-vep/src/annotate_provider.rs
+git commit -m "feat(vep): add VEP_CONTIG_PREFETCH gate decision"
+```
+
+---
+
+### Task 4: Prefetch state machine in `ContigAnnotationStream`
+
+**Files:**
+- Modify: `datafusion/bio-function-vep/src/annotate_provider.rs` — `ContigAnnotationStream` struct (`:10725` area), `poll_next` state loop (`:12148-12250` area), cleanup (`cleanup_registered_tables_on_drop`, `:10753`).
+
+**Interfaces:**
+- Consumes: `prepare_contig_data`, `activate_contig_lookups`, `contig_prefetch_enabled` (Tasks 2–3, exact signatures above).
+- Produces: no new public API; behavioral feature gated by `VEP_CONTIG_PREFETCH`.
+
+**Design (ported from `abf19a5`, adapted to the narrow split):**
+
+New stream field:
+
+```rust
+/// In-flight prefetch of the NEXT contig's data phase (spawned when the
+/// current contig enters annotation; depth is always <= 1). The contig name
+/// rides along so cleanup can log what was discarded. The task spawns no
+/// lookup workers (data phase only), so aborting it leaks nothing.
+prefetched_data: Option<(String, tokio::task::JoinHandle<Result<Option<ContigPreparedData>>>)>,
+```
+
+Helper methods on `ContigAnnotationStream`:
+
+```rust
+fn start_prefetch_next_contig(&mut self) {
+    if self.prefetched_data.is_some() {
+        return; // depth stays at one
+    }
+    if !contig_prefetch_enabled(
+        self.config.annotation_workers,
+        std::env::var("VEP_CONTIG_PREFETCH").ok().as_deref(),
+    ) {
+        return;
+    }
+    // Pop the contig NOW so StartContig cannot double-prepare it.
+    let Some(chrom) = self.contigs.pop_front() else { return };
+    let session = Arc::clone(&self.session);
+    let cache = Arc::clone(&self.cache);
+    let config = self.config.clone();
+    let full_schema = self.full_schema.clone();
+    let prefetch_chrom = chrom.clone();
+    let handle = tokio::spawn(async move {
+        prepare_contig_data(session, cache, prefetch_chrom, config, full_schema).await
+    });
+    self.prefetched_data = Some((chrom, handle));
+}
+
+/// Build the PrepareFuture for StartContig: consume the prefetch if one is in
+/// flight, otherwise run the full prepare inline (first contig, gate off).
+fn next_prepare_future(&mut self, chrom_from_queue: Option<String>) -> Option<PrepareFuture> { ... }
+```
+
+State-loop wiring:
+1. `StartContig` (`:12150`): if `self.prefetched_data` is `Some((chrom, handle))`, take it and build the future as `Box::pin(async move { let data = handle.await.map_err(|e| DataFusionError::Execution(format!("contig prefetch task failed: {e}")))??; match data { None => Ok(None), Some(d) => activate_contig_lookups(session, d).await } })`; do NOT pop from `self.contigs` (the prefetch already popped it). Otherwise pop from `self.contigs` and use `prepare_contig_context` as today. The LIMIT-pushdown early-return must run BEFORE consuming the prefetch, and must abort a pending handle when it bails.
+2. On entering annotation for the current contig — both the serial transition to `AnnotatingContig` and the sharded transition to `AnnotatingParallel` (the `Poll::Ready(Ok(Some(mut ready)))` arm at `:12183`) — call `self.start_prefetch_next_contig()` immediately after the transition succeeds.
+3. Cleanup: in `cleanup_registered_tables_on_drop` and in the error-cleanup transitions, `if let Some((_, handle)) = self.prefetched_data.take() { handle.abort(); }`. Also abort in the `Done` transitions of `StartContig` (limit reached / queue empty).
+4. `ContigAnnotationStream::new` (`:10732`): initialize `prefetched_data: None`.
+
+Error semantics (document in a comment): a prefetch failure surfaces when its contig STARTS, preserving today's user-visible ordering; the current contig's annotation is never interrupted by a bad next contig.
+
+- [ ] **Step 1: Implement the field, helpers, and wiring exactly as above**
+
+- [ ] **Step 2: Verify compile + existing tests**
+
+Run: `cargo test 2>&1 | tail -5 && cargo clippy --all-targets 2>&1 | tail -3`
+Expected: green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add datafusion/bio-function-vep/src/annotate_provider.rs
+git commit -m "perf(vep): prefetch the next contig's data phase while the current one annotates"
+```
+
+---
+
+### Task 5: Wire vepyr to the branch and run the golden parity tests
+
+**Files:**
+- Modify: `/Users/mwiewior/research/git/vepyr/Cargo.toml` (the `[patch]` path)
+
+**Interfaces:**
+- Consumes: the built branch worktree from Task 4.
+- Produces: a vepyr `.venv` build running the prefetch engine; golden tests green.
+
+- [ ] **Step 1: Repoint the patch and rebuild**
+
+In `/Users/mwiewior/research/git/vepyr/Cargo.toml` change the patch line to:
+
+```toml
+[patch."https://github.com/biodatageeks/datafusion-bio-functions.git"]
+datafusion-bio-function-vep = { path = "/Users/mwiewior/research/git/dbf-prefetch/datafusion/bio-function-vep" }
+```
+
+Run:
+```bash
+cd /Users/mwiewior/research/git/vepyr
+env -u CONDA_PREFIX -u CONDA_DEFAULT_ENV uv run maturin develop --release 2>&1 | tail -3
+```
+Expected: `🛠 Installed vepyr-0.3.0`. (Both `VIRTUAL_ENV` and `CONDA_PREFIX` being set breaks maturin — the `env -u` is required on this machine.)
+
+- [ ] **Step 2: Run vepyr's golden + annotate tests**
+
+Run:
+```bash
+cd /Users/mwiewior/research/git/vepyr
+uv run pytest tests/test_golden.py tests/test_annotate.py -x -q 2>&1 | tail -5
+```
+Expected: PASS. These exercise real multi-contig annotation against fixture caches — the closest thing to an engine integration test.
+
+- [ ] **Step 3: Commit (engine repo bookkeeping only — the vepyr patch stays uncommitted)**
+
+No engine commit here; the vepyr `Cargo.toml` patch is machine-local and must NOT be committed to vepyr (it carries the existing "TEMPORARY" comment).
+
+---
+
+### Task 6: Byte-identical A/B on the WGS input
+
+**Files:**
+- No source changes. Uses `/Users/mwiewior/workspace/data_vepyr` inputs and the sweep runner pattern from the scalability session.
+
+- [ ] **Step 1: Hash a gate-OFF run**
+
+```bash
+cd /Users/mwiewior/research/git/vepyr
+out=/Users/mwiewior/workspace/data_vepyr/output/116/prefetch_ab/off.vcf
+mkdir -p "$(dirname $out)"; rm -f "$out"
+VEP_CONTIG_PREFETCH=0 .venv/bin/python -P - "$out" <<'EOF'
+import sys, vepyr
+vepyr.annotate(
+    vcf="/Users/mwiewior/workspace/data_vepyr/input/HG002_normalized.vcf.gz",
+    cache_dir="/Users/mwiewior/workspace/data_vepyr/cache/116_GRCh38_merged",
+    everything=True, hgvs=True, workers=8, compression="plain",
+    reference_fasta="/Users/mwiewior/workspace/data_vepyr/input/Homo_sapiens.GRCh38.dna.primary_assembly.fa",
+    output_vcf=sys.argv[1], show_progress=False)
+EOF
+shasum -a 256 "$out" | tee /tmp/prefetch_off.sha; rm -f "$out"
+```
+
+(Delete between runs — the disk has ~65 GiB free and each plain output is 29.4 GiB.)
+
+- [ ] **Step 2: Hash a gate-ON run and compare**
+
+Same command with `VEP_CONTIG_PREFETCH=1` and `on.vcf`.
+Expected: identical SHA-256. If the hashes differ, STOP — the split changed behavior; bisect Tasks 2/4 before proceeding.
+
+---
+
+### Task 7: Instrumented re-measurement (acceptance)
+
+**Files:**
+- No source changes. Reuses `run_one_scaling.py` / `timestamp_lines.py` from the scalability session (scratchpad) or re-creates them — they call `vepyr.annotate(..., workers=N, show_progress=False)` with `VEP_PROFILE=1` and timestamp stderr lines.
+
+**Acceptance criteria (all from the 2026-08-11 baseline on this machine):**
+- w=8 annotation wall: **≤ ~66 s** (baseline 77.9 s; ~18.7 s of prepare was serial, first contig still pays its own).
+- Per-contig activation gap (time between the previous contig's `pipeline_profile` line and the next `------ contig X START ------`, which now marks activation): **< 0.5 s** for every contig after the first.
+- `max_rss_gb` at w=8: **≤ baseline + 2.0 GB** (baseline 7.4 GB; the prefetch holds one extra contig's context, ~1.7 GB measured on the old branch).
+- Output record count 4,096,123 (checked in Task 6 by the golden/hash runs).
+
+- [ ] **Step 1: Run w=8 and w=16 with VEP_PROFILE=1, gate default (on)**
+
+- [ ] **Step 2: Parse the timestamped log** — per-contig activation gaps + `prepare_total` sums, exactly as in the scalability analysis (contig START = activation now; `prefetch data_start/data_done` trace events give the overlapped span).
+
+- [ ] **Step 3: Record the numbers** in the PR description and update the project memory note `vepyr-worker-scaling-t4-decomposition` (mark cause 1 as fixed, with measured before/after).
+
+If acceptance fails: check first that the prefetch actually overlapped (the `prefetch data_done` trace timestamp must land inside the previous contig's annotation window). The known failure mode is polling the JoinHandle only on stream poll — the prefetch MUST be `tokio::spawn`ed (Task 4), not stored as an unspawned future.
+
+---
+
+### Task 8: Push + PR
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+cd /Users/mwiewior/research/git/dbf-prefetch
+git push -u origin perf/contig-prefetch-master
+```
+
+- [ ] **Step 2: Open the PR against master**
+
+```bash
+gh pr create --title "perf(vep): prefetch the next contig's data phase (WGS w=8: 78s -> <measured>s)" \
+  --body "$(cat <<'EOF'
+Port of the contig-prefetch narrow split (#206/#208 lineage) onto the post-#209
+master. Splits prepare_contig_context into a prefetchable data phase and an
+activation phase; the stream prefetches contig i+1's data phase during contig
+i's annotation. Gate: VEP_CONTIG_PREFETCH (default on for workers>1).
+
+Measured (HG002 WGS, merged 116, plain, 16-core M-series):
+- <w=8 / w=16 before/after table from Task 7>
+- Byte-identical output gate on/off (SHA-256, Task 6).
+- RSS delta: <measured> (bounded by one contig's context; the narrow split
+  avoids the +0.31 GB/worker term of the full prefetch).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** cause-1 fix = cross-contig overlap of the prepare data phase; Tasks 2+4 implement it, 3 gates it, 5–7 verify parity and the win, 8 lands it. The byte-budget deferral (#208 content) is folded into Task 2's activate phase, so Ensembl-cache workers>1 benefits too.
+- **Known trade-offs stated:** `VEP_EARLY_WORKERS` interleave removed (first-contig-only cost); +~1.7 GB steady-state RSS with the gate on; prefetch errors surface at the failing contig's start.
+- **Out of scope (explicitly):** cause 2 (intra-contig utilization / `VEP_GRID_BALANCE` default), cause 3 (engine CPU inflation), prefetch depth > 1, and prefetching the SIFT store lazily. Do not fold these in.

--- a/docs/superpowers/plans/2026-08-23-phase3-kickoff-prompt.md
+++ b/docs/superpowers/plans/2026-08-23-phase3-kickoff-prompt.md
@@ -1,0 +1,121 @@
+# Kickoff prompt for the next session
+
+Copy everything below the line into a new Claude Code session started in
+`~/research/git/vepyr`.
+
+---
+
+Continue the vepyr → Ensembl VEP byte-parity work. Phase 3 (record passthrough)
+is the last piece; phases 1 and 2 are merged and verified.
+
+**Read first:** `docs/superpowers/plans/2026-08-23-phase3-record-passthrough-handover.md`
+in this repo. It has the full status, the empirical proof, the plan,
+the two wrong designs I discarded, and the traps. Do not re-derive any of it.
+
+## What you are finishing
+
+`md5_concordance.py --mode strict` currently fails on the record body with
+exactly three classes:
+
+```
+55,812  FORMAT KEYS (-['PS'] +[])
+55,812  SAMPLE1 keys
+55,714  INFO order
+```
+
+All three vanish if the writer stops re-deriving INFO and FORMAT layout. The
+underlying approach is **proven**: on chr21, the raw input line + `";CSQ=" + csq`
+reproduces the reference VEP output byte for byte on 55,812/55,812 records
+(100.0000%). Re-run that proof on chr22 first as a sanity check — the pattern is
+in the handover doc §2.
+
+The serializer half is done and committed: bio-formats `df53b18` on branch
+`feat/vcf-record-passthrough`, 134 tests green, unpushed.
+
+## The design — read this before planning anything
+
+Two earlier drafts of the handover were wrong. Both are recorded in its §3;
+read them, so you don't repeat either.
+
+- **Not blocked on noodles.** `Record::info()` and `Record::samples()` are
+  public, and `Info<'r>` wraps the raw INFO substring and iterates in source
+  order. No fork. Three repos: bio-formats → bio-functions → vepyr.
+- **Not one column.** Treating INFO order as file-level schema metadata looked
+  safe — zero ordering conflicts on chr1/6/17/21 — but that is a property of
+  this corpus, not a guarantee. A merged VCF can interleave orders and would
+  emit wrong output silently.
+
+**The design:** two `Utf8` columns, **keys only**, written only under an opt-in
+flag.
+
+| column | example | distinct values on chr21 |
+|---|---|---|
+| INFO key order | `platforms;platformnames;datasets;…` | 10 |
+| FORMAT keys | `GT:PS:DP:ADALL:AD:GQ` | 1 (2 on chr6) |
+
+Values are not carried — the audit found zero INFO-value and sample-value
+differences, so they already round-trip. Both columns dictionary-encode to
+almost nothing.
+
+Why each is unavoidable: FORMAT order varies per record (chr6 has both
+`GT:PS:DP:ADALL:AD:GQ` and `GT:AD:PS`), and `PS` is `Type=Integer`, so a source
+`.` parses to NULL — indistinguishable from the key being absent. The serializer
+currently guesses and cannot do better without the record's key list.
+
+The committed serializer work still applies; point it at the carried key order
+and FORMAT key list instead of a whole line.
+
+## Definition of done
+
+```bash
+python3 e2e-testing/scripts/md5_concordance.py \
+  --pair e2e-testing/results/116/fast_chr21/vep_chr21_merged.vcf \
+         /tmp/vepyr_chr21_parity.vcf \
+  --mode strict --explain
+```
+
+reports matching body digests and no record differences, on chr21 and chr22,
+then across all 22 via `--results-dir`. That is the gate for cutting release
+tags — the user cuts them once md5 is confirmed.
+
+## How to work
+
+- **TDD.** Write the failing test, watch it fail for the right reason, then
+  implement. Several bugs in phases 1–2 were caught only because the test was
+  written first.
+- **Verify build success by the install marker, not an exit code.** A piped
+  `cargo`/`maturin` command returns the pipe's status. This masked two real
+  failures and produced a "successful" run against a stale binary whose output
+  was byte-identical to the previous one:
+  ```bash
+  env -u CONDA_PREFIX -u VIRTUAL_ENV uv run maturin develop --release > /tmp/build.log 2>&1
+  grep -q 'Installed vepyr' /tmp/build.log && echo OK || tail -20 /tmp/build.log
+  ```
+- **Stage files explicitly.** `git add -A` swept the user's untracked scripts
+  into a commit once. Name the paths.
+- **Expect review iteration.** These repos' reviewer finds real bugs — 5 to 7
+  rounds per PR in phases 1–2. Address findings by removing mechanism where you
+  can; four of eight findings on one PR were the same substring-vs-structure
+  error, and the fix that finally settled it deleted 200 lines.
+- **CLAUDE.md mandates GSD workflows** for repo edits, but `.planning/ROADMAP.md`
+  does not exist so `/gsd:quick` errors out. The user has been asking for direct
+  edits; confirm that is still fine before your first edit.
+
+## Loose ends you inherit
+
+- **Uncommitted:** the handover doc and this prompt in
+  `docs/superpowers/plans/`.
+- **Committed, unpushed:** bio-formats `df53b18`
+  (`feat/vcf-record-passthrough`); vepyr `e2bcfe9`
+  (`chore/bump-to-header-parity-revs`).
+- **Open issues:** bio-formats #241 (`±Inf` coercion; `qual` as `Float32`),
+  bio-functions #213 (cache data-source versions in provenance).
+- **Worth raising:** `AnnotateVcfConfig` is `pub` with `pub` fields and no
+  `#[non_exhaustive]`, so field additions are semver-breaking — one broke
+  vepyr's compile while bio-functions CI stayed green. The next bio-functions
+  tag should be a minor bump.
+- **Nice-to-have:** teach `md5_concordance.py` to exclude vepyr's own
+  `##datafusion-bio-function-vep*` provenance keys from the header digest, the
+  way it already excludes `##VEP*`, so header comparison reports clean.
+
+Ask before starting anything that spans more than one repo at a time.

--- a/docs/superpowers/plans/2026-08-23-phase3-record-passthrough-handover.md
+++ b/docs/superpowers/plans/2026-08-23-phase3-record-passthrough-handover.md
@@ -1,0 +1,290 @@
+# Phase 3 — record passthrough to byte-identical VCF output
+
+**Written:** 2026-08-23
+**Goal:** make `md5_concordance.py --mode strict` pass on the record body, so
+release tags can be cut.
+
+---
+
+## 1. Where things stand
+
+### Merged
+
+| repo | PR | what it fixed |
+|---|---|---|
+| bio-formats | #240 | QUAL rendered at source precision, not `{:.2}` (also: `format_vcf_float` no longer panics on ±Inf) |
+| bio-formats | #242 | source VCF header re-emitted verbatim |
+| bio-functions | #212 | CSQ description reads `from Ensembl VEP` |
+| bio-functions | #214 | run provenance in the output header |
+| bio-functions | #215 | provenance records `cache_format`, not the vestigial `backend` token |
+
+### Committed, not pushed
+
+- **bio-formats** `df53b18` on `feat/vcf-record-passthrough` — the serializer
+  half of phase 3. 134 tests green, fmt + clippy clean.
+- **vepyr** `e2bcfe9` on `chore/bump-to-header-parity-revs` — rev pins onto the
+  merged engine revisions, plus the two new `AnnotateVcfConfig` fields.
+
+### Open issues
+
+- bio-formats #241 — `±Inf` coercion vs error; whether `qual` should be
+  `Float32` in the schema rather than widened to `f64`.
+- bio-functions #213 — carry the Ensembl cache's data-source versions
+  (gnomAD, ClinVar, dbSNP, GENCODE…) into provenance.
+
+### Verified today
+
+Two chromosomes, annotated with the merged engine and compared to the reference
+Ensembl VEP 116.0 output:
+
+| | chr21 | chr22 |
+|---|---|---|
+| records | 55,812 | 50,861 |
+| header lines | 236 vs VEP's 236 | 236 vs VEP's 236 |
+| canonical body digest | `f1f1cadec368e51cecf93111bed841c7` | `9392f95c482497e25c362d1bb6f55ab5` |
+| digest vs pre-change audit | unchanged | unchanged |
+| strict body | FAIL — 3 classes | FAIL — 3 classes |
+
+Header parity is reached. The only header line that still differs is
+`##bcftools_normCommand`, and that is a harness artifact — the reference VEP run
+was produced from a different normalization than the current input. It is in
+fact evidence the passthrough works, since vepyr is echoing whatever its input
+carried.
+
+**Unchanged digests are the important result:** phases 1 and 2 changed
+serialization without touching annotation content, on 106,673 records.
+
+### What strict mode still reports
+
+```
+55,812  FORMAT KEYS (-['PS'] +[])
+55,812  SAMPLE1 keys
+55,714  INFO order
+```
+
+`QUAL format` is gone from that list — phase 1 removed it. The remaining three
+are phase 3.
+
+---
+
+## 2. Why phase 3 is plumbing, not serializer fixes
+
+Do not attempt to fix these by rendering INFO/FORMAT more cleverly.
+
+- **No global key order exists.** chr6's input carries both
+  `GT:PS:DP:ADALL:AD:GQ` and `GT:AD:PS` — `AD` precedes `PS` in one and follows
+  it in the other. A file-level order table silently produces wrong output on
+  real data.
+- **The `PS` drop is lossy by construction.** The Arrow schema gives every record
+  every FORMAT key the header declares, so the per-record key list is gone before
+  the serializer runs. `filter_all_missing_format_fields` reverse-engineers it
+  from which values are non-missing, and cannot distinguish "absent" from
+  "present but `.`".
+
+Ensembl VEP avoids all of this by never re-rendering: `OutputFactory/VCF.pm`
+copies `$vf->{_line}` and appends to INFO only.
+
+### The approach is empirically proven
+
+On chr21, taking each raw input line and appending the CSQ this engine already
+produces reproduces the reference VEP output **byte for byte on 55,812 / 55,812
+records (100.0000%)**.
+
+Reproduce with the pattern in
+`scratchpad/phase3_proof.py`: zip the bodies of input / VEP / vepyr, splice
+`CSQ=` out of vepyr's INFO onto the raw input line, compare to VEP's line. Run
+this again on chr22 before starting, as a second confirmation.
+
+---
+
+## 3. What the reader must carry, and why
+
+Two earlier drafts of this section were wrong. Recording both, because each
+wrong turn is a trap someone else would walk into.
+
+**Draft 1 — "blocked on a noodles fork."** It concluded phase 3 needed
+`noodles-vcf` to expose a record's raw line (`Fields::buf` is `pub(crate)` with
+no public accessors). True, and irrelevant: the whole line is not what is
+needed. `Record::info()` and `Record::samples()` are already public, and
+`Info<'r>` is a thin wrapper over the raw INFO substring that iterates in
+**source order**. No fork. Three repos, not four.
+
+**Draft 2 — "one column plus schema metadata."** It proposed carrying only the
+per-record FORMAT keys and treating INFO order as a file-level property in
+schema metadata, on the evidence that INFO order had **zero ordering conflicts**
+on chr1, chr6, chr17 and chr21. That evidence is real but it is a property of
+*this corpus*, not a guarantee. A VCF merged from two sources can interleave
+orders; a file-level order would then emit wrong output silently — passing here,
+failing elsewhere. Do not build parity on it.
+
+### The design
+
+Two columns, keys only, both written only when an opt-in flag is set:
+
+| column | example | distinct values on chr21 |
+|---|---|---|
+| INFO key order | `platforms;platformnames;datasets;…` | 10 |
+| FORMAT keys | `GT:PS:DP:ADALL:AD:GQ` | 1 (2 on chr6) |
+
+Keys, not values. The audit found **zero** INFO-value and sample-value
+differences, so values already round-trip through the typed columns. Only order,
+and the per-record FORMAT key list, are lost. Both columns dictionary-encode to
+almost nothing, against ~700 B/record for whole-line passthrough.
+
+### Why each is unavoidable
+
+- **FORMAT order varies per record.** chr6 carries both
+  `GT:PS:DP:ADALL:AD:GQ` and `GT:AD:PS` in one file — different orders of
+  overlapping keys. No file-level order can satisfy both.
+- **`PS` cannot be recovered.** `##FORMAT=<ID=PS,Number=1,Type=Integer>` means a
+  source `.` parses to NULL in an `Int32Array`, identical to the key being
+  absent. The distinction is destroyed at parse time. The serializer currently
+  guesses via `filter_all_missing_format_fields`, and cannot do better without
+  being told the record's key list.
+- **INFO order** is per-record for safety, per the draft-2 reasoning above.
+
+### Completeness check
+
+With both columns carried, all three strict-mode classes close: INFO order
+directly; FORMAT order directly; `PS` because the serializer stops inferring
+keys from non-missing values and emits the carried list. Sample-column key order
+follows the FORMAT keys, so it is the same fix. Everything else already matches
+— CHROM/POS/ID/REF/ALT/FILTER, INFO values and sample values all showed zero
+differences in the audit.
+
+### Residual, worth naming
+
+**QUAL is byte-correct for this corpus, not in general.** Phase 1 renders at f32
+source precision, so an input written `50.0` returns as `50`. Every QUAL in
+HG002 is integral, so it cannot bite here, but strict parity on an arbitrary VCF
+still depends on bio-formats #241 (`qual` as `Float32` rather than widened to
+`f64`).
+
+## 4. Implementation plan
+
+Three repos in a chain. Each step is independently testable; do not batch them.
+
+### Step 1 — bio-formats reader
+
+Branch from `feat/vcf-record-passthrough` (it already carries `df53b18`).
+
+1. Add an opt-in flag to the VCF reader/table provider, e.g.
+   `carry_record_layout: bool`, defaulting **off**. A non-parity read must pay
+   nothing.
+2. When on, add two `Utf8` columns — an INFO key order and a FORMAT key string,
+   keys only — populated from `record.info()` and `record.samples()` in the
+   record loops.
+   Name them via constants in `bio-format-core/src/metadata.rs` beside the
+   existing `VCF_RAW_RECORD_COLUMN`.
+
+Record loops in `datafusion/bio-format-vcf/src/physical_exec.rs`: `:756`,
+`:987` (with `read_record` at `:992`), `:1287`. Check for others with
+`grep -n 'read_record\|read_records'`.
+
+3. Teach the serializer to use them: order INFO by the carried key list
+   (appending keys the list does not mention, such as a newly added `CSQ`), and
+   emit the carried FORMAT key list verbatim instead of deriving one from
+   non-missing values. That last part is what restores `PS`.
+
+Verify: a read/write round trip over a VCF whose INFO order differs from its
+header declaration and which has a FORMAT key missing in every sample. Assert
+byte equality with the input. With the flag off, assert the schema and output
+are unchanged.
+
+### Step 2 — bio-functions
+
+1. Bump the bio-formats rev.
+2. Enable the carry flag on the input `VcfTableProvider` in
+   `annotate_to_vcf` when an opt-in config flag is set.
+3. Add both columns to the SELECT list and to `projection_names` in
+   `vcf_sink.rs` — both lists must agree or the sharded path diverges from the
+   serial one. Search for `select_cols` and `projection_names`.
+
+The serializer already splices INFO; point it at the carried key order and the
+carried FORMAT key list.
+
+Verify: an end-to-end test annotating a small VCF whose INFO order differs from
+its header declaration, asserting the output line equals input + `;CSQ=…`.
+
+### Step 3 — vepyr
+
+1. Bump both engine revs on `chore/bump-to-header-parity-revs`.
+2. Surface the flag through `annotate()`. Suggest defaulting it **on** for VCF
+   input, since parity is the product goal — but make that an explicit decision,
+   not a default that arrives silently.
+
+---
+
+## 5. The verification gate
+
+Build cleanly first. `maturin develop` fails if both `VIRTUAL_ENV` and
+`CONDA_PREFIX` are set:
+
+```bash
+cd ~/research/git/vepyr
+env -u CONDA_PREFIX -u VIRTUAL_ENV uv run maturin develop --release > /tmp/build.log 2>&1
+grep -q 'Installed vepyr' /tmp/build.log && echo OK || tail -20 /tmp/build.log
+```
+
+**Check the install marker, not an exit code.** A piped `cargo`/`maturin`
+invocation returns the pipe's status, not the build's — this masked two real
+failures during phases 1–2 and produced a "successful" run against a stale
+binary whose output was byte-identical to the previous one.
+
+Then annotate and compare:
+
+```bash
+python3 e2e-testing/scripts/md5_concordance.py \
+  --pair e2e-testing/results/116/fast_chr21/vep_chr21_merged.vcf \
+         /tmp/vepyr_chr21_parity.vcf \
+  --mode strict --explain
+```
+
+**Pass condition:** the body digests match, and `--explain` reports no record
+differences. Repeat on chr22, then `--results-dir` across all 22.
+
+Expected residual header difference: each side's own provenance lines
+(`##VEP*` for VEP, `##datafusion-bio-function-vep*` for vepyr) and the
+`##bcftools_normCommand` harness artifact. Annotating both sides from the *same*
+normalized input removes the latter.
+
+Consider extending `md5_concordance.py` to exclude vepyr's provenance keys from
+the header digest the way it already excludes `##VEP*`, so the header
+comparison reports clean.
+
+---
+
+## 6. Traps
+
+- **`AnnotateVcfConfig` is `pub` with `pub` fields and no
+  `#[non_exhaustive]`.** #214's two field additions broke vepyr's compile while
+  bio-functions' own tests stayed green, because they all use
+  `..Default::default()`. Any field you add is semver-breaking. Worth adding
+  `#[non_exhaustive]`, and the next tag should be a minor bump.
+- **The reviewer on these repos finds real bugs, repeatedly.** Phases 1–2 took
+  5–7 review rounds each, and four of eight findings on #214 were the same
+  error: matching a substring where the check needed structure. Expect
+  iteration; budget for it.
+- **QUAL is `f32` on the wire.** noodles returns `Option<f32>` and
+  `physical_exec.rs` widens with `v as f64` (`:821`, `:1076`, `:1352`, `:2959`).
+  Phase 3 makes this moot for passthrough records, but it still governs any
+  reconstructed output.
+- **Cost of passthrough, measured:** +703 B/record carried, about **+10.3%** of
+  output bytes and **~0.3%** of peak RSS. Input columns transit the annotation
+  engine as `Arc` clones (`annotate_provider.rs:7191`), not copies, so the
+  engine cost is a refcount. The sink should get *faster* — it drops roughly 20
+  heap allocations per row.
+- **The e2e corpus is blind to fractional QUAL.** Every QUAL in HG002 is
+  integral, hence exact in `f32`. A 4.1M-record pass proves nothing about
+  QUAL precision; #240's review caught that class only by reading the code.
+
+---
+
+## 7. Reference
+
+- Comparator: `e2e-testing/scripts/md5_concordance.py` — `canonical` normalizes
+  cosmetic serialization, `strict` hashes bytes, `--explain` classifies
+  differences. Exit 0 / 1 / 2.
+- Audit report: https://claude.ai/code/artifact/f031a41a-03df-4842-90e3-c997b41d775b
+- VEP's own rule: `ensembl-vep/modules/Bio/EnsEMBL/VEP/OutputFactory/VCF.pm`,
+  `get_all_lines_by_InputBuffer`.

--- a/docs/superpowers/plans/2026-09-05-plugin-cache-qa-profile.md
+++ b/docs/superpowers/plans/2026-09-05-plugin-cache-qa-profile.md
@@ -1,0 +1,2290 @@
+# Plugin Cache QA Profile Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A Polars tool that verifies a plugin cache's structural invariants, profiles its content into `qa_profile.json`, regenerates a `## Quality profile` section in the plugin's Hugging Face card, and optionally publishes shards + manifest + JSON + card as one Hub commit with a moved tag.
+
+**Architecture:** One package `e2e-testing/scripts/cache_qa/` mirroring `e2e-testing/scripts/comparison/` (pure functions per module, a thin `cli.py`, a `Runner` protocol for subprocesses so tests never touch the network). Every invariant is a per-shard lazy Polars scan reduced to counts; the content profile is one lazy scan over all shards collected on the streaming engine. The manifest is the only source of truth; the vepyr-plugins source manifest is never read.
+
+**Tech Stack:** Python 3.10+, Polars 1.39 (`scan_parquet`, `collect_schema`, `collect(engine="streaming")`), stdlib `argparse`/`json`/`dataclasses`/`subprocess`, pytest. The `hf` CLI (huggingface_hub 1.28) for publishing.
+
+**Spec:** `docs/superpowers/specs/2026-09-05-plugin-cache-qa-profile-design.md`
+
+## Global Constraints
+
+- Package path: `e2e-testing/scripts/cache_qa/`; entry point `e2e-testing/scripts/profile_plugin_cache.py`; tests `tests/test_cache_qa_*.py`. `tests/conftest.py` already puts `e2e-testing/scripts` on `sys.path`, so tests import `from cache_qa import manifest`.
+- Inputs: `<root>/plugin/<name>/manifest.json` and the shards it names. Shard `chrom` values are bare Ensembl contigs (`22`, `X`, `MT`); manifest `chroms[].chrom` is `chr22` / `chrX` / `chrMT`; shard files are `chr<contig>.parquet`.
+- Real shard schema (verified on the v0.1.1 caches): `chrom String, start UInt32, end UInt32, allele_string String, <match…>, <value…>, tier Int8`. Manifest value types seen: `Utf8`, `Int32`, `Float32`.
+- Order key (engine #237): `(tier, start, allele_string, <match columns…>)`.
+- Dedup policy: manifest `assume_unique` (`true` → duplicates warn, `false` → fail, absent → per-plugin fallback table `{clinvar, alphamissense, dbnsfp: dedup; spliceai, cadd: assume unique}`, unknown plugin → dedup/strict) and the detail says when the fallback was used.
+- A contig with `rows == 0` may have no file; any other missing file is a `manifest_files` failure. Profile still runs on present shards.
+- Exit codes: `0` pass/warn, `1` an invariant failed (nothing uploaded), `2` usage or I/O error.
+- Card markers `<!-- qa-profile:start -->` / `<!-- qa-profile:end -->`; insert before `## Usage` when absent, else append. Rendering is byte-idempotent except `generated_at`.
+- `qa_profile.json` `schema_version` is `1`. Tool block records `vepyr`, `polars` versions.
+- No network in tests. All Hub calls go through `Runner.run(argv) -> subprocess.CompletedProcess`.
+- Commit after every task with `Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>` and the session trailer from the harness.
+- Lint with `uv run ruff check e2e-testing/scripts/cache_qa tests` and format with `uv run ruff format` before each commit. Run tests with `uv run pytest tests/test_cache_qa_*.py -q`.
+
+---
+
+### Task 1: Synthetic cache fixture and manifest loader
+
+**Files:**
+- Create: `e2e-testing/scripts/cache_qa/__init__.py`
+- Create: `e2e-testing/scripts/cache_qa/manifest.py`
+- Create: `tests/cache_qa_synthetic.py` (helper, not a test)
+- Test: `tests/test_cache_qa_manifest.py`
+
+**Interfaces:**
+- Produces `cache_qa.manifest`:
+  - `class ManifestError(ValueError)`
+  - `@dataclass(frozen=True) ContigEntry(chrom: str, file: str, rows: int, warm: int, cold: int)` with `.bare` property (`chr22`→`22`, `chrMT`→`MT`).
+  - `@dataclass(frozen=True) ColumnSpec(name: str, role: str, dtype: pl.DataType)`; roles `"key" | "match" | "value" | "tier"`.
+  - `@dataclass(frozen=True) CacheManifest(plugin: str, plugin_dir: Path, cache_source_version: str | None, allele_match: str, assume_unique: bool | None, key_columns: list[str], match_columns: list[str], value_columns: list[tuple[str, str]], contigs: list[ContigEntry])` with methods `expected_schema() -> list[ColumnSpec]`, `order_key() -> list[str]` (`["tier","start","allele_string", *match]`), `probe_key() -> list[str]` (`[*key_columns, *match]`), `shard_path(entry) -> Path`, `present_shards() -> list[tuple[ContigEntry, Path]]`.
+  - `load_manifest(plugin_dir: Path) -> CacheManifest`
+  - `dedup_policy(m: CacheManifest) -> tuple[bool, str]` returning `(assume_unique, detail)`.
+  - `MANIFEST_TYPES: dict[str, pl.DataType]`.
+- Produces `tests/cache_qa_synthetic.py`: `SyntheticCache(root: Path, plugin="demo", match_columns=("symbol",), allele_match="exact", assume_unique=False)` with `.plugin_dir`, `.rows: dict[str, pl.DataFrame]` (contig → frame), `.write()` (writes shards + manifest from `.rows`, returns `plugin_dir`), `.manifest_dict()` and `.set_manifest(dict)`.
+
+- [ ] **Step 1: Create the synthetic cache helper**
+
+`tests/cache_qa_synthetic.py`:
+
+```python
+"""Build tiny three-contig plugin caches for cache_qa tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import polars as pl
+
+CONTIGS = ("chr1", "chr2", "chrX")
+
+
+def _rows(bare: str, n: int, symbol: str) -> pl.DataFrame:
+    starts = [100 + 10 * i for i in range(n)]
+    tiers = [0 if i < 2 else 1 for i in range(n)]
+    return pl.DataFrame(
+        {
+            "chrom": [bare] * n,
+            "start": pl.Series(starts, dtype=pl.UInt32),
+            "end": pl.Series(starts, dtype=pl.UInt32),
+            "allele_string": ["A/G" if i % 2 == 0 else "C/T" for i in range(n)],
+            "symbol": [symbol] * n,
+            "score": ["0.5" if i % 3 else "" for i in range(n)],
+            "raw": pl.Series([float(i) for i in range(n)], dtype=pl.Float32),
+            "tier": pl.Series(tiers, dtype=pl.Int8),
+        }
+    ).sort(["tier", "start", "allele_string", "symbol"])
+
+
+class SyntheticCache:
+    def __init__(
+        self,
+        root: Path,
+        plugin: str = "demo",
+        match_columns: tuple[str, ...] = ("symbol",),
+        allele_match: str = "exact",
+        assume_unique: bool | None = False,
+    ) -> None:
+        self.root = root
+        self.plugin = plugin
+        self.plugin_dir = root / "plugin" / plugin
+        self.match_columns = list(match_columns)
+        self.allele_match = allele_match
+        self.assume_unique = assume_unique
+        self.rows: dict[str, pl.DataFrame] = {
+            "chr1": _rows("1", 6, "GENE1"),
+            "chr2": _rows("2", 4, "GENE2"),
+            "chrX": _rows("X", 3, "GENEX"),
+        }
+        self._manifest_override: dict | None = None
+
+    def manifest_dict(self) -> dict:
+        if self._manifest_override is not None:
+            return self._manifest_override
+        chroms = []
+        for chrom, df in self.rows.items():
+            chroms.append(
+                {
+                    "chrom": chrom,
+                    "file": f"{chrom}.parquet",
+                    "rows": df.height,
+                    "warm": int((df["tier"] == 0).sum()),
+                    "cold": int((df["tier"] == 1).sum()),
+                }
+            )
+        m = {
+            "plugin_name": self.plugin,
+            "source_manifest": f"{self.plugin}.source.toml",
+            "key_columns": ["chrom", "start", "end", "allele_string"],
+            "match_columns": [{"column": c, "template": "{SYMBOL}"} for c in self.match_columns],
+            "value_columns": [
+                {"column": "score", "csq_field": "DEMO_SCORE", "type": "Utf8"},
+                {"column": "raw", "csq_field": "DEMO_RAW", "type": "Float32"},
+            ],
+            "chroms": chroms,
+            "sources": [],
+            "cache_source_version": "v0.1.1@3e1c039405344ccb800f89f9a032c688fd048bec",
+            "allele_match": self.allele_match,
+            "field_order": "alphabetical",
+        }
+        if self.assume_unique is not None:
+            m["assume_unique"] = self.assume_unique
+        return m
+
+    def set_manifest(self, manifest: dict) -> None:
+        self._manifest_override = manifest
+
+    def write(self) -> Path:
+        self.plugin_dir.mkdir(parents=True, exist_ok=True)
+        for chrom, df in self.rows.items():
+            df.write_parquet(self.plugin_dir / f"{chrom}.parquet")
+        (self.plugin_dir / "manifest.json").write_text(
+            json.dumps(self.manifest_dict(), indent=2) + "\n"
+        )
+        return self.plugin_dir
+```
+
+- [ ] **Step 2: Write the failing manifest tests**
+
+`tests/test_cache_qa_manifest.py`:
+
+```python
+import json
+
+import polars as pl
+import pytest
+
+from cache_qa import manifest
+from cache_qa_synthetic import SyntheticCache
+
+
+def test_load_manifest_reads_columns_and_contigs(tmp_path):
+    plugin_dir = SyntheticCache(tmp_path).write()
+    m = manifest.load_manifest(plugin_dir)
+    assert m.plugin == "demo"
+    assert m.key_columns == ["chrom", "start", "end", "allele_string"]
+    assert m.match_columns == ["symbol"]
+    assert m.value_columns == [("score", "Utf8"), ("raw", "Float32")]
+    assert [c.chrom for c in m.contigs] == ["chr1", "chr2", "chrX"]
+    assert m.contigs[2].bare == "X"
+    assert m.assume_unique is False
+    assert m.allele_match == "exact"
+
+
+def test_expected_schema_order_and_types(tmp_path):
+    m = manifest.load_manifest(SyntheticCache(tmp_path).write())
+    specs = m.expected_schema()
+    assert [s.name for s in specs] == [
+        "chrom", "start", "end", "allele_string", "symbol", "score", "raw", "tier"
+    ]
+    assert [s.role for s in specs] == [
+        "key", "key", "key", "key", "match", "value", "value", "tier"
+    ]
+    assert specs[1].dtype == pl.UInt32
+    assert specs[5].dtype == pl.String
+    assert specs[6].dtype == pl.Float32
+    assert specs[7].dtype == pl.Int8
+
+
+def test_keys(tmp_path):
+    m = manifest.load_manifest(SyntheticCache(tmp_path).write())
+    assert m.order_key() == ["tier", "start", "allele_string", "symbol"]
+    assert m.probe_key() == ["chrom", "start", "end", "allele_string", "symbol"]
+
+
+def test_present_shards_skips_missing_files(tmp_path):
+    cache = SyntheticCache(tmp_path)
+    plugin_dir = cache.write()
+    (plugin_dir / "chrX.parquet").unlink()
+    m = manifest.load_manifest(plugin_dir)
+    assert [e.chrom for e, _ in m.present_shards()] == ["chr1", "chr2"]
+
+
+def test_bare_contig_names():
+    assert manifest.ContigEntry("chrMT", "chrMT.parquet", 0, 0, 0).bare == "MT"
+    assert manifest.ContigEntry("chr22", "chr22.parquet", 1, 1, 0).bare == "22"
+
+
+def test_missing_manifest_raises(tmp_path):
+    with pytest.raises(manifest.ManifestError) as e:
+        manifest.load_manifest(tmp_path / "plugin" / "nope")
+    assert "manifest.json" in str(e.value)
+
+
+def test_missing_key_names_the_key(tmp_path):
+    cache = SyntheticCache(tmp_path)
+    m = cache.manifest_dict()
+    del m["chroms"]
+    cache.set_manifest(m)
+    plugin_dir = cache.write()
+    with pytest.raises(manifest.ManifestError) as e:
+        manifest.load_manifest(plugin_dir)
+    assert "chroms" in str(e.value)
+
+
+def test_unknown_value_type_raises(tmp_path):
+    cache = SyntheticCache(tmp_path)
+    m = cache.manifest_dict()
+    m["value_columns"][0]["type"] = "Decimal"
+    cache.set_manifest(m)
+    with pytest.raises(manifest.ManifestError) as e:
+        manifest.load_manifest(cache.write())
+    assert "Decimal" in str(e.value)
+
+
+@pytest.mark.parametrize(
+    "plugin,key,expected,fallback",
+    [
+        ("demo", True, True, False),
+        ("demo", False, False, False),
+        ("spliceai", None, True, True),
+        ("cadd", None, True, True),
+        ("clinvar", None, False, True),
+        ("unknown", None, False, True),
+    ],
+)
+def test_dedup_policy(tmp_path, plugin, key, expected, fallback):
+    cache = SyntheticCache(tmp_path, plugin=plugin, assume_unique=key)
+    m = manifest.load_manifest(cache.write())
+    assume_unique, detail = manifest.dedup_policy(m)
+    assert assume_unique is expected
+    assert ("fallback" in detail) is fallback
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_cache_qa_manifest.py -q`
+Expected: `ModuleNotFoundError: No module named 'cache_qa'`
+
+- [ ] **Step 4: Implement the package init and manifest module**
+
+`e2e-testing/scripts/cache_qa/__init__.py`:
+
+```python
+"""Plugin cache QA: invariants, content profile, card section, publishing."""
+```
+
+`e2e-testing/scripts/cache_qa/manifest.py`:
+
+```python
+"""Load and validate a plugin cache manifest.json; resolve shards and policy."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import polars as pl
+
+
+class ManifestError(ValueError):
+    """manifest.json is missing, unreadable, or lacks a required key."""
+
+
+MANIFEST_TYPES: dict[str, pl.DataType] = {
+    "Utf8": pl.String,
+    "String": pl.String,
+    "Float32": pl.Float32,
+    "Float64": pl.Float64,
+    "Int8": pl.Int8,
+    "Int16": pl.Int16,
+    "Int32": pl.Int32,
+    "Int64": pl.Int64,
+    "UInt8": pl.UInt8,
+    "UInt16": pl.UInt16,
+    "UInt32": pl.UInt32,
+    "UInt64": pl.UInt64,
+    "Boolean": pl.Boolean,
+}
+
+KEY_TYPES: dict[str, pl.DataType] = {
+    "chrom": pl.String,
+    "start": pl.UInt32,
+    "end": pl.UInt32,
+    "allele_string": pl.String,
+}
+
+# Used only when manifest.json predates engine #234 and has no assume_unique key.
+FALLBACK_ASSUME_UNIQUE: dict[str, bool] = {
+    "clinvar": False,
+    "alphamissense": False,
+    "dbnsfp": False,
+    "spliceai": True,
+    "cadd": True,
+}
+
+
+@dataclass(frozen=True)
+class ContigEntry:
+    chrom: str
+    file: str
+    rows: int
+    warm: int
+    cold: int
+
+    @property
+    def bare(self) -> str:
+        """Shard `chrom` value for this contig: `chr22` -> `22`, `chrMT` -> `MT`."""
+        return self.chrom[3:] if self.chrom.startswith("chr") else self.chrom
+
+
+@dataclass(frozen=True)
+class ColumnSpec:
+    name: str
+    role: str  # key | match | value | tier
+    dtype: pl.DataType
+
+
+@dataclass(frozen=True)
+class CacheManifest:
+    plugin: str
+    plugin_dir: Path
+    cache_source_version: str | None
+    allele_match: str
+    assume_unique: bool | None
+    key_columns: list[str]
+    match_columns: list[str]
+    value_columns: list[tuple[str, str]]  # (column, manifest type name)
+    contigs: list[ContigEntry]
+
+    def expected_schema(self) -> list[ColumnSpec]:
+        specs = [ColumnSpec(c, "key", KEY_TYPES.get(c, pl.String)) for c in self.key_columns]
+        specs += [ColumnSpec(c, "match", pl.String) for c in self.match_columns]
+        specs += [ColumnSpec(c, "value", MANIFEST_TYPES[t]) for c, t in self.value_columns]
+        specs.append(ColumnSpec("tier", "tier", pl.Int8))
+        return specs
+
+    def order_key(self) -> list[str]:
+        return ["tier", "start", "allele_string", *self.match_columns]
+
+    def probe_key(self) -> list[str]:
+        return [*self.key_columns, *self.match_columns]
+
+    def shard_path(self, entry: ContigEntry) -> Path:
+        return self.plugin_dir / entry.file
+
+    def present_shards(self) -> list[tuple[ContigEntry, Path]]:
+        out = []
+        for entry in self.contigs:
+            path = self.shard_path(entry)
+            if path.exists():
+                out.append((entry, path))
+        return out
+
+
+def _require(raw: dict, key: str, path: Path):
+    if key not in raw:
+        raise ManifestError(f"{path}: missing key '{key}'")
+    return raw[key]
+
+
+def load_manifest(plugin_dir: Path) -> CacheManifest:
+    path = Path(plugin_dir) / "manifest.json"
+    if not path.exists():
+        raise ManifestError(f"{path}: no such file")
+    try:
+        raw = json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        raise ManifestError(f"{path}: invalid JSON: {e}") from e
+    value_columns = []
+    for v in _require(raw, "value_columns", path):
+        t = v.get("type", "Utf8")
+        if t not in MANIFEST_TYPES:
+            raise ManifestError(f"{path}: value column '{v.get('column')}' has unknown type '{t}'")
+        value_columns.append((v["column"], t))
+    contigs = [
+        ContigEntry(c["chrom"], c["file"], int(c["rows"]), int(c["warm"]), int(c["cold"]))
+        for c in _require(raw, "chroms", path)
+    ]
+    return CacheManifest(
+        plugin=_require(raw, "plugin_name", path),
+        plugin_dir=Path(plugin_dir),
+        cache_source_version=raw.get("cache_source_version"),
+        allele_match=raw.get("allele_match", "exact"),
+        assume_unique=raw.get("assume_unique"),
+        key_columns=list(_require(raw, "key_columns", path)),
+        match_columns=[m["column"] for m in raw.get("match_columns", [])],
+        value_columns=value_columns,
+        contigs=contigs,
+    )
+
+
+def dedup_policy(m: CacheManifest) -> tuple[bool, str]:
+    """(assume_unique, detail). Manifest key wins; otherwise the per-plugin fallback."""
+    if m.assume_unique is not None:
+        return m.assume_unique, f"manifest assume_unique={str(m.assume_unique).lower()}"
+    value = FALLBACK_ASSUME_UNIQUE.get(m.plugin, False)
+    return value, (
+        f"manifest has no assume_unique key; fallback table says "
+        f"{'assume_unique' if value else 'deduplicated'} for '{m.plugin}'"
+    )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_cache_qa_manifest.py -q`
+Expected: all pass.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+uv run ruff check e2e-testing/scripts/cache_qa tests/test_cache_qa_manifest.py tests/cache_qa_synthetic.py && uv run ruff format e2e-testing/scripts/cache_qa tests/test_cache_qa_manifest.py tests/cache_qa_synthetic.py
+git add e2e-testing/scripts/cache_qa tests/test_cache_qa_manifest.py tests/cache_qa_synthetic.py
+git commit -m "feat(cache_qa): manifest loader, dedup policy, synthetic cache fixture"
+```
+
+---
+
+### Task 2: Per-shard invariants: schema, contig, tier_domain, positions, allele_form
+
+**Files:**
+- Create: `e2e-testing/scripts/cache_qa/invariants.py`
+- Test: `tests/test_cache_qa_invariants.py`
+
+**Interfaces:**
+- Consumes `cache_qa.manifest.CacheManifest`, `ContigEntry`, `ColumnSpec`.
+- Produces `cache_qa.invariants`:
+  - `@dataclass InvariantResult(id: str, status: str, detail: str, per_contig: dict[str, int] | None = None)`; `status in {"pass","fail","warn"}`.
+  - `check_schema(m)`, `check_contig(m)`, `check_tier_domain(m)`, `check_positions(m)`, `check_allele_form(m)` each `-> InvariantResult`.
+  - helper `_count_per_shard(m, expr_builder) -> dict[str, int]` where `expr_builder(entry) -> pl.Expr` is a boolean expression; the count of true rows per present shard.
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/test_cache_qa_invariants.py` (first half; Task 3 appends):
+
+```python
+import polars as pl
+
+from cache_qa import invariants, manifest
+from cache_qa_synthetic import SyntheticCache
+
+
+def _load(cache: SyntheticCache) -> manifest.CacheManifest:
+    return manifest.load_manifest(cache.write())
+
+
+def test_schema_passes_on_clean_cache(tmp_path):
+    r = invariants.check_schema(_load(SyntheticCache(tmp_path)))
+    assert r.status == "pass"
+    assert "3 shards" in r.detail
+
+
+def test_schema_fails_on_wrong_type(tmp_path):
+    cache = SyntheticCache(tmp_path)
+    cache.rows["chr2"] = cache.rows["chr2"].with_columns(pl.col("start").cast(pl.Int64))
+    r = invariants.check_schema(_load(cache))
+    assert r.status == "fail"
+    assert "chr2" in r.detail and "start" in r.detail
+
+
+def test_schema_fails_on_wrong_order(tmp_path):
+    cache = SyntheticCache(tmp_path)
+    df = cache.rows["chr1"]
+    cache.rows["chr1"] = df.select([c for c in df.columns if c != "score"] + ["score"])
+    r = invariants.check_schema(_load(cache))
+    assert r.status == "fail" and "chr1" in r.detail
+
+
+def test_contig_counts_foreign_rows(tmp_path):
+    cache = SyntheticCache(tmp_path)
+    df = cache.rows["chr1"]
+    cache.rows["chr1"] = df.with_columns(
+        pl.when(pl.arange(0, df.height) == 0).then(pl.lit("2")).otherwise(pl.col("chrom")).alias("chrom")
+    )
+    r = invariants.check_contig(_load(cache))
+    assert r.status == "fail"
+    assert r.per_contig == {"chr1": 1}
+
+
+def test_contig_passes(tmp_path):
+    assert invariants.check_contig(_load(SyntheticCache(tmp_path))).status == "pass"
+
+
+def test_tier_domain_fails_on_two(tmp_path):
+    cache = SyntheticCache(tmp_path)
+    df = cache.rows["chrX"]
+    cache.rows["chrX"] = df.with_columns(
+        pl.when(pl.arange(0, df.height) == df.height - 1).then(2).otherwise(pl.col("tier")).cast(pl.Int8).alias("tier")
+    )
+    r = invariants.check_tier_domain(_load(cache))
+    assert r.status == "fail" and r.per_contig == {"chrX": 1}
+
+
+def test_positions_flags_end_before_start_minus_one(tmp_path):
+    cache = SyntheticCache(tmp_path)
+    df = cache.rows["chr2"]
+    cache.rows["chr2"] = df.with_columns(
+        pl.when(pl.arange(0, df.height) == 1).then(pl.col("start") - 2).otherwise(pl.col("end")).cast(pl.UInt32).alias("end")
+    )
+    r = invariants.check_positions(_load(cache))
+    assert r.status == "fail" and r.per_contig == {"chr2": 1}
+
+
+def test_positions_allows_insertion(tmp_path):
+    cache = SyntheticCache(tmp_path)
+    df = cache.rows["chr2"]
+    cache.rows["chr2"] = df.with_columns((pl.col("start") - 1).cast(pl.UInt32).alias("end"))
+    assert invariants.check_positions(_load(cache)).status == "pass"
+
+
+def test_allele_form_exact_accepts_shared_base(tmp_path):
+    cache = SyntheticCache(tmp_path, allele_match="exact")
+    cache.rows["chr1"] = cache.rows["chr1"].with_columns(pl.lit("AC/AT").alias("allele_string"))
+    assert invariants.check_allele_form(_load(cache)).status == "pass"
+
+
+def test_allele_form_minimised_rejects_shared_base(tmp_path):
+    cache = SyntheticCache(tmp_path, allele_match="minimised")
+    df = cache.rows["chr1"]
+    cache.rows["chr1"] = df.with_columns(
+        pl.when(pl.arange(0, df.height) == 0).then(pl.lit("AC/AT")).otherwise(pl.col("allele_string")).alias("allele_string")
+    )
+    r = invariants.check_allele_form(_load(cache))
+    assert r.status == "fail" and r.per_contig == {"chr1": 1}
+
+
+def test_allele_form_minimised_allows_dash(tmp_path):
+    cache = SyntheticCache(tmp_path, allele_match="minimised")
+    cache.rows["chr1"] = cache.rows["chr1"].with_columns(pl.lit("-/A").alias("allele_string"))
+    assert invariants.check_allele_form(_load(cache)).status == "pass"
+
+
+def test_allele_form_rejects_missing_slash_or_empty_part(tmp_path):
+    cache = SyntheticCache(tmp_path)
+    df = cache.rows["chrX"]
+    cache.rows["chrX"] = df.with_columns(
+        pl.when(pl.arange(0, df.height) == 0).then(pl.lit("A"))
+        .when(pl.arange(0, df.height) == 1).then(pl.lit("A/"))
+        .otherwise(pl.col("allele_string")).alias("allele_string")
+    )
+    r = invariants.check_allele_form(_load(cache))
+    assert r.status == "fail" and r.per_contig == {"chrX": 2}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_cache_qa_invariants.py -q`
+Expected: `ImportError: cannot import name 'invariants'`
+
+- [ ] **Step 3: Implement the module**
+
+`e2e-testing/scripts/cache_qa/invariants.py`:
+
+```python
+"""Structural invariants over a plugin cache. Each check is a lazy per-shard scan reduced to counts."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import polars as pl
+
+from cache_qa.manifest import CacheManifest, ContigEntry
+
+
+@dataclass
+class InvariantResult:
+    id: str
+    status: str  # pass | fail | warn
+    detail: str
+    per_contig: dict[str, int] | None = None
+
+
+def _count_per_shard(
+    m: CacheManifest, expr_builder: Callable[[ContigEntry], pl.Expr]
+) -> dict[str, int]:
+    """Count rows where `expr_builder(entry)` is true, per present shard (projection pushed down)."""
+    counts: dict[str, int] = {}
+    for entry, path in m.present_shards():
+        n = (
+            pl.scan_parquet(path)
+            .select(expr_builder(entry).fill_null(False).cast(pl.UInt64).sum().alias("n"))
+            .collect()
+            .item()
+        )
+        counts[entry.chrom] = int(n or 0)
+    return counts
+
+
+def _result(id_: str, counts: dict[str, int], noun: str, status_on_hit: str = "fail") -> InvariantResult:
+    bad = {k: v for k, v in counts.items() if v}
+    if not bad:
+        return InvariantResult(id_, "pass", f"0 {noun} in {len(counts)} shards")
+    total = sum(bad.values())
+    return InvariantResult(id_, status_on_hit, f"{total} {noun} in {len(bad)} shards", bad)
+
+
+def check_schema(m: CacheManifest) -> InvariantResult:
+    expected = [(s.name, s.dtype) for s in m.expected_schema()]
+    problems = []
+    n = 0
+    for entry, path in m.present_shards():
+        n += 1
+        actual = list(pl.scan_parquet(path).collect_schema().items())
+        for i, exp in enumerate(expected):
+            act = actual[i] if i < len(actual) else None
+            if act is None or act[0] != exp[0] or act[1] != exp[1]:
+                problems.append(f"{entry.chrom}: expected {exp[0]} {exp[1]}, found {act}")
+                break
+        else:
+            if len(actual) > len(expected):
+                problems.append(f"{entry.chrom}: extra column {actual[len(expected)][0]}")
+    if problems:
+        return InvariantResult("schema", "fail", "; ".join(problems))
+    return InvariantResult("schema", "pass", f"{n} shards match the manifest")
+
+
+def check_contig(m: CacheManifest) -> InvariantResult:
+    counts = _count_per_shard(m, lambda e: pl.col("chrom") != e.bare)
+    return _result("contig", counts, "foreign-contig rows")
+
+
+def check_tier_domain(m: CacheManifest) -> InvariantResult:
+    counts = _count_per_shard(m, lambda e: pl.col("tier").is_null() | ~pl.col("tier").is_in([0, 1]))
+    return _result("tier_domain", counts, "rows with tier outside {0,1}")
+
+
+def check_positions(m: CacheManifest) -> InvariantResult:
+    start = pl.col("start").cast(pl.Int64)
+    end = pl.col("end").cast(pl.Int64)
+    counts = _count_per_shard(m, lambda e: (start < 1) | (end < start - 1))
+    return _result("positions", counts, "rows with start < 1 or end < start - 1")
+
+
+def _allele_violation(allele_match: str) -> pl.Expr:
+    parts = pl.col("allele_string").str.split_exact("/", 1)
+    ref = parts.struct.field("field_0")
+    alt = parts.struct.field("field_1")
+    bad = ref.is_null() | alt.is_null() | (ref == "") | (alt == "")
+    if allele_match == "minimised":
+        shared = (ref.str.slice(0, 1) == alt.str.slice(0, 1)) & (ref != "-") & (alt != "-")
+        bad = bad | shared.fill_null(False)
+    return bad
+
+
+def check_allele_form(m: CacheManifest) -> InvariantResult:
+    counts = _count_per_shard(m, lambda e: _allele_violation(m.allele_match))
+    return _result("allele_form", counts, "malformed allele strings")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_cache_qa_invariants.py -q`
+Expected: all pass. If `split_exact` on a value without `/` yields nulls rather than raising, the `A` case counts as a violation through `alt.is_null()`; if a Polars version raises instead, wrap with `.str.split_exact("/", 1)` on `pl.when(pl.col("allele_string").str.contains("/"))` and count the non-matching rows separately.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+uv run ruff check e2e-testing/scripts/cache_qa tests/test_cache_qa_invariants.py && uv run ruff format e2e-testing/scripts/cache_qa tests/test_cache_qa_invariants.py
+git add e2e-testing/scripts/cache_qa/invariants.py tests/test_cache_qa_invariants.py
+git commit -m "feat(cache_qa): schema, contig, tier, position and allele-form invariants"
+```
+
+---
+
+### Task 3: Cross-row invariants: order, duplicates, manifest_counts, manifest_files; run_all
+
+**Files:**
+- Modify: `e2e-testing/scripts/cache_qa/invariants.py`
+- Test: `tests/test_cache_qa_invariants.py` (append)
+
+**Interfaces:**
+- Produces in `cache_qa.invariants`: `check_order(m)`, `check_duplicates(m)`, `check_manifest_counts(m)`, `check_manifest_files(m)`, `run_all(m) -> list[InvariantResult]` in the spec's table order (`schema, contig, order, tier_domain, manifest_counts, manifest_files, positions, allele_form, duplicates`), and `descending_steps(cols: list[str]) -> pl.Expr`.
+
+- [ ] **Step 1: Append the failing tests**
+
+```python
+def test_order_passes_on_sorted_cache(tmp_path):
+    r = invariants.check_order(_load(SyntheticCache(tmp_path)))
+    assert r.status == "pass" and "0 descending steps" in r.detail
+
+
+def test_order_counts_one_swapped_pair(tmp_path):
+    cache = SyntheticCache(tmp_path)
+    df = cache.rows["chr1"]
+    idx = list(range(df.height))
+    idx[3], idx[4] = idx[4], idx[3]
+    cache.rows["chr1"] = df[idx]
+    r = invariants.check_order(_load(cache))
+    assert r.status == "fail" and r.per_contig == {"chr1": 1}
+
+
+def test_order_uses_match_column_as_final_key(tmp_path):
+    cache = SyntheticCache(tmp_path)
+    df = cache.rows["chr2"]
+    # same tier/start/allele, symbol descending -> one descending step
+    two = df.head(1).with_columns(pl.lit("B").alias("symbol")).vstack(
+        df.head(1).with_columns(pl.lit("A").alias("symbol"))
+    )
+    cache.rows["chr2"] = two
+    r = invariants.check_order(_load(cache))
+    assert r.per_contig == {"chr2": 1}
+
+
+def test_duplicates_fail_when_deduplicated(tmp_path):
+    cache = SyntheticCache(tmp_path, assume_unique=False)
+    df = cache.rows["chr1"]
+    cache.rows["chr1"] = df.vstack(df.head(1)).sort(["tier", "start", "allele_string", "symbol"])
+    r = invariants.check_duplicates(_load(cache))
+    assert r.status == "fail" and r.per_contig == {"chr1": 1}
+
+
+def test_duplicates_warn_when_assume_unique(tmp_path):
+    cache = SyntheticCache(tmp_path, assume_unique=True)
+    df = cache.rows["chr1"]
+    cache.rows["chr1"] = df.vstack(df.head(2)).sort(["tier", "start", "allele_string", "symbol"])
+    r = invariants.check_duplicates(_load(cache))
+    assert r.status == "warn" and r.per_contig == {"chr1": 2}
+    assert "assume_unique" in r.detail
+
+
+def test_duplicates_detail_mentions_fallback(tmp_path):
+    cache = SyntheticCache(tmp_path, plugin="spliceai", assume_unique=None)
+    r = invariants.check_duplicates(_load(cache))
+    assert r.status == "pass" and "fallback" in r.detail
+
+
+def test_manifest_counts_off_by_one(tmp_path):
+    cache = SyntheticCache(tmp_path)
+    m = cache.manifest_dict()
+    m["chroms"][1]["warm"] += 1
+    cache.set_manifest(m)
+    r = invariants.check_manifest_counts(_load(cache))
+    assert r.status == "fail" and "chr2" in r.detail and "warm" in r.detail
+
+
+def test_manifest_counts_pass(tmp_path):
+    assert invariants.check_manifest_counts(_load(SyntheticCache(tmp_path))).status == "pass"
+
+
+def test_manifest_files_missing_with_rows_fails(tmp_path):
+    cache = SyntheticCache(tmp_path)
+    plugin_dir = cache.write()
+    (plugin_dir / "chr2.parquet").unlink()
+    r = invariants.check_manifest_files(manifest.load_manifest(plugin_dir))
+    assert r.status == "fail" and "chr2.parquet" in r.detail
+
+
+def test_manifest_files_missing_with_zero_rows_allowed(tmp_path):
+    cache = SyntheticCache(tmp_path)
+    m = cache.manifest_dict()
+    m["chroms"].append({"chrom": "chrMT", "file": "chrMT.parquet", "rows": 0, "warm": 0, "cold": 0})
+    cache.set_manifest(m)
+    r = invariants.check_manifest_files(_load(cache))
+    assert r.status == "pass"
+
+
+def test_manifest_files_unlisted_shard_fails(tmp_path):
+    cache = SyntheticCache(tmp_path)
+    plugin_dir = cache.write()
+    cache.rows["chr1"].write_parquet(plugin_dir / "chr9.parquet")
+    r = invariants.check_manifest_files(manifest.load_manifest(plugin_dir))
+    assert r.status == "fail" and "chr9.parquet" in r.detail
+
+
+def test_run_all_order_and_ids(tmp_path):
+    results = invariants.run_all(_load(SyntheticCache(tmp_path)))
+    assert [r.id for r in results] == [
+        "schema", "contig", "order", "tier_domain", "manifest_counts",
+        "manifest_files", "positions", "allele_form", "duplicates",
+    ]
+    assert all(r.status == "pass" for r in results)
+```
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+Run: `uv run pytest tests/test_cache_qa_invariants.py -q`
+Expected: the new tests fail with `AttributeError: module 'cache_qa.invariants' has no attribute 'check_order'` (or similar); Task 2 tests still pass.
+
+- [ ] **Step 3: Append the implementations**
+
+Add to `e2e-testing/scripts/cache_qa/invariants.py` (below `check_allele_form`):
+
+```python
+def descending_steps(cols: list[str]) -> pl.Expr:
+    """True where row i is lexicographically smaller than row i-1 on `cols` (nulls never count)."""
+    step = pl.lit(False)
+    equal_prefix = pl.lit(True)
+    for c in cols:
+        cur, prev = pl.col(c), pl.col(c).shift(1)
+        step = step | (equal_prefix & (cur < prev))
+        equal_prefix = equal_prefix & (cur == prev)
+    return step.fill_null(False)
+
+
+def check_order(m: CacheManifest) -> InvariantResult:
+    key = m.order_key()
+    counts = _count_per_shard(m, lambda e: descending_steps(key))
+    return _result("order", counts, "descending steps")
+
+
+def check_duplicates(m: CacheManifest) -> InvariantResult:
+    from cache_qa.manifest import dedup_policy
+
+    assume_unique, policy = dedup_policy(m)
+    key = m.probe_key()
+    counts: dict[str, int] = {}
+    for entry, path in m.present_shards():
+        n = (
+            pl.scan_parquet(path)
+            .group_by(key)
+            .len()
+            .filter(pl.col("len") > 1)
+            .select((pl.col("len") - 1).sum().alias("n"))
+            .collect(engine="streaming")
+            .item()
+        )
+        counts[entry.chrom] = int(n or 0)
+    r = _result("duplicates", counts, "duplicate probe keys", "warn" if assume_unique else "fail")
+    r.detail = f"{r.detail} ({policy})"
+    return r
+
+
+def check_manifest_counts(m: CacheManifest) -> InvariantResult:
+    problems = []
+    checked = 0
+    for entry, path in m.present_shards():
+        checked += 1
+        found = (
+            pl.scan_parquet(path)
+            .select(
+                pl.len().alias("rows"),
+                (pl.col("tier") == 0).sum().alias("warm"),
+                (pl.col("tier") == 1).sum().alias("cold"),
+            )
+            .collect()
+            .row(0, named=True)
+        )
+        for field in ("rows", "warm", "cold"):
+            expected = getattr(entry, field)
+            if int(found[field]) != expected:
+                problems.append(f"{entry.chrom} {field}: manifest {expected}, shard {int(found[field])}")
+    if problems:
+        return InvariantResult("manifest_counts", "fail", "; ".join(problems))
+    return InvariantResult("manifest_counts", "pass", f"rows/warm/cold match in {checked} shards")
+
+
+def check_manifest_files(m: CacheManifest) -> InvariantResult:
+    missing = [e.file for e in m.contigs if e.rows > 0 and not m.shard_path(e).exists()]
+    listed = {e.file for e in m.contigs}
+    unlisted = sorted(p.name for p in m.plugin_dir.glob("chr*.parquet") if p.name not in listed)
+    problems = []
+    if missing:
+        problems.append("missing: " + ", ".join(missing))
+    if unlisted:
+        problems.append("unlisted: " + ", ".join(unlisted))
+    if problems:
+        return InvariantResult("manifest_files", "fail", "; ".join(problems))
+    return InvariantResult("manifest_files", "pass", f"{len(listed)} manifest contigs, no stray shards")
+
+
+def run_all(m: CacheManifest) -> list[InvariantResult]:
+    return [
+        check_schema(m),
+        check_contig(m),
+        check_order(m),
+        check_tier_domain(m),
+        check_manifest_counts(m),
+        check_manifest_files(m),
+        check_positions(m),
+        check_allele_form(m),
+        check_duplicates(m),
+    ]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_cache_qa_invariants.py -q`
+Expected: all pass.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+uv run ruff check e2e-testing/scripts/cache_qa tests/test_cache_qa_invariants.py && uv run ruff format e2e-testing/scripts/cache_qa tests/test_cache_qa_invariants.py
+git add e2e-testing/scripts/cache_qa/invariants.py tests/test_cache_qa_invariants.py
+git commit -m "feat(cache_qa): order, duplicate, manifest count and file invariants"
+```
+
+---
+
+### Task 4: Content profile
+
+**Files:**
+- Create: `e2e-testing/scripts/cache_qa/profile.py`
+- Test: `tests/test_cache_qa_profile.py`
+
+**Interfaces:**
+- Consumes `CacheManifest`.
+- Produces `cache_qa.profile`:
+  - `@dataclass ContigStats(chrom, file, rows, warm, cold, warm_share, bytes, start_min, start_max)`
+  - `@dataclass NumericStats(parsable_share: float, min: float, max: float, mean: float, p50: float, p95: float)`
+  - `@dataclass ColumnStats(name, role, dtype: str, null_share, empty_share: float | None, distinct: int | None, approx: bool, top_values: list[tuple[str, int]] | None, numeric: NumericStats | None, per_contig: dict[str, dict[str, float]])`
+  - `@dataclass Profile(contigs: list[ContigStats], columns: list[ColumnStats], rows: int, warm: int, cold: int, bytes: int)`
+  - `profile_cache(m: CacheManifest) -> Profile`
+  - constants `EXACT_DISTINCT_MAX = 10_000`, `TOP_VALUES_MAX_DISTINCT = 50`, `TOP_VALUES_N = 10`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/test_cache_qa_profile.py`:
+
+```python
+import polars as pl
+import pytest
+
+from cache_qa import manifest, profile
+from cache_qa_synthetic import SyntheticCache
+
+
+@pytest.fixture
+def prof(tmp_path):
+    cache = SyntheticCache(tmp_path)
+    # chr1: 6 rows, score empty at i % 3 == 0 -> 2 empties; one null raw
+    df = cache.rows["chr1"]
+    cache.rows["chr1"] = df.with_columns(
+        pl.when(pl.arange(0, df.height) == 5).then(None).otherwise(pl.col("raw")).cast(pl.Float32).alias("raw")
+    )
+    m = manifest.load_manifest(cache.write())
+    return profile.profile_cache(m), m
+
+
+def test_contig_table(prof):
+    p, m = prof
+    by = {c.chrom: c for c in p.contigs}
+    assert by["chr1"].rows == 6 and by["chr1"].warm == 2 and by["chr1"].cold == 4
+    assert by["chr1"].warm_share == pytest.approx(2 / 6)
+    assert by["chr1"].start_min == 100 and by["chr1"].start_max == 150
+    assert by["chr1"].bytes == (m.plugin_dir / "chr1.parquet").stat().st_size
+    assert p.rows == 13 and p.warm == 6 and p.cold == 7
+    assert p.bytes == sum(c.bytes for c in p.contigs)
+
+
+def test_column_roles_and_null_share(prof):
+    p, _ = prof
+    cols = {c.name: c for c in p.columns}
+    assert cols["chrom"].role == "key" and cols["tier"].role == "tier"
+    assert cols["symbol"].role == "match" and cols["score"].role == "value"
+    assert cols["raw"].null_share == pytest.approx(1 / 13)
+    assert cols["raw"].per_contig["chr1"]["null_share"] == pytest.approx(1 / 6)
+    assert cols["chrom"].distinct is None  # key columns get only the null share
+
+
+def test_empty_share_counts_empty_string_and_dot(tmp_path):
+    cache = SyntheticCache(tmp_path)
+    cache.rows["chr2"] = cache.rows["chr2"].with_columns(pl.lit(".").alias("score"))
+    p = profile.profile_cache(manifest.load_manifest(cache.write()))
+    score = next(c for c in p.columns if c.name == "score")
+    # chr1: 2 empties of 6; chr2: 4 dots of 4; chrX: 1 empty of 3
+    assert score.empty_share == pytest.approx(7 / 13)
+    assert score.per_contig["chr2"]["empty_share"] == pytest.approx(1.0)
+
+
+def test_exact_distinct_and_top_values(prof):
+    p, _ = prof
+    symbol = next(c for c in p.columns if c.name == "symbol")
+    assert symbol.distinct == 3 and symbol.approx is False
+    assert symbol.top_values[0] == ("GENE1", 6)
+    assert [v for v, _ in symbol.top_values] == ["GENE1", "GENE2", "GENEX"]
+
+
+def test_numeric_on_parsable_text(prof):
+    p, _ = prof
+    score = next(c for c in p.columns if c.name == "score")
+    assert score.numeric is not None
+    assert score.numeric.parsable_share == pytest.approx(9 / 13)
+    assert score.numeric.min == 0.5 and score.numeric.max == 0.5
+
+
+def test_numeric_on_float_column(prof):
+    p, _ = prof
+    raw = next(c for c in p.columns if c.name == "raw")
+    assert raw.numeric.parsable_share == pytest.approx(12 / 13)
+    assert raw.numeric.min == 0.0 and raw.numeric.max == 5.0
+    assert raw.empty_share is None
+
+
+def test_top_values_capped_at_ten_and_absent_above_fifty_distinct(tmp_path, monkeypatch):
+    cache = SyntheticCache(tmp_path)
+    for chrom, df in cache.rows.items():
+        cache.rows[chrom] = df.with_columns(
+            (pl.lit(chrom) + pl.arange(0, df.height).cast(pl.String)).alias("symbol")
+        )
+    m = manifest.load_manifest(cache.write())
+    symbol = next(c for c in profile.profile_cache(m).columns if c.name == "symbol")
+    assert symbol.distinct == 13 and len(symbol.top_values) == profile.TOP_VALUES_N
+    monkeypatch.setattr(profile, "TOP_VALUES_MAX_DISTINCT", 12)
+    symbol = next(c for c in profile.profile_cache(m).columns if c.name == "symbol")
+    assert symbol.top_values is None
+
+
+def test_profile_runs_with_missing_zero_row_shard(tmp_path):
+    cache = SyntheticCache(tmp_path)
+    m = cache.manifest_dict()
+    m["chroms"].append({"chrom": "chrMT", "file": "chrMT.parquet", "rows": 0, "warm": 0, "cold": 0})
+    cache.set_manifest(m)
+    p = profile.profile_cache(manifest.load_manifest(cache.write()))
+    assert [c.chrom for c in p.contigs] == ["chr1", "chr2", "chrX", "chrMT"]
+    assert p.contigs[-1].rows == 0 and p.contigs[-1].bytes == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_cache_qa_profile.py -q`
+Expected: `ImportError: cannot import name 'profile'`
+
+- [ ] **Step 3: Implement the module**
+
+`e2e-testing/scripts/cache_qa/profile.py`:
+
+```python
+"""Content profile of a plugin cache: contig table and per-column statistics (Polars, streaming)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import polars as pl
+
+from cache_qa.manifest import CacheManifest, ColumnSpec
+
+EXACT_DISTINCT_MAX = 10_000
+TOP_VALUES_MAX_DISTINCT = 50
+TOP_VALUES_N = 10
+
+
+@dataclass
+class ContigStats:
+    chrom: str
+    file: str
+    rows: int
+    warm: int
+    cold: int
+    warm_share: float
+    bytes: int
+    start_min: int | None
+    start_max: int | None
+
+
+@dataclass
+class NumericStats:
+    parsable_share: float
+    min: float
+    max: float
+    mean: float
+    p50: float
+    p95: float
+
+
+@dataclass
+class ColumnStats:
+    name: str
+    role: str
+    dtype: str
+    null_share: float
+    empty_share: float | None
+    distinct: int | None
+    approx: bool
+    top_values: list[tuple[str, int]] | None
+    numeric: NumericStats | None
+    per_contig: dict[str, dict[str, float]] = field(default_factory=dict)
+
+
+@dataclass
+class Profile:
+    contigs: list[ContigStats]
+    columns: list[ColumnStats]
+    rows: int
+    warm: int
+    cold: int
+    bytes: int
+
+
+def _is_text(spec: ColumnSpec) -> bool:
+    return spec.dtype == pl.String
+
+
+def _is_numeric(spec: ColumnSpec) -> bool:
+    return spec.dtype.is_numeric()
+
+
+def _share(num: int | float | None, den: int) -> float:
+    return float(num or 0) / den if den else 0.0
+
+
+def _contig_table(m: CacheManifest, lf: pl.LazyFrame) -> list[ContigStats]:
+    per = (
+        lf.group_by("chrom")
+        .agg(
+            pl.len().alias("rows"),
+            (pl.col("tier") == 0).sum().alias("warm"),
+            (pl.col("tier") == 1).sum().alias("cold"),
+            pl.col("start").min().alias("start_min"),
+            pl.col("start").max().alias("start_max"),
+        )
+        .collect(engine="streaming")
+    )
+    found = {r["chrom"]: r for r in per.to_dicts()}
+    out = []
+    for entry in m.contigs:
+        path = m.shard_path(entry)
+        size = path.stat().st_size if path.exists() else 0
+        r = found.get(entry.bare)
+        if r is None:
+            out.append(ContigStats(entry.chrom, entry.file, 0, 0, 0, 0.0, size, None, None))
+            continue
+        out.append(
+            ContigStats(
+                entry.chrom, entry.file, int(r["rows"]), int(r["warm"]), int(r["cold"]),
+                _share(r["warm"], int(r["rows"])), size, int(r["start_min"]), int(r["start_max"]),
+            )
+        )
+    return out
+
+
+def _empty_expr(name: str) -> pl.Expr:
+    return (pl.col(name) == "") | (pl.col(name) == ".")
+
+
+def _column_stats(m: CacheManifest, lf: pl.LazyFrame, total_rows: int, bare_to_chrom: dict[str, str]) -> list[ColumnStats]:
+    specs = m.expected_schema()
+    aggs: list[pl.Expr] = []
+    for s in specs:
+        aggs.append(pl.col(s.name).null_count().alias(f"{s.name}__null"))
+        if s.role in ("match", "value") and _is_text(s):
+            aggs.append(_empty_expr(s.name).sum().alias(f"{s.name}__empty"))
+            aggs.append(pl.col(s.name).cast(pl.Float64, strict=False).is_not_null().sum().alias(f"{s.name}__parsable"))
+        if s.role in ("match", "value"):
+            aggs.append(pl.col(s.name).approx_n_unique().alias(f"{s.name}__approx_nunique"))
+    overall = lf.select(aggs).collect(engine="streaming").row(0, named=True)
+    per_contig = lf.group_by("chrom").agg(aggs).collect(engine="streaming").to_dicts()
+
+    out = []
+    for s in specs:
+        null_share = _share(overall[f"{s.name}__null"], total_rows)
+        pc: dict[str, dict[str, float]] = {}
+        for r in per_contig:
+            chrom = bare_to_chrom.get(r["chrom"], r["chrom"])
+            # raw counts; profile_cache turns them into shares once contig row counts are known
+            pc[chrom] = {"_null": int(r[f"{s.name}__null"])}
+            if f"{s.name}__empty" in r:
+                pc[chrom]["_empty"] = int(r[f"{s.name}__empty"])
+        if s.role in ("key", "tier"):
+            out.append(ColumnStats(s.name, s.role, str(s.dtype), null_share, None, None, False, None, None, pc))
+            continue
+
+        empty_share = _share(overall.get(f"{s.name}__empty"), total_rows) if _is_text(s) else None
+        approx_n = int(overall[f"{s.name}__approx_nunique"] or 0)
+        if approx_n <= EXACT_DISTINCT_MAX:
+            distinct = int(lf.select(pl.col(s.name).n_unique()).collect(engine="streaming").item())
+            approx = False
+        else:
+            distinct, approx = approx_n, True
+
+        top_values = None
+        if distinct <= TOP_VALUES_MAX_DISTINCT:
+            top = (
+                lf.group_by(s.name).len().sort(["len", s.name], descending=[True, False])
+                .head(TOP_VALUES_N).collect(engine="streaming")
+            )
+            top_values = [(str(v), int(n)) for v, n in top.iter_rows()]
+
+        numeric = None
+        parsable = int(overall.get(f"{s.name}__parsable") or 0) if _is_text(s) else total_rows - int(overall[f"{s.name}__null"])
+        if _is_numeric(s) or (_is_text(s) and parsable > 0):
+            col = pl.col(s.name).cast(pl.Float64, strict=False)
+            q = lf.select(
+                col.min().alias("min"), col.max().alias("max"), col.mean().alias("mean"),
+                col.quantile(0.5).alias("p50"), col.quantile(0.95).alias("p95"),
+            ).collect(engine="streaming").row(0, named=True)
+            numeric = NumericStats(
+                _share(parsable, total_rows), float(q["min"]), float(q["max"]),
+                float(q["mean"]), float(q["p50"]), float(q["p95"]),
+            )
+        out.append(ColumnStats(s.name, s.role, str(s.dtype), null_share, empty_share, distinct, approx, top_values, numeric, pc))
+    return out
+
+
+def profile_cache(m: CacheManifest) -> Profile:
+    files = [str(p) for _, p in m.present_shards()]
+    lf = pl.scan_parquet(files)
+    contigs = _contig_table(m, lf)
+    rows = sum(c.rows for c in contigs)
+    bare_to_chrom = {e.bare: e.chrom for e in m.contigs}
+    columns = _column_stats(m, lf, rows, bare_to_chrom)
+    rows_by_chrom = {c.chrom: c.rows for c in contigs}
+    for col in columns:  # turn raw per-contig counts into shares
+        for chrom, raw in list(col.per_contig.items()):
+            n = rows_by_chrom.get(chrom, 0)
+            shares = {"null_share": _share(raw["_null"], n)}
+            if "_empty" in raw:
+                shares["empty_share"] = _share(raw["_empty"], n)
+            col.per_contig[chrom] = shares
+    return Profile(
+        contigs=contigs,
+        columns=columns,
+        rows=rows,
+        warm=sum(c.warm for c in contigs),
+        cold=sum(c.cold for c in contigs),
+        bytes=sum(c.bytes for c in contigs),
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_cache_qa_profile.py -q`
+Expected: all pass. If `approx_n_unique` is unavailable on a dtype, replace it with `n_unique()` for that column (small caches) and keep `approx=False`.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+uv run ruff check e2e-testing/scripts/cache_qa tests/test_cache_qa_profile.py && uv run ruff format e2e-testing/scripts/cache_qa tests/test_cache_qa_profile.py
+git add e2e-testing/scripts/cache_qa/profile.py tests/test_cache_qa_profile.py
+git commit -m "feat(cache_qa): contig table and per-column content profile"
+```
+
+---
+
+### Task 5: Report assembly (`qa_profile.json`)
+
+**Files:**
+- Create: `e2e-testing/scripts/cache_qa/report.py`
+- Test: `tests/test_cache_qa_report.py`
+
+**Interfaces:**
+- Consumes `InvariantResult`, `Profile`, `CacheManifest`.
+- Produces `cache_qa.report`:
+  - `SCHEMA_VERSION = 1`
+  - `overall_status(results: list[InvariantResult]) -> str`
+  - `build_report(m: CacheManifest, results, profile: Profile, generated_at: str, tool: dict[str, str]) -> dict`
+  - `tool_versions() -> dict[str, str]` (`{"vepyr": …, "polars": …, "schema_version": 1}`; vepyr version from `importlib.metadata.version("vepyr")` falling back to `"unknown"`).
+  - `write_report(report: dict, path: Path) -> None` (pretty JSON, trailing newline).
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/test_cache_qa_report.py`:
+
+```python
+import json
+
+from cache_qa import invariants, manifest, profile, report
+from cache_qa_synthetic import SyntheticCache
+
+
+def _inputs(tmp_path):
+    m = manifest.load_manifest(SyntheticCache(tmp_path).write())
+    return m, invariants.run_all(m), profile.profile_cache(m)
+
+
+def test_status_aggregation():
+    R = invariants.InvariantResult
+    assert report.overall_status([R("a", "pass", "")]) == "pass"
+    assert report.overall_status([R("a", "pass", ""), R("b", "warn", "")]) == "warn"
+    assert report.overall_status([R("a", "warn", ""), R("b", "fail", "")]) == "fail"
+
+
+def test_report_keys_and_values(tmp_path):
+    m, results, prof = _inputs(tmp_path)
+    r = report.build_report(m, results, prof, "2026-09-05T12:00:00Z", {"vepyr": "0.4.0", "polars": "1.39.3", "schema_version": 1})
+    assert set(r) == {"plugin", "cache_source_version", "generated_at", "tool", "status", "invariants", "summary", "contigs", "columns"}
+    assert r["plugin"] == "demo" and r["status"] == "pass"
+    assert r["tool"]["schema_version"] == 1
+    assert r["summary"] == {"rows": 13, "warm": 6, "cold": 7, "bytes": prof.bytes, "contigs": 3}
+    assert r["invariants"][0] == {"id": "schema", "status": "pass", "detail": "3 shards match the manifest"}
+    assert r["contigs"][0]["chrom"] == "chr1" and r["contigs"][0]["warm_share"] == 2 / 6
+    col = next(c for c in r["columns"] if c["name"] == "symbol")
+    assert col["top_values"][0] == ["GENE1", 6] and col["numeric"] is None
+
+
+def test_per_contig_only_when_present(tmp_path):
+    m, results, prof = _inputs(tmp_path)
+    results[1].per_contig = {"chr1": 2}
+    r = report.build_report(m, results, prof, "t", report.tool_versions())
+    assert r["invariants"][1]["per_contig"] == {"chr1": 2}
+    assert "per_contig" not in r["invariants"][0]
+
+
+def test_write_report_roundtrip(tmp_path):
+    m, results, prof = _inputs(tmp_path)
+    r = report.build_report(m, results, prof, "t", report.tool_versions())
+    out = tmp_path / "qa_profile.json"
+    report.write_report(r, out)
+    text = out.read_text()
+    assert text.endswith("}\n") and json.loads(text) == r
+
+
+def test_tool_versions_has_polars():
+    t = report.tool_versions()
+    assert t["schema_version"] == 1 and t["polars"].count(".") >= 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_cache_qa_report.py -q`
+Expected: `ImportError: cannot import name 'report'`
+
+- [ ] **Step 3: Implement the module**
+
+`e2e-testing/scripts/cache_qa/report.py`:
+
+```python
+"""Assemble qa_profile.json from invariant results and the content profile."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from importlib import metadata
+from pathlib import Path
+
+import polars as pl
+
+from cache_qa.invariants import InvariantResult
+from cache_qa.manifest import CacheManifest
+from cache_qa.profile import Profile
+
+SCHEMA_VERSION = 1
+
+
+def overall_status(results: list[InvariantResult]) -> str:
+    statuses = {r.status for r in results}
+    if "fail" in statuses:
+        return "fail"
+    if "warn" in statuses:
+        return "warn"
+    return "pass"
+
+
+def tool_versions() -> dict[str, str | int]:
+    try:
+        vepyr_version = metadata.version("vepyr")
+    except metadata.PackageNotFoundError:
+        vepyr_version = "unknown"
+    return {"vepyr": vepyr_version, "polars": pl.__version__, "schema_version": SCHEMA_VERSION}
+
+
+def _invariant_dict(r: InvariantResult) -> dict:
+    d = {"id": r.id, "status": r.status, "detail": r.detail}
+    if r.per_contig:
+        d["per_contig"] = dict(r.per_contig)
+    return d
+
+
+def _column_dict(c) -> dict:
+    d = asdict(c)
+    if d["top_values"] is not None:
+        d["top_values"] = [[v, n] for v, n in d["top_values"]]
+    return d
+
+
+def build_report(
+    m: CacheManifest,
+    results: list[InvariantResult],
+    profile: Profile,
+    generated_at: str,
+    tool: dict[str, str | int],
+) -> dict:
+    return {
+        "plugin": m.plugin,
+        "cache_source_version": m.cache_source_version,
+        "generated_at": generated_at,
+        "tool": dict(tool),
+        "status": overall_status(results),
+        "invariants": [_invariant_dict(r) for r in results],
+        "summary": {
+            "rows": profile.rows,
+            "warm": profile.warm,
+            "cold": profile.cold,
+            "bytes": profile.bytes,
+            "contigs": len(profile.contigs),
+        },
+        "contigs": [asdict(c) for c in profile.contigs],
+        "columns": [_column_dict(c) for c in profile.columns],
+    }
+
+
+def write_report(report: dict, path: Path) -> None:
+    Path(path).write_text(json.dumps(report, indent=2) + "\n")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_cache_qa_report.py -q`
+Expected: all pass.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+uv run ruff check e2e-testing/scripts/cache_qa tests/test_cache_qa_report.py && uv run ruff format e2e-testing/scripts/cache_qa tests/test_cache_qa_report.py
+git add e2e-testing/scripts/cache_qa/report.py tests/test_cache_qa_report.py
+git commit -m "feat(cache_qa): qa_profile.json report assembly"
+```
+
+---
+
+### Task 6: Card section rendering and splicing
+
+**Files:**
+- Create: `e2e-testing/scripts/cache_qa/card.py`
+- Test: `tests/test_cache_qa_card.py`
+
+**Interfaces:**
+- Consumes the report `dict` from Task 5.
+- Produces `cache_qa.card`:
+  - `START = "<!-- qa-profile:start -->"`, `END = "<!-- qa-profile:end -->"`
+  - `render_section(report: dict) -> str` (starts with `## Quality profile`, no markers)
+  - `splice(readme: str, section: str) -> str` (replace between markers; else insert before `## Usage`; else append)
+  - `format_int(n) -> str` (`4,439,569`), `format_bytes(n) -> str` (`7.4 MB`, `85 MB`, `2.2 GB`), `format_pct(x) -> str` (`2.6%`).
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/test_cache_qa_card.py`:
+
+```python
+from cache_qa import card
+
+
+def _report(status="pass"):
+    return {
+        "plugin": "demo",
+        "generated_at": "2026-09-05T12:00:00Z",
+        "tool": {"vepyr": "0.4.0", "polars": "1.39.3", "schema_version": 1},
+        "status": status,
+        "invariants": [
+            {"id": "schema", "status": "pass", "detail": "3 shards match the manifest"},
+            {"id": "duplicates", "status": "warn", "detail": "412 duplicate keys (assume_unique)", "per_contig": {"chr1": 400}},
+        ],
+        "summary": {"rows": 4439569, "warm": 113018, "cold": 4326551, "bytes": 85012345, "contigs": 2},
+        "contigs": [
+            {"chrom": "chr1", "file": "chr1.parquet", "rows": 401099, "warm": 10445, "cold": 390654, "warm_share": 0.026, "bytes": 7400000, "start_min": 1, "start_max": 2},
+            {"chrom": "chrMT", "file": "chrMT.parquet", "rows": 0, "warm": 0, "cold": 0, "warm_share": 0.0, "bytes": 0, "start_min": None, "start_max": None},
+        ],
+        "columns": [
+            {"name": "chrom", "role": "key", "dtype": "String", "null_share": 0.0, "empty_share": None, "distinct": None, "approx": False, "top_values": None, "numeric": None, "per_contig": {}},
+            {"name": "clnsig", "role": "value", "dtype": "String", "null_share": 0.0, "empty_share": 0.0012, "distinct": 31, "approx": False,
+             "top_values": [["Uncertain_significance", 1900000], ["Likely_benign", 1200000]], "numeric": None, "per_contig": {}},
+            {"name": "am", "role": "value", "dtype": "Float32", "null_share": 0.0, "empty_share": None, "distinct": 68000000, "approx": True, "top_values": None,
+             "numeric": {"parsable_share": 1.0, "min": 0.0, "max": 1.0, "mean": 0.3, "p50": 0.121, "p95": 0.912}, "per_contig": {}},
+        ],
+    }
+
+
+def test_render_contains_all_three_tables():
+    s = card.render_section(_report())
+    assert s.startswith("## Quality profile")
+    assert "Generated 2026-09-05 by `profile_plugin_cache.py` (vepyr 0.4.0, Polars 1.39.3)" in s
+    assert "| schema | ✅ pass | 3 shards match the manifest |" in s
+    assert "| duplicates | ⚠️ warn | 412 duplicate keys (assume_unique) |" in s
+    assert "| chr1 | 401,099 | 10,445 | 390,654 | 2.6% | 7.4 MB |" in s
+    assert "| **total** | **4,439,569** | **113,018** | **4,326,551** | **2.5%** | **85 MB** |" in s
+    assert "| clnsig | value | String | 0.00 | 0.12 | 31 | — | Uncertain_significance (1.9M), Likely_benign (1.2M) |" in s
+    assert "| am | value | Float32 | 0.00 | — | ~68M | 0.000 / 0.121 / 0.912 / 1.000 | — |" in s
+    assert "| chrom |" not in s  # key columns are not listed
+
+
+def test_render_marks_fail():
+    r = _report("fail")
+    r["invariants"][0]["status"] = "fail"
+    assert "| schema | ❌ fail |" in card.render_section(r)
+
+
+def test_formatters():
+    assert card.format_int(4439569) == "4,439,569"
+    assert card.format_bytes(7400000) == "7.4 MB"
+    assert card.format_bytes(85012345) == "85 MB"
+    assert card.format_bytes(2237109762) == "2.2 GB"
+    assert card.format_bytes(0) == "0 B"
+    assert card.format_pct(0.026) == "2.6%"
+    assert card.format_count_short(1900000) == "1.9M"
+    assert card.format_count_short(68000000) == "68M"
+    assert card.format_count_short(412) == "412"
+
+
+def test_splice_inserts_before_usage():
+    readme = "# T\n\n## Contents\n\nx\n\n## Usage\n\ny\n"
+    out = card.splice(readme, "## Quality profile\n\nq\n")
+    assert out.index(card.START) < out.index("## Usage")
+    assert out.count(card.START) == 1 and out.count(card.END) == 1
+    assert "## Contents\n\nx\n" in out and out.endswith("## Usage\n\ny\n")
+
+
+def test_splice_replaces_between_markers_idempotently():
+    readme = "# T\n\n## Usage\n\ny\n"
+    once = card.splice(readme, "## Quality profile\n\nv1\n")
+    twice = card.splice(once, "## Quality profile\n\nv2\n")
+    assert "v1" not in twice and "v2" in twice
+    assert twice.count(card.START) == 1
+    assert card.splice(twice, "## Quality profile\n\nv2\n") == twice
+
+
+def test_splice_appends_without_usage():
+    out = card.splice("# T\n\nbody\n", "## Quality profile\n\nq\n")
+    assert out.startswith("# T\n\nbody\n") and out.rstrip().endswith(card.END)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_cache_qa_card.py -q`
+Expected: `ImportError: cannot import name 'card'`
+
+- [ ] **Step 3: Implement the module**
+
+`e2e-testing/scripts/cache_qa/card.py`:
+
+```python
+"""Render the `## Quality profile` card section and splice it into a README."""
+
+from __future__ import annotations
+
+START = "<!-- qa-profile:start -->"
+END = "<!-- qa-profile:end -->"
+_STATUS_ICON = {"pass": "✅", "warn": "⚠️", "fail": "❌"}
+
+
+def format_int(n: int) -> str:
+    return f"{int(n):,}"
+
+
+def format_bytes(n: int) -> str:
+    n = int(n)
+    if n < 1_000:
+        return f"{n} B"
+    for unit, div in (("KB", 1e3), ("MB", 1e6), ("GB", 1e9), ("TB", 1e12)):
+        if n < div * 1000 or unit == "TB":
+            v = n / div
+            return f"{v:.1f} {unit}" if v < 10 else f"{v:.0f} {unit}"
+    raise AssertionError("unreachable")
+
+
+def format_pct(x: float) -> str:
+    return f"{100 * float(x):.1f}%"
+
+
+def format_count_short(n: int) -> str:
+    n = int(n)
+    if n >= 1_000_000:
+        v = n / 1e6
+        return f"{v:.1f}M" if v < 10 else f"{v:.0f}M"
+    if n >= 1_000:
+        v = n / 1e3
+        return f"{v:.1f}K" if v < 10 else f"{v:.0f}K"
+    return str(n)
+
+
+def _numeric_cell(numeric: dict | None) -> str:
+    if not numeric:
+        return "—"
+    return " / ".join(f"{numeric[k]:.3f}" for k in ("min", "p50", "p95", "max"))
+
+
+def _top_cell(top: list | None) -> str:
+    if not top:
+        return "—"
+    return ", ".join(f"{v} ({format_count_short(n)})" for v, n in top)
+
+
+def render_section(report: dict) -> str:
+    tool = report["tool"]
+    lines = [
+        "## Quality profile",
+        "",
+        f"Generated {report['generated_at'][:10]} by `profile_plugin_cache.py` "
+        f"(vepyr {tool['vepyr']}, Polars {tool['polars']}) from the shards in this commit; "
+        "machine-readable copy in [`qa_profile.json`](qa_profile.json).",
+        "",
+        "### Invariants",
+        "",
+        "| check | status | detail |",
+        "|---|---|---|",
+    ]
+    for inv in report["invariants"]:
+        icon = _STATUS_ICON[inv["status"]]
+        lines.append(f"| {inv['id']} | {icon} {inv['status']} | {inv['detail']} |")
+    lines += ["", "### Contigs", "", "| contig | rows | warm | cold | warm % | size |", "|---|--:|--:|--:|--:|--:|"]
+    for c in report["contigs"]:
+        lines.append(
+            f"| {c['chrom']} | {format_int(c['rows'])} | {format_int(c['warm'])} | {format_int(c['cold'])} "
+            f"| {format_pct(c['warm_share'])} | {format_bytes(c['bytes'])} |"
+        )
+    s = report["summary"]
+    warm_share = s["warm"] / s["rows"] if s["rows"] else 0.0
+    lines.append(
+        f"| **total** | **{format_int(s['rows'])}** | **{format_int(s['warm'])}** | **{format_int(s['cold'])}** "
+        f"| **{format_pct(warm_share)}** | **{format_bytes(s['bytes'])}** |"
+    )
+    lines += [
+        "", "### Columns", "",
+        "| column | role | type | null % | empty % | distinct | numeric (min / p50 / p95 / max) | top values |",
+        "|---|---|---|--:|--:|--:|---|---|",
+    ]
+    for col in report["columns"]:
+        if col["role"] not in ("match", "value"):
+            continue
+        empty = "—" if col["empty_share"] is None else f"{100 * col['empty_share']:.2f}"
+        distinct = "—" if col["distinct"] is None else (
+            f"~{format_count_short(col['distinct'])}" if col["approx"] else format_int(col["distinct"])
+        )
+        lines.append(
+            f"| {col['name']} | {col['role']} | {col['dtype']} | {100 * col['null_share']:.2f} | {empty} "
+            f"| {distinct} | {_numeric_cell(col['numeric'])} | {_top_cell(col['top_values'])} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def splice(readme: str, section: str) -> str:
+    """Replace the marked block, else insert it before `## Usage`, else append it."""
+    block = f"{START}\n{section.rstrip()}\n{END}\n"
+    if START in readme and END in readme:
+        head = readme[: readme.index(START)]
+        tail = readme[readme.index(END) + len(END) :].lstrip("\n")
+        return head + block + ("\n" + tail if tail else "")
+    marker = "\n## Usage"
+    if marker in readme:
+        i = readme.index(marker) + 1
+        return readme[:i] + block + "\n" + readme[i:]
+    return readme.rstrip("\n") + "\n\n" + block
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_cache_qa_card.py -q`
+Expected: all pass.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+uv run ruff check e2e-testing/scripts/cache_qa tests/test_cache_qa_card.py && uv run ruff format e2e-testing/scripts/cache_qa tests/test_cache_qa_card.py
+git add e2e-testing/scripts/cache_qa/card.py tests/test_cache_qa_card.py
+git commit -m "feat(cache_qa): quality-profile card section rendering and splicing"
+```
+
+---
+
+### Task 7: Staging and publishing through an injected runner
+
+**Files:**
+- Create: `e2e-testing/scripts/cache_qa/stage.py`
+- Test: `tests/test_cache_qa_stage.py`
+
+**Interfaces:**
+- Consumes `CacheManifest`.
+- Produces `cache_qa.stage`:
+  - `class Runner(Protocol): def run(self, argv: list[str]) -> subprocess.CompletedProcess: ...`
+  - `class SubprocessRunner` (real; `subprocess.run(argv, capture_output=True, text=True)`).
+  - `class PublishError(RuntimeError)`.
+  - `build_stage(m: CacheManifest, qa_profile: Path, readme: Path, stage_dir: Path) -> list[Path]` (hard links; falls back to copy when `os.link` raises `OSError`; returns staged paths).
+  - `publish(runner, repo: str, stage_dir: Path, tag: str, commit_message: str) -> str` (runs `hf upload`, `hf repos tag delete --yes`, `hf repos tag create`; returns the head sha parsed from `hf datasets info --format json`).
+  - `verify(runner, repo: str, stage_dir: Path, tag: str) -> list[str]` (returns mismatches: size differences, missing files, tag not at head; empty list = ok). Uses `hf datasets info <repo> --format json --expand siblings` for sizes and sha; `hf datasets info <repo> --revision <tag> --format json` for the tag sha.
+  - `check_hf_available(runner) -> None` raises `PublishError` when `hf auth whoami` fails.
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/test_cache_qa_stage.py`:
+
+```python
+import json
+import subprocess
+
+import pytest
+
+from cache_qa import manifest, stage
+from cache_qa_synthetic import SyntheticCache
+
+
+class FakeRunner:
+    def __init__(self, responses=None, fail_on=None):
+        self.calls: list[list[str]] = []
+        self.responses = responses or {}
+        self.fail_on = fail_on
+
+    def run(self, argv):
+        self.calls.append(list(argv))
+        key = " ".join(argv[:3])
+        if self.fail_on and self.fail_on in " ".join(argv):
+            return subprocess.CompletedProcess(argv, 1, "", "boom")
+        out = self.responses.get(key, "")
+        return subprocess.CompletedProcess(argv, 0, out, "")
+
+
+def _staged(tmp_path):
+    m = manifest.load_manifest(SyntheticCache(tmp_path).write())
+    qa = m.plugin_dir / "qa_profile.json"
+    qa.write_text("{}\n")
+    readme = tmp_path / "README.md"
+    readme.write_text("# card\n")
+    stage_dir = tmp_path / "stage_demo"
+    staged = stage.build_stage(m, qa, readme, stage_dir)
+    return m, stage_dir, staged
+
+
+def test_build_stage_links_every_listed_file(tmp_path):
+    m, stage_dir, staged = _staged(tmp_path)
+    names = sorted(p.name for p in staged)
+    assert names == ["README.md", "chr1.parquet", "chr2.parquet", "chrX.parquet", "manifest.json", "qa_profile.json"]
+    src = m.plugin_dir / "chr1.parquet"
+    assert (stage_dir / "chr1.parquet").stat().st_ino == src.stat().st_ino  # hard link
+
+
+def test_build_stage_skips_zero_row_missing_shard(tmp_path):
+    cache = SyntheticCache(tmp_path)
+    md = cache.manifest_dict()
+    md["chroms"].append({"chrom": "chrMT", "file": "chrMT.parquet", "rows": 0, "warm": 0, "cold": 0})
+    cache.set_manifest(md)
+    m = manifest.load_manifest(cache.write())
+    qa = m.plugin_dir / "qa_profile.json"; qa.write_text("{}\n")
+    readme = tmp_path / "README.md"; readme.write_text("# c\n")
+    staged = stage.build_stage(m, qa, readme, tmp_path / "s")
+    assert "chrMT.parquet" not in {p.name for p in staged}
+
+
+def test_publish_runs_upload_and_moves_tag(tmp_path):
+    m, stage_dir, _ = _staged(tmp_path)
+    runner = FakeRunner(responses={"hf datasets info": json.dumps({"sha": "abc123"})})
+    head = stage.publish(runner, "org/repo", stage_dir, "v0.1.1", "msg")
+    assert head == "abc123"
+    argv = runner.calls
+    assert argv[0][:3] == ["hf", "upload", "org/repo"] and str(stage_dir) in argv[0] and "--type" in argv[0] and "dataset" in argv[0]
+    assert argv[0][argv[0].index("--commit-message") + 1] == "msg"
+    assert ["hf", "repos", "tag", "delete", "org/repo", "v0.1.1", "--type", "dataset", "--yes"] == argv[1]
+    assert argv[2][:6] == ["hf", "repos", "tag", "create", "org/repo", "v0.1.1"]
+
+
+def test_publish_raises_when_upload_fails(tmp_path):
+    m, stage_dir, _ = _staged(tmp_path)
+    with pytest.raises(stage.PublishError) as e:
+        stage.publish(FakeRunner(fail_on="hf upload"), "org/repo", stage_dir, "v0.1.1", "msg")
+    assert "hf upload" in str(e.value) and "boom" in str(e.value)
+
+
+def test_verify_reports_size_and_tag_mismatch(tmp_path):
+    m, stage_dir, staged = _staged(tmp_path)
+    siblings = [{"rfilename": p.name, "size": p.stat().st_size} for p in staged]
+    siblings[0]["size"] += 1  # README size wrong
+    siblings.pop()            # one file missing on the hub
+    runner = FakeRunner(responses={
+        "hf datasets info": json.dumps({"sha": "head1", "siblings": siblings}),
+    })
+    # the tag lookup uses the same argv prefix; make it answer a different sha
+    orig = runner.run
+    def run(argv):
+        if "--revision" in argv:
+            return subprocess.CompletedProcess(argv, 0, json.dumps({"sha": "old"}), "")
+        return orig(argv)
+    runner.run = run
+    problems = stage.verify(runner, "org/repo", stage_dir, "v0.1.1")
+    assert any("README.md" in p and "size" in p for p in problems)
+    assert any("missing" in p for p in problems)
+    assert any("tag" in p for p in problems)
+
+
+def test_verify_clean(tmp_path):
+    m, stage_dir, staged = _staged(tmp_path)
+    siblings = [{"rfilename": p.name, "size": p.stat().st_size} for p in staged]
+    runner = FakeRunner(responses={"hf datasets info": json.dumps({"sha": "h", "siblings": siblings})})
+    assert stage.verify(runner, "org/repo", stage_dir, "v0.1.1") == []
+
+
+def test_check_hf_available_raises(tmp_path):
+    with pytest.raises(stage.PublishError):
+        stage.check_hf_available(FakeRunner(fail_on="hf auth whoami"))
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_cache_qa_stage.py -q`
+Expected: `ImportError: cannot import name 'stage'`
+
+- [ ] **Step 3: Implement the module**
+
+`e2e-testing/scripts/cache_qa/stage.py`:
+
+```python
+"""Hard-link staging directory and Hugging Face publishing through an injected runner."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Protocol
+
+from cache_qa.manifest import CacheManifest
+
+
+class PublishError(RuntimeError):
+    """A Hub command failed or the published state does not match the staged files."""
+
+
+class Runner(Protocol):
+    def run(self, argv: list[str]) -> subprocess.CompletedProcess: ...
+
+
+class SubprocessRunner:
+    def run(self, argv: list[str]) -> subprocess.CompletedProcess:
+        try:
+            return subprocess.run(argv, capture_output=True, text=True, check=False)
+        except FileNotFoundError as e:
+            raise PublishError(
+                f"`{argv[0]}` is not on PATH; install with `curl -LsSf https://hf.co/cli/install.sh | bash`"
+            ) from e
+
+
+def _run_ok(runner: Runner, argv: list[str]) -> subprocess.CompletedProcess:
+    cp = runner.run(argv)
+    if cp.returncode != 0:
+        raise PublishError(f"`{' '.join(argv)}` failed (exit {cp.returncode}): {cp.stderr.strip() or cp.stdout.strip()}")
+    return cp
+
+
+def check_hf_available(runner: Runner) -> None:
+    """Fail before any upload when `hf` is missing or not logged in."""
+    _run_ok(runner, ["hf", "auth", "whoami"])
+
+
+def _link_or_copy(src: Path, dst: Path) -> None:
+    if dst.exists():
+        dst.unlink()
+    try:
+        os.link(src, dst)
+    except OSError:
+        shutil.copy2(src, dst)
+
+
+def build_stage(m: CacheManifest, qa_profile: Path, readme: Path, stage_dir: Path) -> list[Path]:
+    stage_dir = Path(stage_dir)
+    if stage_dir.exists():
+        shutil.rmtree(stage_dir)
+    stage_dir.mkdir(parents=True)
+    staged: list[Path] = []
+    for entry, path in m.present_shards():
+        dst = stage_dir / entry.file
+        _link_or_copy(path, dst)
+        staged.append(dst)
+    for src, name in ((m.plugin_dir / "manifest.json", "manifest.json"), (Path(qa_profile), "qa_profile.json"), (Path(readme), "README.md")):
+        dst = stage_dir / name
+        _link_or_copy(src, dst)
+        staged.append(dst)
+    return staged
+
+
+def _info(runner: Runner, repo: str, revision: str | None = None, expand_siblings: bool = False) -> dict:
+    argv = ["hf", "datasets", "info", repo, "--format", "json"]
+    if revision:
+        argv += ["--revision", revision]
+    if expand_siblings:
+        argv += ["--expand", "siblings"]
+    cp = _run_ok(runner, argv)
+    try:
+        return json.loads(cp.stdout)
+    except json.JSONDecodeError as e:
+        raise PublishError(f"`{' '.join(argv)}` returned non-JSON output: {cp.stdout[:200]}") from e
+
+
+def publish(runner: Runner, repo: str, stage_dir: Path, tag: str, commit_message: str) -> str:
+    _run_ok(runner, ["hf", "upload", repo, str(stage_dir), ".", "--type", "dataset", "--commit-message", commit_message])
+    runner.run(["hf", "repos", "tag", "delete", repo, tag, "--type", "dataset", "--yes"])  # absent tag is fine
+    _run_ok(runner, ["hf", "repos", "tag", "create", repo, tag, "--type", "dataset", "--message", commit_message])
+    return str(_info(runner, repo)["sha"])
+
+
+def verify(runner: Runner, repo: str, stage_dir: Path, tag: str) -> list[str]:
+    problems: list[str] = []
+    info = _info(runner, repo, expand_siblings=True)
+    remote = {s["rfilename"]: s for s in info.get("siblings", [])}
+    for path in sorted(Path(stage_dir).iterdir()):
+        r = remote.get(path.name)
+        if r is None:
+            problems.append(f"{path.name}: missing on the hub")
+            continue
+        size = r.get("size")
+        if size is not None and int(size) != path.stat().st_size:
+            problems.append(f"{path.name}: size {path.stat().st_size} local vs {size} on the hub")
+    head = str(info.get("sha"))
+    tag_sha = str(_info(runner, repo, revision=tag).get("sha"))
+    if tag_sha != head:
+        problems.append(f"tag {tag} resolves to {tag_sha[:7]}, head is {head[:7]}")
+    return problems
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_cache_qa_stage.py -q`
+Expected: all pass. On a filesystem where `tmp_path` and the fixture are on the same volume the inode assertion holds; if CI runs on a volume without hard links, the copy fallback makes the inode test fail — in that case assert `filecmp.cmp(src, dst, shallow=False)` instead.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+uv run ruff check e2e-testing/scripts/cache_qa tests/test_cache_qa_stage.py && uv run ruff format e2e-testing/scripts/cache_qa tests/test_cache_qa_stage.py
+git add e2e-testing/scripts/cache_qa/stage.py tests/test_cache_qa_stage.py
+git commit -m "feat(cache_qa): hard-link staging and hf publish/verify via injected runner"
+```
+
+---
+
+### Task 8: CLI, entry point, README-from-hub
+
+**Files:**
+- Create: `e2e-testing/scripts/cache_qa/cli.py`
+- Create: `e2e-testing/scripts/profile_plugin_cache.py`
+- Test: `tests/test_cache_qa_cli.py`
+
+**Interfaces:**
+- Consumes every module above.
+- Produces `cache_qa.cli`:
+  - `parse_args(argv: list[str] | None) -> argparse.Namespace` with `plugin`, `root`, `out`, `readme`, `readme_from_hub`, `publish`, `tag`, `commit_message`, `json_only`.
+  - `main(argv=None, runner: Runner | None = None, now: Callable[[], str] | None = None) -> int`.
+  - `fetch_readme(runner, repo: str, dest: Path) -> Path` (runs `hf download <repo> README.md --type dataset --local-dir <dir>`).
+  - Exit codes 0/1/2 per the spec.
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/test_cache_qa_cli.py`:
+
+```python
+import json
+import subprocess
+
+import polars as pl
+import pytest
+
+from cache_qa import card, cli
+from cache_qa_synthetic import SyntheticCache
+
+
+class FakeRunner:
+    def __init__(self, readme_text="# card\n\n## Usage\n\nu\n"):
+        self.calls = []
+        self.readme_text = readme_text
+
+    def run(self, argv):
+        self.calls.append(list(argv))
+        if argv[:2] == ["hf", "download"]:
+            local_dir = argv[argv.index("--local-dir") + 1]
+            from pathlib import Path
+            Path(local_dir).mkdir(parents=True, exist_ok=True)
+            (Path(local_dir) / "README.md").write_text(self.readme_text)
+            return subprocess.CompletedProcess(argv, 0, "", "")
+        if argv[:3] == ["hf", "datasets", "info"]:
+            from pathlib import Path
+            stage_dir = next(p for c in self.calls if c[:2] == ["hf", "upload"] for p in [Path(c[3])])
+            siblings = [{"rfilename": p.name, "size": p.stat().st_size} for p in stage_dir.iterdir()]
+            return subprocess.CompletedProcess(argv, 0, json.dumps({"sha": "h", "siblings": siblings}), "")
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+
+def test_parse_requires_plugin_and_root():
+    with pytest.raises(SystemExit):
+        cli.parse_args([])
+    a = cli.parse_args(["demo", "--root", "/r"])
+    assert a.plugin == "demo" and a.root == "/r" and a.publish is None and a.json_only is False
+
+
+def test_pass_writes_json_and_readme(tmp_path):
+    cache = SyntheticCache(tmp_path)
+    cache.write()
+    readme = tmp_path / "README.md"
+    readme.write_text("# T\n\n## Usage\n\nu\n")
+    rc = cli.main(["demo", "--root", str(tmp_path), "--readme", str(readme)], now=lambda: "2026-09-05T00:00:00Z")
+    assert rc == 0
+    out = json.loads((cache.plugin_dir / "qa_profile.json").read_text())
+    assert out["status"] == "pass" and out["generated_at"] == "2026-09-05T00:00:00Z"
+    assert card.START in readme.read_text() and "## Quality profile" in readme.read_text()
+
+
+def test_json_only_skips_readme(tmp_path):
+    cache = SyntheticCache(tmp_path); cache.write()
+    readme = tmp_path / "README.md"; readme.write_text("# T\n")
+    assert cli.main(["demo", "--root", str(tmp_path), "--readme", str(readme), "--json-only"]) == 0
+    assert readme.read_text() == "# T\n"
+
+
+def test_failed_invariant_exits_1_and_blocks_publish(tmp_path):
+    cache = SyntheticCache(tmp_path)
+    df = cache.rows["chrX"]
+    cache.rows["chrX"] = df.with_columns(pl.lit(2).cast(pl.Int8).alias("tier"))
+    cache.write()
+    runner = FakeRunner()
+    rc = cli.main(["demo", "--root", str(tmp_path), "--readme-from-hub", "org/repo", "--publish", "org/repo", "--tag", "v1"], runner=runner)
+    assert rc == 1
+    assert not any(c[:2] == ["hf", "upload"] for c in runner.calls)
+    assert json.loads((cache.plugin_dir / "qa_profile.json").read_text())["status"] == "fail"
+
+
+def test_missing_manifest_exits_2(tmp_path):
+    assert cli.main(["nope", "--root", str(tmp_path)]) == 2
+
+
+def test_publish_requires_readme_source(tmp_path):
+    SyntheticCache(tmp_path).write()
+    assert cli.main(["demo", "--root", str(tmp_path), "--publish", "org/repo", "--tag", "v1"], runner=FakeRunner()) == 2
+
+
+def test_publish_happy_path(tmp_path):
+    cache = SyntheticCache(tmp_path); cache.write()
+    runner = FakeRunner()
+    rc = cli.main(
+        ["demo", "--root", str(tmp_path), "--readme-from-hub", "org/repo", "--publish", "org/repo", "--tag", "v0.1.1", "--commit-message", "m"],
+        runner=runner,
+    )
+    assert rc == 0
+    kinds = [tuple(c[:2]) for c in runner.calls]
+    assert ("hf", "download") in kinds and ("hf", "upload") in kinds
+    upload = next(c for c in runner.calls if c[:2] == ["hf", "upload"])
+    from pathlib import Path
+    staged = sorted(p.name for p in Path(upload[3]).iterdir())
+    assert staged == ["README.md", "chr1.parquet", "chr2.parquet", "chrX.parquet", "manifest.json", "qa_profile.json"]
+    assert card.START in (Path(upload[3]) / "README.md").read_text()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_cache_qa_cli.py -q`
+Expected: `ImportError: cannot import name 'cli'`
+
+- [ ] **Step 3: Implement the CLI and entry point**
+
+`e2e-testing/scripts/cache_qa/cli.py`:
+
+```python
+"""profile_plugin_cache.py: verify, profile, render the card, optionally publish."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import sys
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+
+import polars as pl
+
+from cache_qa import card, invariants, profile, report, stage
+from cache_qa.manifest import ManifestError, load_manifest
+
+EXIT_OK, EXIT_FAILED, EXIT_USAGE = 0, 1, 2
+
+
+def parse_args(argv: list[str] | None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        prog="profile_plugin_cache.py",
+        description="Check a plugin cache's invariants, profile its content, update its Hub card.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("plugin", help="plugin name, e.g. clinvar")
+    p.add_argument("--root", required=True, help="plugin cache root containing plugin/<name>/")
+    p.add_argument("--out", default=None, help="qa_profile.json path (default: <root>/plugin/<name>/qa_profile.json)")
+    p.add_argument("--readme", default=None, help="README.md to update in place")
+    p.add_argument("--readme-from-hub", default=None, metavar="REPO", help="fetch README.md from this dataset repo first")
+    p.add_argument("--publish", default=None, metavar="REPO", help="upload shards, manifest, JSON and README as one commit")
+    p.add_argument("--tag", default=None, help="tag to move to the new head (required with --publish)")
+    p.add_argument("--commit-message", default=None)
+    p.add_argument("--json-only", action="store_true", help="skip the card even if --readme is given")
+    return p.parse_args(argv)
+
+
+def fetch_readme(runner: stage.Runner, repo: str, dest_dir: Path) -> Path:
+    cp = runner.run(["hf", "download", repo, "README.md", "--type", "dataset", "--local-dir", str(dest_dir)])
+    if cp.returncode != 0:
+        raise stage.PublishError(f"hf download README.md from {repo} failed: {cp.stderr.strip()}")
+    path = Path(dest_dir) / "README.md"
+    if not path.exists():
+        raise stage.PublishError(f"hf download did not produce {path}")
+    return path
+
+
+def _utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def main(argv: list[str] | None = None, runner: stage.Runner | None = None, now: Callable[[], str] | None = None) -> int:
+    args = parse_args(argv)
+    runner = runner or stage.SubprocessRunner()
+    now = now or _utc_now
+    if args.publish and not (args.readme or args.readme_from_hub):
+        print("error: --publish needs --readme or --readme-from-hub (the card would go stale)", file=sys.stderr)
+        return EXIT_USAGE
+    if args.publish and not args.tag:
+        print("error: --publish needs --tag", file=sys.stderr)
+        return EXIT_USAGE
+
+    plugin_dir = Path(args.root) / "plugin" / args.plugin
+    try:
+        m = load_manifest(plugin_dir)
+    except ManifestError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return EXIT_USAGE
+
+    scratch = Path(tempfile.mkdtemp(prefix=f"cache_qa_{args.plugin}_"))
+    readme_path: Path | None = Path(args.readme) if args.readme else None
+    try:
+        if args.publish:
+            stage.check_hf_available(runner)
+        if args.readme_from_hub:
+            readme_path = fetch_readme(runner, args.readme_from_hub, scratch / "readme")
+        try:
+            results = invariants.run_all(m)
+            prof = profile.profile_cache(m)
+        except (OSError, pl.exceptions.PolarsError) as e:
+            print(f"error: cannot read shards: {e}", file=sys.stderr)
+            return EXIT_USAGE
+        rep = report.build_report(m, results, prof, now(), report.tool_versions())
+        out = Path(args.out) if args.out else plugin_dir / "qa_profile.json"
+        report.write_report(rep, out)
+        for r in results:
+            print(f"{r.id:16s} {r.status:5s} {r.detail}")
+        print(f"status={rep['status']} rows={rep['summary']['rows']:,} json={out}")
+
+        if readme_path is not None and not args.json_only:
+            readme_path.write_text(card.splice(readme_path.read_text(), card.render_section(rep)))
+            print(f"card updated: {readme_path}")
+
+        if rep["status"] == "fail":
+            print("invariants failed; nothing published", file=sys.stderr)
+            return EXIT_FAILED
+        if args.publish:
+            if readme_path is None:
+                return EXIT_USAGE
+            stage_dir = scratch / f"stage_{args.plugin}"
+            stage.build_stage(m, out, readme_path, stage_dir)
+            message = args.commit_message or f"{args.plugin}: quality profile {rep['generated_at'][:10]} ({m.cache_source_version or 'unversioned'})"
+            head = stage.publish(runner, args.publish, stage_dir, args.tag, message)
+            problems = stage.verify(runner, args.publish, stage_dir, args.tag)
+            if problems:
+                print("published but verification failed:\n  " + "\n  ".join(problems), file=sys.stderr)
+                return EXIT_FAILED
+            print(f"published {args.publish} @ {head[:7]}, tag {args.tag}")
+        return EXIT_OK
+    except stage.PublishError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return EXIT_USAGE
+```
+
+`e2e-testing/scripts/profile_plugin_cache.py`:
+
+```python
+#!/usr/bin/env python3
+"""Verify a plugin cache's invariants, profile its content, update its Hub card.
+
+See docs/superpowers/specs/2026-09-05-plugin-cache-qa-profile-design.md and
+e2e-testing/README.md for usage.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from cache_qa.cli import main  # noqa: E402
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+Run `chmod +x e2e-testing/scripts/profile_plugin_cache.py`.
+
+- [ ] **Step 4: Run the whole cache_qa suite**
+
+Run: `uv run pytest tests/test_cache_qa_*.py -q`
+Expected: all pass.
+
+- [ ] **Step 5: Lint and commit**
+
+```bash
+uv run ruff check e2e-testing/scripts/cache_qa e2e-testing/scripts/profile_plugin_cache.py tests/test_cache_qa_cli.py && uv run ruff format e2e-testing/scripts/cache_qa e2e-testing/scripts/profile_plugin_cache.py tests/test_cache_qa_cli.py
+git add e2e-testing/scripts/cache_qa/cli.py e2e-testing/scripts/profile_plugin_cache.py tests/test_cache_qa_cli.py
+git commit -m "feat(cache_qa): profile_plugin_cache.py CLI with publish and exit codes"
+```
+
+---
+
+### Task 9: Run on the real caches, document, publish
+
+**Files:**
+- Modify: `docs/downloads.md` (add a "Quality profile" paragraph)
+- Modify: `e2e-testing/README.md` (usage block for `profile_plugin_cache.py`)
+
+**Interfaces:** none new; this task exercises the CLI on `~/workspace/data_vepyr/plugin_cache_v0.1.1`.
+
+- [ ] **Step 1: Dry run on the smallest cache**
+
+```bash
+uv run python e2e-testing/scripts/profile_plugin_cache.py clinvar --root ~/workspace/data_vepyr/plugin_cache_v0.1.1 --json-only
+```
+Expected: nine `pass` lines (duplicates `pass`, detail `manifest assume_unique=false`), `status=pass rows=4,439,569`, JSON written next to the shards. Runtime a few seconds.
+
+- [ ] **Step 2: Run the three larger local caches**
+
+```bash
+for p in alphamissense dbnsfp spliceai; do
+  uv run python e2e-testing/scripts/profile_plugin_cache.py $p --root ~/workspace/data_vepyr/plugin_cache_v0.1.1 --json-only || echo "$p exit=$?"
+done
+```
+Expected: `pass` or `warn` for each (SpliceAI duplicates may `warn` because the source repeats bare keys at overlapping-gene loci; the detail must say `manifest assume_unique=true`). Record wall time and peak RSS (`/usr/bin/time -l`) for the report; targets are under a minute for dbNSFP and SpliceAI. If `order` fails on any cache, stop: that is a real finding, not a tool bug, and needs an engine issue.
+
+- [ ] **Step 3: Publish the card sections for the public caches**
+
+```bash
+for p in clinvar alphamissense spliceai; do
+  uv run python e2e-testing/scripts/profile_plugin_cache.py $p \
+    --root ~/workspace/data_vepyr/plugin_cache_v0.1.1 \
+    --readme-from-hub biodatageeks/vepyr_116_GRCh38_plugin_$p \
+    --publish biodatageeks/vepyr_116_GRCh38_plugin_$p --tag v0.1.1 \
+    --commit-message "Add quality profile section and qa_profile.json"
+done
+```
+Expected: each prints `published … tag v0.1.1`; the Hub card shows `## Quality profile` before `## Usage`; `qa_profile.json` is listed in the repo files. CADD is published separately once its full build lands (Rollout step 2 of the spec).
+
+- [ ] **Step 4: Document**
+
+Append to `docs/downloads.md` under the plugin caches section:
+
+```markdown
+### Quality profile
+
+Every published plugin cache carries a `## Quality profile` section on its dataset card
+and a machine-readable `qa_profile.json` next to the shards, generated by
+`e2e-testing/scripts/profile_plugin_cache.py`. The section lists the structural
+invariants the runtime relies on (schema, contig, row order, tier domain, manifest
+counts and files, positions, allele form, duplicate probe keys) with pass/warn/fail,
+a per-contig row and size table, and per-column null, empty, distinct and numeric
+summaries. A failed invariant blocks publishing, so a card with the section always
+describes shards that passed.
+```
+
+Add to `e2e-testing/README.md` next to the comparison usage:
+
+```markdown
+### Plugin cache QA
+
+```bash
+uv run python e2e-testing/scripts/profile_plugin_cache.py clinvar --root ~/workspace/data_vepyr/plugin_cache_v0.1.1
+# with card update and publish
+uv run python e2e-testing/scripts/profile_plugin_cache.py clinvar --root … \
+  --readme-from-hub biodatageeks/vepyr_116_GRCh38_plugin_clinvar \
+  --publish biodatageeks/vepyr_116_GRCh38_plugin_clinvar --tag v0.1.1
+```
+
+Exit 0 pass/warn, 1 an invariant failed (nothing uploaded), 2 usage or I/O error.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/downloads.md e2e-testing/README.md
+git commit -m "docs: quality profile section and profile_plugin_cache.py usage"
+```
+
+---
+
+## Self-review notes
+
+- Spec coverage: inputs and dedup policy (Task 1); all nine invariants with the spec's ids, statuses and detail shapes (Tasks 2 and 3); content profile fields, exact/approx distinct rule, top values rule, numeric on parsable text (Task 4); `qa_profile.json` layout, `status` aggregation, `schema_version` (Task 5); card section text, tables, markers, insertion and idempotence (Task 6); staging by hard link, one `hf upload` commit, tag move, post-upload verification, `Runner` protocol (Task 7); CLI flags, exit codes, `--publish` refused on fail and without a README source, `hf` availability check (Task 8); rollout on the five caches, publishing three, docs (Task 9). Out of scope items are untouched.
+- Type consistency: `InvariantResult(id, status, detail, per_contig)` is used identically by `report.build_report` and `card.render_section` (which reads the dict form). `Profile` field names (`contigs`, `columns`, `rows`, `warm`, `cold`, `bytes`) match `build_report`. `CacheManifest.present_shards()` is the single source of "which shards exist" for invariants, profile and staging.
+- Known judgement calls recorded for the executor: `check_order` collects the projected key columns per shard in memory rather than streaming, because `shift` needs whole-column context; memory is bounded by the key columns of one shard (a few GB for CADD chr1). `check_duplicates` counts rows beyond the first per key. The card lists only match and value columns.

--- a/docs/superpowers/plans/2026-09-09-mnv-allele-trim-parity.md
+++ b/docs/superpowers/plans/2026-09-09-mnv-allele-trim-parity.md
@@ -1,0 +1,260 @@
+# MNV allele trimming parity (vepyr#95)
+
+**Status:** awaiting human go-ahead at runbook step 1d. No file in any of the three
+checkouts has been edited. This artifact is the gate.
+
+**Goal:** make vepyr's CSQ `Allele` and internal variant coordinates match Ensembl VEP
+116.0 for same-length multi-base substitutions (MNVs), without disturbing the indel path.
+
+**Architecture:** the whole fix lands in `datafusion-bio-functions`. `datafusion-bio-formats`
+is untouched; vepyr takes a pin bump plus a regression test.
+
+**Spec:** `biodatageeks/vepyr#95`, corrected by the analysis below — the issue's proposed
+rule is wrong for indels and must not be implemented as written.
+
+---
+
+## 1. The defect
+
+For a REF/ALT pair of equal length longer than one base, vepyr strips the shared leading
+bases and advances the variant start by that many positions. Ensembl VEP leaves such a pair
+completely untouched. `GAC>GTC` at POS 100 is reported by VEP as `Allele=GTC` spanning
+100-102 and by vepyr as `Allele=TC` spanning 101-102. Because the shift is internal, the
+printed VCF `POS` is unaffected — the divergence surfaces in `Codons`, `cDNA_position`,
+`CDS_position`, `HGVSc`, `DISTANCE` and, where the span change flips a term,
+`most_severe_consequence`.
+
+**Triggering record shape:** `len(REF) == len(ALT) > 1` **and** REF and ALT share at least
+one leading base. A same-length pair sharing no leading base (`GCCTT>TCCTT`) is already
+correct, which is why the whole-genome gate is green.
+
+### Measured, not assumed
+
+Real Ensembl VEP 116.0 (docker `ensemblorg/ensembl-vep:release_116.0`, `--everything --hgvs`,
+offline cache) against vepyr at the current master pin, same input, REF bases taken from the
+real GRCh38 FASTA:
+
+| case | shape | VEP 116.0 `Allele` | vepyr `Allele` | verdict |
+|---|---|---|---|---|
+| `GCC>GTC` | MNV, prefix 1 | `GTC` | `TC` | **diverges** |
+| `CCTGG>CTTGG` | MNV, prefix 1, len 5 | `CTTGG` | `TTGG` | **diverges** |
+| `TCCC>TC` | indel, prefix 2, suffix 1 | `-` | `-` | match |
+| `TTCA>TA` | indel, prefix 1, suffix 1 | `-` | `-` | match |
+| `A>G` | SNV control | `G` | `G` | match |
+
+Blast radius measured on a coding MNV, `chr22:20086483 ATA>AGA`, 25 CSQ entries, against an
+SNV control at the same locus that matched perfectly:
+
+| field | VEP | vepyr |
+|---|---|---|
+| `Allele` | `AGA` | `GA` |
+| `Codons` | `ATA/AGA` | `aTA/aGA` |
+| `CDS_position` | `520-522` | `521-522` |
+| `cDNA_position` | `1156-1158` | `1157-1158` |
+| `HGVSc` | `c.521T>G` | `c.521-522T>G` |
+| `DISTANCE` | `341` / `650` / `4899` | `342` / `651` / `4900` |
+
+`Protein_position`, `Amino_acids`, `VARIANT_CLASS`, `Consequence` and the CSQ entry count were
+identical. The `DISTANCE` off-by-one on the non-coding probes is independent confirmation that
+the coordinate shift is real and not only an `Allele` string difference.
+
+## 2. The issue's proposed fix is wrong for indels — do not implement it as written
+
+Issue #95 models VEP's default rule from `Parser/VCF.pm:295-336` alone: "one leading base,
+only for indels, never a suffix". That is only half of VEP's default path. At **`release/116.0`**,
+`Parser.pm:844` `post_process_vfs()` runs immediately after, and line `:881`
+
+```perl
+$vf = ${$self->minimise_alleles([$vf])}[0] if $is_non_minimised_indel;
+```
+
+is **not** gated on `--minimal` (that gate is the line above it, `:852`).
+`$is_non_minimised_indel` is initialised at `:863` and set at `:871-880` by a length test on the
+original untrimmed VCF REF/ALT (`nontrimmed_allele_string`, `Parser/VCF.pm:343`). So VEP's
+composed default rule is:
+
+- **same length** → no trim at all, no coordinate shift;
+- **different length** → anchor chop, then a full `trim_sequences` (full prefix **and** full
+  suffix, `ensembl-variation` `release/116` `Utils/Sequence.pm:965`).
+
+vepyr already implements the second line correctly. The VEP run above confirms it from the
+outside: `TTCA>TA` yields `Allele=-` in VEP, not the `TTG/G`-shaped one-base chop the issue
+predicts. Two consequences for the plan:
+
+1. **Issue item 3 is answered: there is no shared-suffix defect.** The suffix loop stays.
+2. **Issue items 1 and 3, implemented verbatim, would regress every shared-suffix indel** and
+   re-open what engine PR #110 (`7d4ee58`) fixed against a real chr14 `DISTANCE` mismatch. The
+   issue's own proposed assertion `vcf_to_vep_allele("AT","GTT") == ("AT","GTT")` is wrong;
+   VEP gives `A/GT`, which is what vepyr produces today.
+
+The fix is therefore **one condition — skip the trim when `ref.len() == alt.len()`** — applied
+at the sites that must not drift apart, not the rewrite the issue describes.
+
+## 3. Ownership
+
+| repo | verdict | evidence |
+|---|---|---|
+| `datafusion-bio-formats` | **untouched** | no trimming, minimisation or coordinate logic anywhere in `bio-format-vcf/src/`; `physical_exec.rs:989-990` writes REF verbatim and ALT pipe-joined; `start` is the raw 1-based POS given vepyr's `zero_based=false` (`vepyr/src/annotate.rs:489-494`); `end` from `get_variant_end` (`:815-836`) already equals VEP's `Parser/VCF.pm:254`. Verified byte-identical between pinned rev `419be98` and the drifted `feat/cooler` branch for every file quoted. |
+| `datafusion-bio-functions` | **owner** | every trim, every `is_indel` predicate and all three coordinate shifts live here |
+| `vepyr` | **carrier** | no allele or coordinate code at all; stake is the pin at `Cargo.toml:88` and two blind gates |
+
+A decisive argument against ever fixing this in formats: `bio-format-vcf/src/serializer.rs:607-671`
+reconstructs the output VCF's POS/REF/ALT from those same columns, so trimming in the reader
+would rewrite the user's own records on the `output_vcf=` path.
+
+## 4. The change, per repo, in dependency order
+
+### 4a. `datafusion-bio-formats` — no change
+
+No pin bump on its own account. vepyr keeps both `datafusion-bio-format-*` lines at
+`tag = "v1.12.1"`; the comment at `vepyr/Cargo.toml:84-87` requires the reference form stay a
+tag or the formats crates compile twice (E0308).
+
+### 4b. `datafusion-bio-functions` — the whole fix, four sites
+
+Pinned rev `8b1abd0` (= tag `v0.20.1`, = `origin/master`).
+
+| # | site | change |
+|---|---|---|
+| 1 | `allele.rs:296-342` `vcf_to_vep_allele` | return the pair untouched when `ref_allele.len() == alt_allele.len()`. Leave the indel suffix loop at `:315-325` exactly as it is. |
+| 2 | `allele.rs:764-793` `vep_prefix_suffix_len` | the same guard, so `vep_norm_start` (`:812-815`) and `vep_norm_end` (`:826-829`) cannot drift from site 1 |
+| 3 | `transcript_consequence.rs:57-58` | widen the bail-out from `(prefix_len == 0 && same length)` to `same length`; `:93`'s `new_start = pos + prefix_len` then never fires for a same-length pair |
+| 4 | `allele.rs:353-382` `vcf_to_vep_input_allele` | `is_indel` at `:358` is `ref.len() != 1 \|\| alt.len() != 1` ("not an SNV") where VEP's is `length($alt) != length($ref)`. **See the open question in §7 — this site has an out-of-repo cost and may be split into its own PR.** |
+
+Sites 1-3 must land in one commit: `Allele` comes from site 1, the colocated-match coordinates
+from site 2 and the consequence engine's span from site 3. Fixing any subset silently
+desynchronises the CSQ value from the coordinates it was computed at.
+
+Falls out for free at site 1: a two-base MNV such as `GA>GT` currently trims to `A/T` and
+classifies as `VARIANT_CLASS=SNV` (`annotate_provider.rs:7854-7862`); VEP calls it
+`substitution`. The same guard fixes it.
+
+### 4c. `vepyr` — pin bump plus a regression test
+
+- `Cargo.toml:88` — `datafusion-bio-function-vep` tag → the functions PR head commit, then the
+  merge commit after merge.
+- One integration test in `tests/test_annotate.py` asserting `Allele` on an MNV, with an SNV
+  positive control. **Constraint:** `tests/data/golden/cache/` is trimmed to chr1
+  `start <= 852_922` and `tests/data/golden/reference.fa` holds 860,893 bases, so any new
+  record must sit inside that window with a REF matching the FASTA.
+- `docs/plugins.md:391-410` presents the trim as unconditional; add one sentence saying the
+  parser rule is same-length-conditional.
+
+## 5. The failing test, and why no existing gate can see this
+
+**No existing fixture can see the defect.** Measured, not quoted from the issue:
+
+- `tests/data/golden/input.vcf` — 100 records: 91 SNVs, 9 indels, **zero MNVs**, zero
+  multi-allelic, zero `ALT=.`, zero shared-suffix indels. Every one of the 9 indels has shared
+  prefix exactly 1 and shared suffix exactly 0, so both the current and the fixed rule produce
+  identical output. All six golden suites share this one input.
+- The golden gate is blinder still: `tests/_golden_suite.py:173-174` **excludes `Allele`** from
+  the VCF field comparison, and it is absent from `DEFAULT_DF_COMPARISON_FIELDS` (`:126-152`).
+  An MNV in the fixture would fail via `DISTANCE`/`Codons`/`cDNA_position`/`CDS_position`/`HGVSc`,
+  not via `Allele`.
+- The 22-autosome strict-md5 gate is **structurally** blind, not stale: `HG002_normalized.vcf.gz`
+  contains 511 MNVs, but they come from multi-allelic splitting and every one shares no leading
+  base, so the full-prefix trim is already a no-op on them. Its 29,404 shared-suffix indels are
+  on the indel branch, which this fix does not touch.
+
+Failing tests to write, in the owning repo:
+
+- **Engine, `allele.rs`:** MNV untouched (`GAC>GTC`, `ATCG>AGCG`, and the 25-mer pair from the
+  issue); indel path frozen — `AG>ATCG → -/TC`, `ATTG>AG → TT/-`, `T>AGTAAATTTTTTTTCT`,
+  `AT>GTT → A/GT`. The frozen set is the guard against the issue's over-broad rule.
+- **Engine, `transcript_consequence.rs`:** `from_vcf` for `ATCG/AGCG` must become
+  `start 100, ATCG/AGCG` (today: `start 101, TCG/GCG`).
+- **Engine, consistency:** site 1 and site 3 must agree for a fixed table of pairs.
+- **vepyr:** the integration test in §4c.
+
+Existing tests that **must be updated** because they pin the defect:
+`allele.rs:1043-1049` (`test_complex_indel_common_prefix`, `ATCG/ATTT → CG/TT`),
+`allele.rs:1163-1170` (`test_vcf_to_vep_allele_mnv_no_suffix_trim`, `ATCG/AGCG → TCG/GCG`),
+`transcript_consequence.rs:13798-13807` (`from_vcf_mnv_prefix_only_no_suffix_trim`).
+
+Existing tests that **must stay green untouched** — these are the regression guard:
+`allele.rs:1196-1203` (`test_vcf_to_vep_allele_prefix_and_suffix_insertion`, the exact
+`ATTG>AG` shape), `transcript_consequence.rs:13809`, `:13817`, `:13826`.
+
+## 6. Pin cascade
+
+| PR | pins |
+|---|---|
+| `datafusion-bio-formats` | **none — no PR** |
+| `datafusion-bio-functions` | nothing (formats stays at `v1.12.1`) |
+| `vepyr` | the functions PR head, re-pinned to the merge commit after merge |
+
+Two PRs, not three. Branch name in both: `fix/mnv-allele-trim-parity`.
+
+## 7. Decisions (confirmed by the human, 2026-09-09)
+
+| # | decision |
+|---|---|
+| Q1 | **Isolate the plugin key.** Fix site 4's `is_indel` for VEP semantics, and route the plugin probe through a dedicated key function preserving today's anchor-shift, so no built plugin cache is invalidated and neither `cadd.source.toml` nor `clinvar.source.toml` changes. A test must prove the probe key for an MNV is byte-unchanged. |
+| Q2 | **Standalone test *and* extend the golden** with an MNV plus a shared-suffix indel, via a scoped docker VEP 116.0 run. |
+| Q3 | **Scope out the `minimal=` kwarg**, and **post the corrected rule on issue #95** so the wrong rule is not implemented later from the issue text alone. |
+| Q4 | **Not in this PR.** The `Allele` exclusion at `tests/_golden_suite.py:173-174` is filed separately — changing it may turn other golden suites red for reasons unrelated to this fix. |
+
+### The questions as originally posed
+
+**Q1 — scope of site 4 (`vcf_to_vep_input_allele`).** Correcting its `is_indel` is required for
+MNV `HGVSp` parity (the `parser_*` fields derive from it), but it changes the **runtime plugin
+probe key** for MNVs while every already-built plugin shard still stores them anchor-shifted.
+The published manifests hard-code today's predicate into their build SQL —
+`vepyr-plugins/plugins/cadd/cadd.source.toml:47-48` and
+`plugins/clinvar/clinvar.source.toml:109-110` — and ClinVar genuinely contains same-length
+delins records, so this is not hypothetical. The existing fallback does not rescue it.
+Three options: **(a)** land sites 1-3 now and file site 4 separately; **(b)** fix site 4 but
+route the plugin probe through a dedicated key function preserving today's semantics, so no
+cache is invalidated — *my recommendation*; **(c)** fix site 4, update both manifests and
+rebuild/republish the CADD and ClinVar caches.
+
+**Q2 — fixture route.** **(a)** a standalone fixture plus a vepyr integration test, cheap and
+sufficient; **(b)** additionally splice an MNV and a shared-suffix indel into
+`tests/data/golden/`, which needs a ~1-minute docker VEP 116.0 run (`prepare.py` cannot do it —
+it extracts golden lines by exact `(CHROM,POS,REF,ALT)` key from a pre-existing WGS run, and
+HG002 contains no prefix-sharing MNV). *Recommendation:* (b), so the gate stops being blind
+permanently.
+
+**Q3 — issue item 4, the `minimal=` kwarg.** Not needed for default-VEP parity: the run above
+shows vepyr's indel output already equals VEP's non-minimal form. *Recommendation:* scope out
+and say so on the issue.
+
+**Q4 — `Allele` excluded from the golden comparison** (`tests/_golden_suite.py:173-174`). Fix
+in this PR, or file separately? It is the reason a fixture alone would not have caught this.
+
+## 8. Expected gate movement
+
+**Quality: nothing moves.** All 9 golden indels and all 91 SNVs are unaffected by the guard;
+all 511 corpus MNVs are prefix-0; the 29,404 shared-suffix indels stay on the unchanged branch.
+Prediction: six golden suites green, `verify_parity_gate.py` exits 0, 22/22 strict-md5 body
+digests still match. **This is also why a new fixture is mandatory — otherwise the fix ships
+unverified.**
+
+**Performance: no measurable change.** The edit adds one integer length comparison per row on a
+path that already computes both lengths. Expect every phase, `annotation_seconds` and
+`max_rss_kb` inside noise at both 1 and 8 workers; `compare_runs.py` must return VERDICT pass
+with no phase moving more than a couple of percent. Any real movement means something else
+changed and should be investigated rather than accepted.
+
+## 9. Version provenance of the Perl analysis
+
+The first pass read the Perl at `release/115.2`. Re-verified against the pinned target,
+`ensembl-vep release/116.0`:
+
+- `modules/Bio/EnsEMBL/VEP/Parser/VCF.pm` — **content-identical** to 115.2; the entire diff
+  between the two tags is the copyright year. `:295-297` (`is_indel` on a length difference),
+  `:325-336` (the one-base anchor chop) and `:343` (`nontrimmed_allele_string`) all hold.
+- `modules/Bio/EnsEMBL/VEP/Parser.pm` — 48 lines differ between 115.2 and 116.0, but **none of
+  them touch this logic**: a diff filtered to `minimis|is_non_minimised|nontrimmed` is empty.
+  Only the line numbers moved, and the anchors above are the 116.0 ones.
+- `ensembl-variation` `Utils/Sequence.pm` — `trim_sequences` is **unchanged** between
+  `release/115` and `release/116`. The only functional difference in that file is in
+  `get_3prime_seq_offset` (`check_length` no longer subtracts the deletion length), which
+  affects HGVS 3'-shifting, not allele trimming, and is out of scope here — though it is worth
+  remembering when working vepyr#32 or #50.
+
+The remaining Perl-semantics assumption — that assigning to the `foreach` variable at `:881`
+aliases the array element — is standard, and is **corroborated from the outside** by the
+VEP 116.0 docker run in §1, which is the stronger evidence. Both agree, so the plan proceeds on
+the measurement rather than on the Perl.

--- a/docs/superpowers/plans/2026-09-11-catalog-phenotypeorthologous-manifest.md
+++ b/docs/superpowers/plans/2026-09-11-catalog-phenotypeorthologous-manifest.md
@@ -1,0 +1,403 @@
+# Catalog: PhenotypeOrthologous manifest and validator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish `plugins/phenotypeorthologous/phenotypeorthologous.source.toml` in `biodatageeks/vepyr-plugins`, with the validator, README and skill doc understanding `provider = "gff"`, `[source.gff]` and `lookup = "interval"`.
+
+**Architecture:** One PR on `vepyr-plugins` (branch `feat/phenotypeorthologous`, based on `origin/master` at `3e1c039`). The validator is a single Python script run by CI; a small pytest file exercises the new rules with in-memory manifests. The manifest mirrors the engine contract from the engine plan (`docs/superpowers/plans/2026-09-11-engine-gff-provider-and-interval-lookup.md`). Release `v0.2.0` (minor: new plugin) is cut by a human via the Release workflow after merge.
+
+**Tech Stack:** TOML, Python 3.11+ (`tomllib`), pytest, GitHub Actions.
+
+**Spec:** vepyr `docs/superpowers/specs/2026-09-11-gff-plugin-source-and-phenotypeorthologous-design.md`.
+
+## Global Constraints
+
+- Repo: `/Users/mwiewior/research/git/vepyr-plugins`. Its checkout is on `fix/clinvar-numeric-id`; create a worktree from `origin/master` for this work.
+- `url` must be the Ensembl release-116 FTP path; `md5` = `20e5401a198d7d3db66a982c037d3ad4` (computed locally on 2026-09-11 over the 3,424,946-byte file, because Ensembl's `CHECKSUMS` file there uses BSD `sum`). Say so in a comment.
+- Top-level scalar keys precede every `[[table]]` header (TOML absorption rule).
+- Validator exit code 1 on any error; CI (`.github/workflows/validate-manifests.yml`) runs `python scripts/validate_manifests.py`.
+- Commit trailers as in the engine plan.
+
+---
+
+### Task 1: Validator rules for `gff`, `[source.gff]` and `lookup`
+
+**Files:**
+- Modify: `scripts/validate_manifests.py:16` (`PROVIDERS`), `:18-19` (constants), `:90-105` (top-level checks), `:129-158` (source checks)
+- Create: `tests/test_validate_manifests.py`
+- Modify: `.github/workflows/validate-manifests.yml` (add `pip install pytest && pytest -q tests`)
+
+**Interfaces:**
+- Produces: `LOOKUPS = {"point", "interval"}`; `validate_manifest(path: Path, errors: list[str]) -> None` unchanged signature.
+
+- [ ] **Step 1: Write the failing tests**
+
+`tests/test_validate_manifests.py`:
+
+```python
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+import validate_manifests as vm  # noqa: E402
+
+GFF = '''\
+plugin_name = "demo"
+coordinate_system = "1-based"
+lookup = "interval"
+field_order = "alphabetical"
+ingest_sql = "SELECT chrom, start, \\"end\\", gene_id, \\"Rat_gene_id\\" AS rat FROM plugin_demo_src"
+
+[[source]]
+provider = "gff"
+path = "demo.gff3.gz"
+url = "https://example.org/demo.gff3.gz"
+md5 = "20e5401a198d7d3db66a982c037d3ad4"
+index = "tabix"
+  [source.gff]
+  attributes = ["gene_id", "Rat_gene_id"]
+
+[[match_column]]
+column = "gene_id"
+template = "{Gene}"
+
+[[value_columns]]
+column = "rat"
+csq_field = "Demo_Rat"
+type = "Utf8"
+'''
+
+
+def _errors(tmp_path: Path, body: str) -> list[str]:
+    d = tmp_path / "plugins" / "demo"
+    d.mkdir(parents=True)
+    p = d / "demo.source.toml"
+    p.write_text(body, encoding="utf-8")
+    errors: list[str] = []
+    vm.validate_manifest(p, errors)
+    return errors
+
+
+def test_gff_interval_manifest_is_valid(tmp_path):
+    assert _errors(tmp_path, GFF) == []
+
+
+def test_gff_requires_attributes(tmp_path):
+    body = GFF.replace('  [source.gff]\n  attributes = ["gene_id", "Rat_gene_id"]\n', "")
+    assert any("source[0].gff" in e and "required" in e for e in _errors(tmp_path, body))
+    body = GFF.replace('attributes = ["gene_id", "Rat_gene_id"]', "attributes = []")
+    assert any("non-empty" in e for e in _errors(tmp_path, body))
+
+
+def test_gff_table_rejected_for_other_providers(tmp_path):
+    body = GFF.replace('provider = "gff"', 'provider = "bed"').replace('index = "tabix"\n', "")
+    assert any("source[0].gff is only valid for provider gff" in e for e in _errors(tmp_path, body))
+
+
+def test_tabix_allowed_for_gff(tmp_path):
+    assert not any("index='tabix'" in e for e in _errors(tmp_path, GFF))
+
+
+def test_lookup_values(tmp_path):
+    body = GFF.replace('lookup = "interval"', 'lookup = "span"')
+    assert any("lookup must be one of" in e for e in _errors(tmp_path, body))
+
+
+def test_interval_rejects_allele_match(tmp_path):
+    body = GFF.replace('lookup = "interval"', 'lookup = "interval"\nallele_match = "minimised"')
+    assert any("allele_match" in e and "interval" in e for e in _errors(tmp_path, body))
+
+
+def test_point_default_still_accepts_existing_manifests():
+    errors: list[str] = []
+    for path in sorted(vm.ROOT.glob(vm.MANIFEST_GLOB)):
+        vm.validate_manifest(path, errors)
+    assert errors == []
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd <worktree> && python -m pytest -q tests/test_validate_manifests.py`
+Expected: `test_gff_interval_manifest_is_valid` fails with `source[0].provider must be one of […]`; the negative tests fail because the errors are not produced.
+
+- [ ] **Step 3: Implement**
+
+`scripts/validate_manifests.py`:
+
+```python
+PROVIDERS = {"vcf", "csv", "tsv", "parquet", "bed", "gff"}
+LOOKUPS = {"point", "interval"}
+TABIX_PROVIDERS = {"csv", "tsv", "vcf", "gff"}
+```
+
+After the `field_order` check:
+
+```python
+    lookup = manifest.get("lookup", "point")
+    if lookup not in LOOKUPS:
+        errors.append(f"{path}: lookup must be one of {sorted(LOOKUPS)}")
+    elif lookup == "interval" and manifest.get("allele_match", "exact") != "exact":
+        errors.append(
+            f"{path}: allele_match has no meaning with lookup='interval' "
+            "(interval rows carry no allele); remove it"
+        )
+```
+
+In the source loop, replace the tabix provider set with `TABIX_PROVIDERS` and add after the `csv` checks:
+
+```python
+            gff = source.get("gff")
+            if provider == "gff":
+                if not isinstance(gff, dict):
+                    errors.append(f"{path}: {label}.gff table is required for provider gff")
+                else:
+                    attributes = gff.get("attributes")
+                    if (
+                        not isinstance(attributes, list)
+                        or not attributes
+                        or not all(isinstance(a, str) and a for a in attributes)
+                    ):
+                        errors.append(
+                            f"{path}: {label}.gff.attributes must be a non-empty list of strings"
+                        )
+            elif gff is not None:
+                errors.append(f"{path}: {label}.gff is only valid for provider gff")
+```
+
+Update the tabix message to `"index='tabix' is supported only for csv/tsv/vcf/gff"`.
+
+`.github/workflows/validate-manifests.yml`: after the existing validator step add
+
+```yaml
+      - run: pip install pytest && pytest -q tests
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `python -m pytest -q tests/test_validate_manifests.py && python scripts/validate_manifests.py`
+Expected: all pass; validator prints `Validated 5 plugin source manifests`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/validate_manifests.py tests/test_validate_manifests.py .github/workflows/validate-manifests.yml
+git commit -m "feat(validator): accept gff sources, [source.gff].attributes and lookup=interval"
+```
+
+### Task 2: The manifest
+
+**Files:**
+- Create: `plugins/phenotypeorthologous/phenotypeorthologous.source.toml`
+- Create: `plugins/phenotypeorthologous/README.md`
+
+- [ ] **Step 1: Write the manifest**
+
+```toml
+# PhenotypeOrthologous — phenotypes of rat and mouse orthologues, keyed by the
+# Ensembl gene overlapping the variant (Ensembl VEP `PhenotypeOrthologous.pm`,
+# VEP_plugins release/116, sha256 89be8f30dd464f81913bef367831e8a08258e4085207f8291c956487f47de8ac).
+#
+# VEP queries the GFF with the VARIANT's span and keeps the first record whose
+# `gene_id` equals the transcript's gene stable id, so a flanking variant only
+# matches while it still lies inside the gene span. `lookup = "interval"`
+# reproduces exactly that: span overlap + `{Gene}` discriminator, first row in
+# file order. The plugin's optional `model=rat|mouse` filter is not modelled;
+# all four fields are always emitted (empty where the file has no value).
+plugin_name       = "phenotypeorthologous"
+coordinate_system = "1-based"
+lookup            = "interval"
+field_order       = "alphabetical"   # loaded with --plugin: VEP sorts header keys
+assume_unique     = true             # one row per gene_id in the file (16,409 rows, 0 dups)
+ingest_sql = """
+SELECT chrom,
+       start,
+       "end",
+       gene_id,
+       "Mouse_gene_id"               AS mouse_gene_id,
+       "Mouse_Orthologous_phenotype" AS mouse_phenotype,
+       "Rat_gene_id"                 AS rat_gene_id,
+       "Rat_Orthologous_phenotype"   AS rat_phenotype
+FROM plugin_phenotypeorthologous_src
+"""
+
+[[source]]
+provider = "gff"
+path     = "PhenotypesOrthologous_homo_sapiens_112_GRCh38.gff3.gz"
+url      = "https://ftp.ensembl.org/pub/release-116/variation/PhenotypeOrthologous/PhenotypesOrthologous_homo_sapiens_112_GRCh38.gff3.gz"
+# Computed locally on 2026-09-11 (3,424,946 bytes): the CHECKSUMS file in that
+# directory is BSD `sum` output, not MD5. Sibling .tbi md5: 1eb833a26c247418910685289c6528cc.
+md5      = "20e5401a198d7d3db66a982c037d3ad4"
+index    = "tabix"
+  [source.gff]
+  attributes = [
+    "gene_id",
+    "Mouse_gene_id",
+    "Mouse_Orthologous_phenotype",
+    "Rat_gene_id",
+    "Rat_Orthologous_phenotype",
+  ]
+
+[[match_column]]
+column   = "gene_id"
+template = "{Gene}"
+
+[[value_columns]]
+column      = "mouse_gene_id"
+csq_field   = "PhenotypeOrthologous_Mouse_geneid"
+type        = "Utf8"
+description = "PhenotypeOrthologous MouseGene associated with Mouse"
+
+[[value_columns]]
+column      = "mouse_phenotype"
+csq_field   = "PhenotypeOrthologous_Mouse_phenotype"
+type        = "Utf8"
+description = "PhenotypeOrthologous MousePhenotypes associated with orthologous genes in Mouse"
+
+[[value_columns]]
+column      = "rat_gene_id"
+csq_field   = "PhenotypeOrthologous_Rat_geneid"
+type        = "Utf8"
+description = "PhenotypeOrthologous RatGene associated with Rat"
+
+[[value_columns]]
+column      = "rat_phenotype"
+csq_field   = "PhenotypeOrthologous_Rat_phenotype"
+type        = "Utf8"
+description = "PhenotypeOrthologous RatPhenotypes associated with orthologous genes in Rat"
+```
+
+- [ ] **Step 2: Write the per-plugin README**
+
+`plugins/phenotypeorthologous/README.md`:
+
+```markdown
+# PhenotypeOrthologous
+
+Source: Ensembl release-116 FTP,
+`variation/PhenotypeOrthologous/PhenotypesOrthologous_homo_sapiens_112_GRCh38.gff3.gz`
+(BGZF + `.tbi`, 3.4 MB, 16,409 gene features on chr1–22, X, MT and four
+unplaced contigs; no chrY). GRCh38 only, as the upstream plugin enforces.
+
+The file is used as published — no preprocessing — so `verify_source="strict"`
+applies. Ensembl's `CHECKSUMS` there is BSD `sum` output; the manifest `md5`
+was computed on the downloaded file.
+
+Match rule (from `PhenotypeOrthologous.pm`): tabix query by the variant's span,
+first record whose `gene_id` equals the transcript's gene stable id. Fields
+are emitted alphabetically (VEP sorts plugin header keys). RefSeq transcripts
+in a merged cache never match (their gene id is not an ENSG id). Licence:
+Ensembl data, free for any use (see the Ensembl FTP README).
+```
+
+- [ ] **Step 3: Validate**
+
+Run: `python scripts/validate_manifests.py && python -m pytest -q tests`
+Expected: `Validated 6 plugin source manifests`; tests pass (the existing-manifests test now covers the new file).
+
+- [ ] **Step 4: Build chr22 against the engine PR branch** (requires the engine plan's PR 2 branch checked out in `/Users/mwiewior/research/git/datafusion-bio-functions` worktree `<engine-wt>`; the GFF and `.tbi` downloaded to `~/workspace/data_vepyr/plugin_input/phenotypeorthologous/`)
+
+```bash
+cd <engine-wt>
+cargo run -p datafusion-bio-function-vep --features parquet-cache --example build_plugin -- \
+  --manifest <catalog-wt>/plugins/phenotypeorthologous/phenotypeorthologous.source.toml \
+  --source-path ~/workspace/data_vepyr/plugin_input/phenotypeorthologous/PhenotypesOrthologous_homo_sapiens_112_GRCh38.gff3.gz \
+  --variation-cache-dir ~/workspace/data_vepyr/cache/116_GRCh38_merged \
+  --out /tmp/po_cache --chrom 22 --verify-source strict
+```
+
+Expected output: `chr22 rows=377 warm=0 cold=377` and `wrote plugin/phenotypeorthologous/manifest.json`. Then check the schema:
+
+```bash
+uv run --project /Users/mwiewior/research/git/vepyr python -c "
+import polars as pl; df = pl.read_parquet('/tmp/po_cache/plugin/phenotypeorthologous/chr22.parquet')
+print(df.schema); print(df.head(3))"
+```
+
+Expected columns: `chrom, start, end, gene_id, mouse_gene_id, mouse_phenotype, rat_gene_id, rat_phenotype, tier`; first row gene `ENSG00000198445` at 16590751–16592810 (the first chr22 feature in the file).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugins/phenotypeorthologous/
+git commit -m "feat(phenotypeorthologous): gff-sourced interval manifest for Ensembl's PhenotypeOrthologous plugin"
+```
+
+### Task 3: README and skill doc
+
+**Files:**
+- Modify: `README.md:24-45` (manifest table + "All five" paragraph), `:97-127` (Adding a plugin step 1 and 4)
+- Modify: `.claude/skills/adding-a-plugin/SKILL.md:111-200` (§1 source formats: add a GFF bullet), and add a short "§1b. Lookup kinds" subsection after it
+
+- [ ] **Step 1: README edits**
+
+Add the table row after dbNSFP:
+
+```markdown
+| **PhenotypeOrthologous** | [`plugins/phenotypeorthologous`](plugins/phenotypeorthologous/phenotypeorthologous.source.toml) | GFF3 (tabix), `lookup = "interval"` | `{Gene}` + span overlap | 4 | ✅ |
+```
+
+Change "All five are validated" to "All six are validated against golden Ensembl VEP 116 output. Five have a prebuilt cache…". In "Adding a plugin" step 1 add "gene-span GFF → `phenotypeorthologous`"; in step 4 add "`lookup`, `[source.gff]`" to the list of things the validator checks.
+
+- [ ] **Step 2: Skill doc edits**
+
+Append to the §1 list:
+
+```markdown
+- **GFF3** (features with `key=value;` attributes): `provider = "gff"` via
+  `datafusion-bio-format-gff`. Declare the attribute keys you need in
+  `[source.gff].attributes`; each becomes a flat nullable Utf8 column with the
+  attribute's exact name (quote it in SQL when it has upper-case letters:
+  `"Rat_gene_id"`). The eight fixed columns are `chrom, start, end, type,
+  source, score, strand, phase`. Values are percent-decoded (`%3B` → `;`) and
+  never trimmed. BGZF + `.tbi` sources take `index = "tabix"` and are sliced
+  per chromosome; plain or gzip GFF is read whole.
+```
+
+New subsection:
+
+```markdown
+## 1b. Lookup kinds: `point` (default) vs `interval`
+
+`point` is the exact probe on `(start, allele_string, <match…>)` with tiering
+inherited from the variation cache — every per-variant scoring plugin.
+
+`interval` is for a source whose rows are genomic spans with no allele (gene
+or region tracks). The shard drops `allele_string`, skips the tier join, keeps
+file order per `(start)`, and at runtime a row matches when its `[start, end]`
+overlaps the variant's VEP-normalised span **and** every `[[match_column]]`
+discriminator agrees; the first row in file order wins. Decide by reading the
+Ensembl plugin's `run()`: if it calls `get_data($vf->{chr}, $vf_start,
+$vf_end)` and filters by an id, that is `interval` + a template such as
+`{Gene}`. `allele_match` is rejected for `interval`.
+```
+
+- [ ] **Step 3: Validate docs render and commit**
+
+Run: `python scripts/validate_manifests.py` (no change expected) and view the README diff.
+
+```bash
+git add README.md .claude/skills/adding-a-plugin/SKILL.md
+git commit -m "docs: GFF sources, interval lookup and the PhenotypeOrthologous row"
+```
+
+### Task 4: Draft PR and release handoff
+
+- [ ] **Step 1: Push and open the draft PR**
+
+```bash
+git push -u origin feat/phenotypeorthologous
+gh pr create --draft --title "feat: PhenotypeOrthologous manifest (gff source, interval lookup)" --body-file <(cat <<'EOF'
+Adds `plugins/phenotypeorthologous/`, sourced from Ensembl's release-116 GFF3 (md5-pinned, tabix), keyed by gene span + `{Gene}`. Validator learns `provider = "gff"`, `[source.gff].attributes` and `lookup = "interval"`.
+
+Requires datafusion-bio-functions PRs #<PR1> and #<PR2>. Parity evidence lands in vepyr PR #<PR4>. Release as `v0.2.0` (minor: new plugin) after merge.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+https://claude.ai/code/session_01Ybip12LHW1qoorZjs3TwYT
+EOF
+)
+```
+
+- [ ] **Step 2: Handoff note for the human**: after merge, run the Release workflow with `bump=minor` (→ `v0.2.0`); the vepyr plan's publish task pins that tag in `build_plugin_cache(..., "v0.2.0", ...)` and records it as `cache_source_version`.

--- a/docs/superpowers/plans/2026-09-11-catalog-phenotypeorthologous-manifest.md
+++ b/docs/superpowers/plans/2026-09-11-catalog-phenotypeorthologous-manifest.md
@@ -367,7 +367,8 @@ inherited from the variation cache — every per-variant scoring plugin.
 or region tracks). The shard drops `allele_string`, skips the tier join, keeps
 file order per `(start)`, and at runtime a row matches when its `[start, end]`
 overlaps the variant's VEP-normalised span **and** every `[[match_column]]`
-discriminator agrees; the first row in file order wins. Decide by reading the
+discriminator agrees (an interval tree per discriminator, so dense tracks are
+fine); the first row in file order wins. Decide by reading the
 Ensembl plugin's `run()`: if it calls `get_data($vf->{chr}, $vf_start,
 $vf_end)` and filters by an id, that is `interval` + a template such as
 `{Gene}`. `allele_match` is rejected for `interval`.

--- a/docs/superpowers/plans/2026-09-11-engine-gff-provider-and-interval-lookup.md
+++ b/docs/superpowers/plans/2026-09-11-engine-gff-provider-and-interval-lookup.md
@@ -1,0 +1,1373 @@
+# Engine: `gff` provider and `lookup = "interval"` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a plugin source manifest read a GFF3 file (`provider = "gff"`) and declare an interval-keyed lookup (`lookup = "interval"`) so the PhenotypeOrthologous plugin can be built and probed by the engine.
+
+**Architecture:** Two stacked PRs on `biodatageeks/datafusion-bio-functions`. PR 1 adds a `ProviderKind::Gff` arm on top of `datafusion-bio-format-gff`'s `GffTableProvider` (flat attribute columns, per-chromosome slicing through the existing tabix materialiser). PR 2 adds a `LookupKind` (`point` today, new `interval`) that drops `allele_string`, skips the variation tier join at build time, and at runtime loads the whole per-chromosome shard into a discriminator-keyed interval map probed with the variant's VEP-normalised span.
+
+**Tech Stack:** Rust 2021, DataFusion 53, Arrow/Parquet 58, `datafusion-bio-format-gff` tag `v1.12.1`, noodles (bgzf/tabix/csi) at the workspace revs, serde/toml.
+
+**Spec:** `docs/superpowers/specs/2026-09-11-gff-plugin-source-and-phenotypeorthologous-design.md` (in vepyr).
+
+## Global Constraints
+
+- Work in a git worktree of `/Users/mwiewior/research/git/datafusion-bio-functions` branched from `origin/master` at `4b0bd00` (vepyr's current pin). Do not branch from the local `fix/mnv-allele-trim-parity` checkout.
+- bio-formats crates are pinned by **tag** `v1.12.1` in `datafusion/bio-function-vep/Cargo.toml`; the new `datafusion-bio-format-gff` dependency must use the same `tag = "v1.12.1"` form, never `rev`.
+- Crate: `datafusion/bio-function-vep`. Module: `src/plugin_cache/`. Run tests with `cargo test -p datafusion-bio-function-vep --features parquet-cache -- plugin_cache` from the repo root; run `cargo fmt --all` and `cargo clippy -p datafusion-bio-function-vep --features parquet-cache --all-targets -- -D warnings` before each commit.
+- Existing point-lookup behaviour must not change: every existing `plugin_cache` test keeps passing unmodified except where a signature gains a parameter (those tests pass `LookupKind::Point` / the old key list).
+- PR 1 = Tasks 1–3 (branch `feat/plugin-gff-provider`). PR 2 = Tasks 4–9 (branch `feat/plugin-interval-lookup`, stacked on PR 1). Draft PRs, no merging by the agent (vepyr-fix discipline).
+- Commit message trailer on every commit:
+  `Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>` and
+  `Claude-Session: https://claude.ai/code/session_01Ybip12LHW1qoorZjs3TwYT`.
+
+---
+
+## PR 1 — `gff` provider
+
+### Task 1: Manifest surface for `gff`
+
+**Files:**
+- Modify: `datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs:19-29` (`ProviderKind`), `:60-77` (params structs), `:79-111` (`SourceSpec`), `:271-320` (`validate`)
+- Test: same file, `mod tests`
+
+**Interfaces:**
+- Produces: `ProviderKind::Gff`; `pub struct GffParams { pub attributes: Vec<String> }`; `SourceSpec.gff: Option<GffParams>`.
+
+- [ ] **Step 1: Write the failing tests** (append inside `mod tests` of `source_manifest.rs`)
+
+```rust
+    const GFF_MANIFEST: &str = r##"
+plugin_name = "po"
+coordinate_system = "1-based"
+ingest_sql = "SELECT chrom, start, \"end\", gene_id, \"Rat_gene_id\" AS rat FROM plugin_po_src"
+
+[[source]]
+provider = "gff"
+path = "/tmp/po.gff3.gz"
+url = "https://example.org/po.gff3.gz"
+md5 = "20e5401a198d7d3db66a982c037d3ad4"
+index = "tabix"
+  [source.gff]
+  attributes = ["gene_id", "Rat_gene_id"]
+
+[[value_columns]]
+column = "rat"
+csq_field = "PO_Rat"
+type = "Utf8"
+"##;
+
+    #[test]
+    fn parses_gff_source_with_attributes() {
+        let m: SourceManifest = toml::from_str(GFF_MANIFEST).unwrap();
+        m.validate().unwrap();
+        assert_eq!(m.sources[0].provider, ProviderKind::Gff);
+        assert_eq!(
+            m.sources[0].gff.as_ref().unwrap().attributes,
+            vec!["gene_id".to_string(), "Rat_gene_id".to_string()]
+        );
+        assert_eq!(m.sources[0].index, Some(SourceIndex::Tabix));
+    }
+
+    #[test]
+    fn gff_source_requires_attributes() {
+        let missing = GFF_MANIFEST.replace(
+            "  [source.gff]\n  attributes = [\"gene_id\", \"Rat_gene_id\"]\n",
+            "",
+        );
+        let m: SourceManifest = toml::from_str(&missing).unwrap();
+        let err = m.validate().unwrap_err().to_string();
+        assert!(err.contains("[source.gff]"), "{err}");
+
+        let empty = GFF_MANIFEST.replace(
+            "attributes = [\"gene_id\", \"Rat_gene_id\"]",
+            "attributes = []",
+        );
+        let m: SourceManifest = toml::from_str(&empty).unwrap();
+        let err = m.validate().unwrap_err().to_string();
+        assert!(err.contains("at least one attribute"), "{err}");
+    }
+
+    #[test]
+    fn gff_table_is_rejected_on_other_providers() {
+        let wrong = GFF_MANIFEST
+            .replace("provider = \"gff\"", "provider = \"bed\"")
+            .replace("index = \"tabix\"\n", "");
+        let m: SourceManifest = toml::from_str(&wrong).unwrap();
+        let err = m.validate().unwrap_err().to_string();
+        assert!(err.contains("[source.gff]") && err.contains("Bed"), "{err}");
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cargo test -p datafusion-bio-function-vep --features parquet-cache -- plugin_cache::source_manifest`
+Expected: compile error, `no variant named Gff` / `no field gff`.
+
+- [ ] **Step 3: Implement**
+
+In `source_manifest.rs`:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ProviderKind {
+    Vcf,
+    Csv,
+    Tsv,
+    Parquet,
+    Bed,
+    /// GFF3 via `datafusion-bio-format-gff`. `[source.gff].attributes` names the
+    /// attribute keys exposed as flat Utf8 columns next to the eight fixed
+    /// GFF columns (`chrom, start, end, type, source, score, strand, phase`).
+    Gff,
+}
+
+/// GFF provider parameters.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GffParams {
+    /// Attribute keys to project as flat nullable Utf8 columns, in this order.
+    /// Values are percent-decoded by the reader and otherwise untouched.
+    pub attributes: Vec<String>,
+}
+```
+
+Add to `SourceSpec` after `csv`:
+
+```rust
+    #[serde(default)]
+    pub gff: Option<GffParams>,
+```
+
+In `validate()`, inside the `for source in &self.sources` loop, before the tabix checks:
+
+```rust
+            match (source.provider, source.gff.as_ref()) {
+                (ProviderKind::Gff, None) => {
+                    return Err(DataFusionError::Execution(format!(
+                        "plugin '{}' {} is a gff source but has no [source.gff] table",
+                        self.plugin_name,
+                        source.label()
+                    )));
+                }
+                (ProviderKind::Gff, Some(gff)) if gff.attributes.is_empty() => {
+                    return Err(DataFusionError::Execution(format!(
+                        "plugin '{}' {} must list at least one attribute in \
+                         [source.gff].attributes",
+                        self.plugin_name,
+                        source.label()
+                    )));
+                }
+                (other, Some(_)) if other != ProviderKind::Gff => {
+                    return Err(DataFusionError::Execution(format!(
+                        "plugin '{}' {} declares [source.gff] for a {other:?} source",
+                        self.plugin_name,
+                        source.label()
+                    )));
+                }
+                _ => {}
+            }
+```
+
+Extend the tabix provider check at `:291-300` to include `ProviderKind::Gff`:
+
+```rust
+                if !matches!(
+                    source.provider,
+                    ProviderKind::Csv | ProviderKind::Tsv | ProviderKind::Vcf | ProviderKind::Gff
+                ) {
+                    return Err(DataFusionError::Execution(format!(
+                        "plugin '{}' declares a tabix index for a {:?} source; tabix indexes are \
+                         supported only for csv/tsv/vcf/gff providers",
+                        self.plugin_name, source.provider
+                    )));
+                }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cargo test -p datafusion-bio-function-vep --features parquet-cache -- plugin_cache::source_manifest`
+Expected: all PASS, including the pre-existing ones.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs
+git commit -m "feat(plugin-cache): declare gff sources with [source.gff].attributes"
+```
+
+### Task 2: `GffTableProvider` registration arm
+
+**Files:**
+- Modify: `datafusion/bio-function-vep/Cargo.toml:41-44` (dependency)
+- Modify: `datafusion/bio-function-vep/src/plugin_cache/provider.rs:13-27` (imports), `:46-119` (`materialize_tabix_chrom` suffix), `:167-279` (`register_sources_impl`)
+- Test: `provider.rs` `mod tests`
+
+**Interfaces:**
+- Consumes: `ProviderKind::Gff`, `SourceSpec.gff` (Task 1); `GffTableProvider::new(file_path: String, attr_fields: Option<Vec<String>>, object_storage_options: Option<ObjectStorageOptions>, coordinate_system_zero_based: bool) -> Result<Self>` from `datafusion_bio_format_gff::table_provider`.
+- Produces: table `plugin_<name>_src[_<part>]` with columns `chrom Utf8, start UInt32, end UInt32, type Utf8, source Utf8, score Float32?, strand Utf8, phase UInt32?` + one nullable Utf8 column per attribute.
+
+- [ ] **Step 1: Add the dependency**
+
+In `datafusion/bio-function-vep/Cargo.toml` after the `datafusion-bio-format-bed` line:
+
+```toml
+datafusion-bio-format-gff = { git = "https://github.com/biodatageeks/datafusion-bio-formats.git", tag = "v1.12.1" }
+```
+
+Run: `cargo check -p datafusion-bio-function-vep --features parquet-cache` — Expected: OK (same tag, no duplicate crate graph).
+
+- [ ] **Step 2: Write the failing tests** (append to `mod tests` in `provider.rs`)
+
+```rust
+    /// Three gene features on two contigs. `%3B` must decode, the leading space
+    /// on the rat phenotype must survive, and the mouse attribute is absent on
+    /// the second row.
+    const GFF_ROWS: &[(&str, usize, usize, &str)] = &[
+        ("1", 600000, 605000, "ID=gene:ENSG1;gene_id=ENSG1;Rat_gene_id=RNO1;Rat_Orthologous_phenotype= a b|c%3Bd;Mouse_gene_id=MUS1"),
+        ("1", 610000, 612000, "ID=gene:ENSG2;gene_id=ENSG2;Rat_gene_id=RNO2;Rat_Orthologous_phenotype=x"),
+        ("2", 100, 200, "ID=gene:ENSG3;gene_id=ENSG3;Rat_gene_id=RNO3;Rat_Orthologous_phenotype=y"),
+    ];
+
+    fn gff_body() -> String {
+        let mut s = String::from("##gff-version 3\n");
+        for &(c, st, en, attrs) in GFF_ROWS {
+            s.push_str(&format!("{c}\ttest\tgene\t{st}\t{en}\t.\t+\t.\t{attrs}\n"));
+        }
+        s
+    }
+
+    fn write_bgzf_tabix_gff(path: &std::path::Path) {
+        let file = std::fs::File::create(path).unwrap();
+        let mut writer = noodles_bgzf::io::Writer::new(file);
+        let mut indexer = noodles_tabix::index::Indexer::default();
+        indexer.set_header(
+            csi::binning_index::index::header::Builder::gff()
+                .set_line_skip_count(0)
+                .build(),
+        );
+        writeln!(writer, "##gff-version 3").unwrap();
+        let mut chunk_start = writer.virtual_position();
+        for &(c, st, en, attrs) in GFF_ROWS {
+            writeln!(writer, "{c}\ttest\tgene\t{st}\t{en}\t.\t+\t.\t{attrs}").unwrap();
+            let chunk_end = writer.virtual_position();
+            indexer
+                .add_record(
+                    c,
+                    Position::try_from(st).unwrap(),
+                    Position::try_from(en).unwrap(),
+                    Chunk::new(chunk_start, chunk_end),
+                )
+                .unwrap();
+            chunk_start = chunk_end;
+        }
+        writer.finish().unwrap();
+        let index_file = std::fs::File::create(format!("{}.tbi", path.display())).unwrap();
+        let mut index_writer = noodles_tabix::io::Writer::new(index_file);
+        index_writer.write_index(&indexer.build()).unwrap();
+    }
+
+    fn gff_manifest(path: &std::path::Path, tabix: bool) -> SourceManifest {
+        let index = if tabix { "index = \"tabix\"" } else { "" };
+        toml::from_str(&format!(
+            r##"
+plugin_name = "po"
+coordinate_system = "1-based"
+ingest_sql = "SELECT 1"
+
+[[source]]
+provider = "gff"
+path = "{}"
+{index}
+  [source.gff]
+  attributes = ["gene_id", "Rat_gene_id", "Rat_Orthologous_phenotype", "Mouse_gene_id"]
+
+[[value_columns]]
+column = "rat"
+csq_field = "PO_Rat"
+type = "Utf8"
+"##,
+            path.display()
+        ))
+        .unwrap()
+    }
+
+    async fn collect_gff(ctx: &SessionContext) -> Vec<(String, u32, u32, Option<String>, Option<String>, Option<String>)> {
+        use datafusion::arrow::array::UInt32Array;
+        let batches = ctx
+            .sql("SELECT chrom, start, \"end\", gene_id, \"Rat_Orthologous_phenotype\", \"Mouse_gene_id\" FROM plugin_po_src ORDER BY start")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        let mut out = Vec::new();
+        for b in &batches {
+            let chrom = b.column(0).as_any().downcast_ref::<StringArray>().unwrap();
+            let start = b.column(1).as_any().downcast_ref::<UInt32Array>().unwrap();
+            let end = b.column(2).as_any().downcast_ref::<UInt32Array>().unwrap();
+            let gene = b.column(3).as_any().downcast_ref::<StringArray>().unwrap();
+            let rat = b.column(4).as_any().downcast_ref::<StringArray>().unwrap();
+            let mouse = b.column(5).as_any().downcast_ref::<StringArray>().unwrap();
+            for r in 0..b.num_rows() {
+                let opt = |a: &StringArray| (!a.is_null(r)).then(|| a.value(r).to_string());
+                out.push((chrom.value(r).to_string(), start.value(r), end.value(r), opt(gene), opt(rat), opt(mouse)));
+            }
+        }
+        out
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn gff_plain_and_gzip_expose_flat_attributes() {
+        let dir = tempfile::tempdir().unwrap();
+        let plain = dir.path().join("po.gff3");
+        std::fs::write(&plain, gff_body()).unwrap();
+        let gz = dir.path().join("po.gff3.gz");
+        write_gz(&gz, &gff_body());
+
+        for path in [plain, gz] {
+            let ctx = SessionContext::new();
+            let temps = register_sources(&ctx, &gff_manifest(&path, false)).await.unwrap();
+            assert!(temps.is_empty(), "gff needs no staging temp: {path:?}");
+            let rows = collect_gff(&ctx).await;
+            assert_eq!(rows.len(), 3, "{path:?}");
+            assert_eq!(rows[0].0, "2");
+            assert_eq!((rows[1].1, rows[1].2), (600000, 605000), "1-based coordinates pass through");
+            assert_eq!(rows[1].3.as_deref(), Some("ENSG1"));
+            assert_eq!(rows[1].4.as_deref(), Some(" a b|c;d"), "leading space kept, %3B decoded");
+            assert_eq!(rows[1].5.as_deref(), Some("MUS1"));
+            assert_eq!(rows[2].5, None, "absent attribute is NULL");
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn gff_tabix_source_materializes_only_requested_contig() {
+        let dir = tempfile::tempdir().unwrap();
+        let gz = dir.path().join("po.gff3.gz");
+        write_bgzf_tabix_gff(&gz);
+        let manifest = gff_manifest(&gz, true);
+
+        let ctx = SessionContext::new();
+        let temps = register_sources_for_chrom(&ctx, &manifest, "chr1").await.unwrap();
+        assert_eq!(temps.len(), 1);
+        let rows = collect_gff(&ctx).await;
+        assert_eq!(rows.iter().map(|r| r.0.as_str()).collect::<Vec<_>>(), vec!["1", "1"]);
+        assert_eq!(rows[0].4.as_deref(), Some(" a b|c;d"));
+
+        // A contig absent from the index yields zero rows, not an error.
+        let ctx = SessionContext::new();
+        register_sources_for_chrom(&ctx, &manifest, "X").await.unwrap();
+        assert!(collect_gff(&ctx).await.is_empty());
+
+        // Unscoped registration of a tabix source is refused, as for csv.
+        let ctx = SessionContext::new();
+        assert!(register_sources(&ctx, &manifest).await.is_err());
+    }
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `cargo test -p datafusion-bio-function-vep --features parquet-cache -- plugin_cache::provider::tests::gff`
+Expected: FAIL — `register_sources_impl` has no `Gff` arm (non-exhaustive match compile error).
+
+- [ ] **Step 4: Implement the arm**
+
+Imports in `provider.rs`:
+
+```rust
+use datafusion_bio_format_gff::table_provider::GffTableProvider;
+```
+
+Change `materialize_tabix_chrom` to take the temp suffix so a GFF slice keeps a GFF name (the reader sniffs compression by content, but a recognisable suffix helps debugging):
+
+```rust
+fn materialize_tabix_chrom(path: &str, chrom: &str, suffix: &str) -> Result<(String, tempfile::TempPath)> {
+    ...
+    let mut tmp = tempfile::Builder::new()
+        .prefix("plugin_src_")
+        .suffix(suffix)
+        .tempfile()
+```
+
+and pass `".tsv"` from `materialize_plain` (`:140`). Add the arm before `ProviderKind::Bed`:
+
+```rust
+            ProviderKind::Gff => {
+                let gff = spec.gff.as_ref().ok_or_else(|| {
+                    DataFusionError::Execution(format!("gff source '{table}' missing [source.gff]"))
+                })?;
+                // Same lock-step rule as the VCF/BED arms: `ingest_sql` sees the
+                // coordinate system the manifest declares.
+                let zero_based = matches!(
+                    manifest.coordinate_system,
+                    CoordinateSystem::ZeroBasedHalfOpen
+                );
+                // A tabix-indexed GFF is sliced to the requested contig exactly
+                // like an indexed TSV (records copied verbatim, so the temp is
+                // valid GFF3). Plain or gzip GFF is opened in place: the reader
+                // detects compression by content and reads it whole.
+                let path = if spec.index == Some(SourceIndex::Tabix) {
+                    let chrom = chrom.ok_or_else(|| {
+                        DataFusionError::Execution(format!(
+                            "BGZF/tabix source '{}' requires a chromosome-scoped plugin-cache build",
+                            spec.path
+                        ))
+                    })?;
+                    let (plain, temp) = materialize_tabix_chrom(&spec.path, chrom, ".gff3")?;
+                    temps.push(temp);
+                    plain
+                } else {
+                    spec.path.clone()
+                };
+                let provider = GffTableProvider::new(path, Some(gff.attributes.clone()), None, zero_based)
+                    .map_err(|e| DataFusionError::Execution(format!("open GFF source '{table}': {e}")))?;
+                ctx.register_table(&table, Arc::new(provider))?;
+            }
+```
+
+Update the module doc at `:1-11` with one sentence: "GFF uses `datafusion-bio-format-gff`'s `GffTableProvider` with the manifest's `[source.gff].attributes` projected as flat Utf8 columns."
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cargo test -p datafusion-bio-function-vep --features parquet-cache -- plugin_cache::provider`
+Expected: PASS. If `gff_tabix_source_materializes_only_requested_contig` fails because the reader reports zero rows for the temp slice, the header comment line is the cause: `Builder::gff()` sets `meta = '#'`, and the query result never contains header lines, so check that the temp file's first record starts with a contig, then check `GffTableProvider` accepts a file without `##gff-version` (it does in v1.12.1; if not, write `##gff-version 3\n` at the top of the temp in the Gff arm before the records).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add datafusion/bio-function-vep/Cargo.toml Cargo.lock datafusion/bio-function-vep/src/plugin_cache/provider.rs
+git commit -m "feat(plugin-cache): gff source provider via datafusion-bio-format-gff"
+```
+
+### Task 3: PR 1 hygiene and draft PR
+
+**Files:**
+- Modify: `datafusion/bio-function-vep/src/plugin_cache/mod.rs:1-8` (module doc mentions GFF), `datafusion/bio-function-vep/examples/build_plugin.rs:1-18` (doc comment: "`gff` sources with `index = \"tabix\"` are sliced per chromosome like indexed TSV")
+
+- [ ] **Step 1: Full test, fmt, clippy**
+
+Run: `cargo fmt --all && cargo clippy -p datafusion-bio-function-vep --features parquet-cache --all-targets -- -D warnings && cargo test -p datafusion-bio-function-vep --features parquet-cache`
+Expected: clean; all tests pass.
+
+- [ ] **Step 2: Commit and open the draft PR**
+
+```bash
+git add -A datafusion/bio-function-vep/src/plugin_cache/mod.rs datafusion/bio-function-vep/examples/build_plugin.rs
+git commit -m "docs(plugin-cache): mention the gff provider"
+git push -u origin feat/plugin-gff-provider
+gh pr create --draft --title "feat(plugin-cache): gff source provider" --body-file <(cat <<'EOF'
+Adds `provider = "gff"` to plugin source manifests, backed by `datafusion-bio-format-gff` (tag v1.12.1). `[source.gff].attributes` projects attribute keys as flat Utf8 columns; `index = "tabix"` slices per chromosome through the existing tabix materialiser.
+
+First half of the PhenotypeOrthologous port; the interval lookup follows in a stacked PR. Spec: vepyr `docs/superpowers/specs/2026-09-11-gff-plugin-source-and-phenotypeorthologous-design.md`.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+https://claude.ai/code/session_01Ybip12LHW1qoorZjs3TwYT
+EOF
+)
+```
+
+---
+
+## PR 2 — `lookup = "interval"`
+
+### Task 4: `LookupKind` in both manifests
+
+**Files:**
+- Modify: `datafusion/bio-function-vep/src/plugin_cache/cache_manifest.rs:140-175` (`CacheManifest`), `:177-186` (enums), `:230-268` (`from_source`)
+- Modify: `datafusion/bio-function-vep/src/plugin_cache/source_manifest.rs:176-212` (`SourceManifest`), `validate`
+- Modify: `datafusion/bio-function-vep/src/plugin_cache/builder.rs:279-293` (`schema_matches`)
+- Modify: `datafusion/bio-function-vep/src/plugin_cache/registry.rs:381-409` (test helper `write_empty_manifest` gains `lookup: Default::default()`)
+- Test: `cache_manifest.rs`, `source_manifest.rs` test modules
+
+**Interfaces:**
+- Produces: `pub enum LookupKind { Point, Interval }` (serde lowercase, `Default = Point`) in `cache_manifest.rs`; `SourceManifest.lookup: LookupKind`; `CacheManifest.lookup: LookupKind`; `pub fn key_columns(lookup: LookupKind) -> Vec<String>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `cache_manifest.rs` tests:
+
+```rust
+    #[test]
+    fn legacy_manifest_without_lookup_reads_as_point() {
+        let json = r#"{
+            "plugin_name": "demo",
+            "source_manifest": "demo.source.toml",
+            "key_columns": ["chrom","start","end","allele_string"],
+            "value_columns": [{"column":"s","csq_field":"S","type":"Float32"}],
+            "chroms": []
+        }"#;
+        let m: CacheManifest = serde_json::from_str(json).unwrap();
+        assert_eq!(m.lookup, LookupKind::Point);
+    }
+
+    #[test]
+    fn interval_manifest_records_lookup_and_key_columns() {
+        let src: SourceManifest = toml::from_str(
+            r##"
+plugin_name = "po"
+coordinate_system = "1-based"
+lookup = "interval"
+ingest_sql = "SELECT 1"
+[[source]]
+provider = "gff"
+path = "/tmp/po.gff3.gz"
+  [source.gff]
+  attributes = ["gene_id"]
+[[match_column]]
+column = "gene_id"
+template = "{Gene}"
+[[value_columns]]
+column = "rat"
+csq_field = "PO_Rat"
+type = "Utf8"
+"##,
+        )
+        .unwrap();
+        let cache = CacheManifest::from_source(&src, "po.source.toml");
+        assert_eq!(cache.lookup, LookupKind::Interval);
+        assert_eq!(cache.key_columns, vec!["chrom", "start", "end"]);
+        let json = serde_json::to_string(&cache).unwrap();
+        assert!(json.contains("\"lookup\":\"interval\""));
+    }
+```
+
+In `source_manifest.rs` tests:
+
+```rust
+    #[test]
+    fn interval_lookup_rejects_minimised_allele_match() {
+        let text = GFF_MANIFEST.replace(
+            "coordinate_system = \"1-based\"",
+            "coordinate_system = \"1-based\"\nlookup = \"interval\"\nallele_match = \"minimised\"",
+        );
+        let m: SourceManifest = toml::from_str(&text).unwrap();
+        let err = m.validate().unwrap_err().to_string();
+        assert!(err.contains("allele_match"), "{err}");
+    }
+
+    #[test]
+    fn lookup_defaults_to_point() {
+        let m: SourceManifest = toml::from_str(CADD_LIKE).unwrap();
+        assert_eq!(m.lookup, crate::plugin_cache::cache_manifest::LookupKind::Point);
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p datafusion-bio-function-vep --features parquet-cache -- plugin_cache::cache_manifest plugin_cache::source_manifest`
+Expected: compile errors on `LookupKind` / `.lookup`.
+
+- [ ] **Step 3: Implement**
+
+`cache_manifest.rs`, next to `FieldOrder`:
+
+```rust
+/// How the runtime finds a shard row for a consequence line.
+///
+/// `Point` is the original exact probe on `(start, allele_string, <match…>)`
+/// with variation-inherited tiering. `Interval` rows carry a genomic span and
+/// no allele: a row matches when its `[start, end]` overlaps the variant's
+/// VEP-normalised span and every match discriminator agrees. The first such
+/// row in file order wins, as a tabix-backed Ensembl plugin returns records.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LookupKind {
+    #[default]
+    Point,
+    Interval,
+}
+
+/// The shard key columns a lookup kind stores, in shard order.
+pub fn key_columns(lookup: LookupKind) -> Vec<String> {
+    match lookup {
+        LookupKind::Point => vec!["chrom".into(), "start".into(), "end".into(), "allele_string".into()],
+        LookupKind::Interval => vec!["chrom".into(), "start".into(), "end".into()],
+    }
+}
+```
+
+`CacheManifest` gains, after `field_order`:
+
+```rust
+    /// Lookup kind the shards were built for. Absent in caches built before
+    /// interval plugins existed, which are all point lookups.
+    #[serde(default)]
+    pub lookup: LookupKind,
+```
+
+`from_source`: `key_columns: key_columns(src.lookup)` and `lookup: src.lookup`.
+
+`SourceManifest` gains, after `field_order`:
+
+```rust
+    /// Lookup kind; `interval` drops `allele_string` and the variation tier
+    /// join and matches rows by span overlap plus discriminators.
+    #[serde(default)]
+    pub lookup: crate::plugin_cache::cache_manifest::LookupKind,
+```
+
+`validate()` end, before value-column checks:
+
+```rust
+        if self.lookup == crate::plugin_cache::cache_manifest::LookupKind::Interval
+            && self.allele_match != crate::plugin_cache::cache_manifest::AlleleMatch::Exact
+        {
+            return Err(DataFusionError::Execution(format!(
+                "plugin '{}' sets allele_match = {:?} with lookup = \"interval\"; interval rows \
+                 carry no allele, so allele_match has no meaning there",
+                self.plugin_name, self.allele_match
+            )));
+        }
+```
+
+`builder.rs::schema_matches`: prepend `a.lookup == b.lookup &&` to the boolean.
+
+`registry.rs` test helper `write_empty_manifest` and any other `CacheManifest { .. }` literal in tests: add `lookup: Default::default(),`.
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cargo test -p datafusion-bio-function-vep --features parquet-cache -- plugin_cache`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add datafusion/bio-function-vep/src/plugin_cache/{cache_manifest,source_manifest,builder,registry}.rs
+git commit -m "feat(plugin-cache): LookupKind (point|interval) on source and cache manifests"
+```
+
+### Task 5: Build path for interval shards
+
+**Files:**
+- Modify: `datafusion/bio-function-vep/src/plugin_cache/normalize.rs:56-79` (`wrap_normalization`)
+- Modify: `datafusion/bio-function-vep/src/plugin_cache/write.rs:26-44` (`plugin_output_schema`)
+- Modify: `datafusion/bio-function-vep/src/plugin_cache/dedup.rs:40-51` and `check_assume_unique_sample` (key names parameter)
+- Modify: `datafusion/bio-function-vep/src/plugin_cache/build.rs:410-660` (`build_plugin_chrom_staged`), new fn `write_interval_shard`
+- Test: `normalize.rs`, `write.rs`, `build.rs` test modules
+
+**Interfaces:**
+- `wrap_normalization(inner_view: &str, coord: CoordinateSystem, lookup: LookupKind, match_columns: &[String], value_columns: &[String]) -> String`
+- `plugin_output_schema(lookup: LookupKind, matches: &[MatchColumn], values: &[ValueColumn]) -> SchemaRef`
+- `dedup_keep_first(stream, key_columns: &[String]) -> Result<Vec<RecordBatch>>` and `check_assume_unique_sample(stream, key_columns: &[String])` where `key_columns` is the **full** key list (`["start","allele_string",<match…>]` for point, `["start","end",<match…>]` for interval). Add `pub fn probe_key_columns(lookup: LookupKind, match_columns: &[String]) -> Vec<String>` in `dedup.rs` that builds it.
+- `write_interval_shard(deduped: Vec<RecordBatch>, out_schema: &SchemaRef, path: &Path, chrom: &str, plugin_name: &str) -> Result<(usize, usize, usize)>` in `build.rs` (rows, warm=0, cold=rows).
+
+- [ ] **Step 1: Write the failing tests**
+
+`normalize.rs`:
+
+```rust
+    #[test]
+    fn interval_projection_has_no_allele_string() {
+        let sql = wrap_normalization(
+            "plugin_po_ingest",
+            CoordinateSystem::OneBased,
+            LookupKind::Interval,
+            &["gene_id".to_string()],
+            &["rat".to_string()],
+        );
+        assert!(!sql.contains("allele_string"), "{sql}");
+        assert!(sql.contains("CAST(\"end\" AS BIGINT) AS \"end\", gene_id, rat"), "{sql}");
+    }
+```
+
+(and pass `LookupKind::Point` in the three existing tests.)
+
+`write.rs`:
+
+```rust
+    #[test]
+    fn interval_schema_drops_allele_string_and_keeps_tier() {
+        let schema = plugin_output_schema(
+            LookupKind::Interval,
+            &[MatchColumn { column: "gene_id".into(), template: "{Gene}".into() }],
+            &f32_value_col(),
+        );
+        let names: Vec<_> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+        assert_eq!(names, vec!["chrom", "start", "end", "gene_id", "am_pathogenicity", "tier"]);
+    }
+```
+
+`build.rs` (new test at the end of its `mod tests`, using the GFF helpers — copy `GFF_ROWS`, `gff_body` and `write_gz` from `provider.rs` tests into a small `#[cfg(test)] pub(crate) mod test_gff` module in `provider.rs` so both files share them):
+
+```rust
+    #[tokio::test(flavor = "multi_thread")]
+    async fn interval_build_writes_span_rows_in_file_order_without_tier_join() {
+        use crate::plugin_cache::provider::test_gff::{gff_body, write_gz};
+        let dir = tempfile::tempdir().unwrap();
+        let gz = dir.path().join("po.gff3.gz");
+        write_gz(&gz, &gff_body());
+        let manifest: SourceManifest = toml::from_str(&format!(
+            r##"
+plugin_name = "po"
+coordinate_system = "1-based"
+lookup = "interval"
+field_order = "alphabetical"
+ingest_sql = """
+SELECT chrom, start, "end", gene_id,
+       "Rat_gene_id" AS rat_gene_id, "Rat_Orthologous_phenotype" AS rat_phenotype
+FROM plugin_po_src
+"""
+[[source]]
+provider = "gff"
+path = "{}"
+  [source.gff]
+  attributes = ["gene_id", "Rat_gene_id", "Rat_Orthologous_phenotype"]
+[[match_column]]
+column = "gene_id"
+template = "{{Gene}}"
+[[value_columns]]
+column = "rat_gene_id"
+csq_field = "PO_Rat_geneid"
+type = "Utf8"
+[[value_columns]]
+column = "rat_phenotype"
+csq_field = "PO_Rat_phenotype"
+type = "Utf8"
+"##,
+            gz.display()
+        ))
+        .unwrap();
+        // The variation shard is unused by an interval build; any readable
+        // shard satisfies the signature. `write_synthetic_variation` (existing
+        // helper in this test module, build.rs:679) with no rows is enough.
+        let variation = dir.path().join("chr1.parquet");
+        write_synthetic_variation(&variation, &[]);
+        let out = dir.path().join("cache");
+        let entry = build_plugin_chrom(&manifest, "po.source.toml", &variation, &out, "1")
+            .await
+            .unwrap();
+        assert_eq!((entry.rows, entry.warm, entry.cold), (2, 0, 2));
+        let shard = out.join("plugin/po/chr1.parquet");
+        let batches = read_all(&shard).await;
+        let names: Vec<_> = batches[0].schema().fields().iter().map(|f| f.name().clone()).collect();
+        assert_eq!(names, vec!["chrom", "start", "end", "gene_id", "rat_gene_id", "rat_phenotype", "tier"]);
+        let starts: Vec<u32> = batches.iter().flat_map(|b| b.column(1).as_any().downcast_ref::<UInt32Array>().unwrap().values().to_vec()).collect();
+        assert_eq!(starts, vec![600000, 610000]);
+        let tiers: Vec<i8> = batches.iter().flat_map(|b| b.column(6).as_any().downcast_ref::<Int8Array>().unwrap().values().to_vec()).collect();
+        assert_eq!(tiers, vec![1, 1]);
+    }
+```
+
+`write_synthetic_variation` already exists in `build.rs`'s test module (`:679`). Add `read_all` next to it:
+
+```rust
+    async fn read_all(path: &std::path::Path) -> Vec<RecordBatch> {
+        use parquet::arrow::async_reader::ParquetRecordBatchStreamBuilder;
+        let file = tokio::fs::File::open(path).await.unwrap();
+        let mut stream = ParquetRecordBatchStreamBuilder::new(file).await.unwrap().build().unwrap();
+        let mut out = Vec::new();
+        while let Some(b) = futures::TryStreamExt::try_next(&mut stream).await.unwrap() {
+            out.push(b);
+        }
+        out
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p datafusion-bio-function-vep --features parquet-cache -- plugin_cache::normalize plugin_cache::write plugin_cache::build::tests::interval`
+Expected: compile errors (signatures) then, once signatures exist, the build test fails because the shard has `allele_string` / the join runs.
+
+- [ ] **Step 3: Implement**
+
+`normalize.rs`:
+
+```rust
+pub fn wrap_normalization(
+    inner_view: &str,
+    coord: CoordinateSystem,
+    lookup: LookupKind,
+    match_columns: &[String],
+    value_columns: &[String],
+) -> String {
+    let start_expr = match coord {
+        CoordinateSystem::OneBased => "CAST(start AS BIGINT)".to_string(),
+        CoordinateSystem::ZeroBasedHalfOpen => "CAST(start AS BIGINT) + 1".to_string(),
+    };
+    let mut projection = format!(
+        "canonical_contig(chrom) AS chrom, {start_expr} AS start, CAST(\"end\" AS BIGINT) AS \"end\""
+    );
+    if lookup == LookupKind::Point {
+        projection.push_str(", allele_string");
+    }
+    for col in match_columns.iter().chain(value_columns.iter()) {
+        projection.push_str(&format!(", {col}"));
+    }
+    format!("SELECT {projection} FROM {inner_view}")
+}
+```
+
+`write.rs`:
+
+```rust
+pub fn plugin_output_schema(lookup: LookupKind, matches: &[MatchColumn], values: &[ValueColumn]) -> SchemaRef {
+    let mut fields = vec![
+        Field::new("chrom", DataType::Utf8, false),
+        Field::new("start", DataType::UInt32, false),
+        Field::new("end", DataType::UInt32, false),
+    ];
+    if lookup == LookupKind::Point {
+        fields.push(Field::new("allele_string", DataType::Utf8, false));
+    }
+    ...
+```
+
+`dedup.rs`: replace the hard-coded `key_names` with the parameter, and add:
+
+```rust
+/// The runtime probe key a shard row must be unique on, in shard order.
+pub fn probe_key_columns(lookup: LookupKind, match_columns: &[String]) -> Vec<String> {
+    let mut key: Vec<String> = match lookup {
+        LookupKind::Point => vec!["start".into(), "allele_string".into()],
+        LookupKind::Interval => vec!["start".into(), "end".into()],
+    };
+    key.extend(match_columns.iter().cloned());
+    key
+}
+```
+
+Update both call sites in `build.rs:491-495` to `let key_cols = probe_key_columns(src.lookup, &match_cols);` and pass `&key_cols`. Update dedup tests to pass the full key list.
+
+`build.rs`: after the `info!("read+normalize+dedup done …")` block and before the memory-pool setup, insert:
+
+```rust
+    let out_schema = plugin_output_schema(src.lookup, &src.match_columns, &src.value_columns);
+    let plugin_dir = output_cache_root.join("plugin").join(&src.plugin_name);
+    std::fs::create_dir_all(&plugin_dir)
+        .map_err(|e| DataFusionError::Execution(format!("mkdir {}: {e}", plugin_dir.display())))?;
+    let file_name = format!("{}.parquet", canonical_chrom_label(chrom));
+    let shard_path = plugin_dir.join(&file_name);
+    let build_tmp = plugin_dir.join(format!("{file_name}.build.tmp"));
+    let scratch = ScratchGuard::new([build_tmp.clone()]);
+
+    if src.lookup == LookupKind::Interval {
+        // No allele → nothing to inherit a tier from. Sort by (start, arrival
+        // order) so the shard preserves the tabix/file order VEP iterates, and
+        // stamp every row cold.
+        let (rows, warm, cold) =
+            write_interval_shard(deduped, &out_schema, &build_tmp, chrom, &src.plugin_name).await?;
+        info!(
+            "plugin_cache[{}/{chrom}]: interval shard written, rows={rows}, {:.1}s total",
+            src.plugin_name,
+            t_start.elapsed().as_secs_f64()
+        );
+        return finish_staged(scratch, build_tmp, shard_path, file_name, chrom, rows, warm, cold);
+    }
+```
+
+and move the existing `out_schema`/`plugin_dir`/`file_name`/`shard_path`/`build_tmp`/`scratch` block (`:546-556`) up so it is declared once (delete the later duplicate). Extract the tail at `:623-658` into
+
+```rust
+#[allow(clippy::too_many_arguments)]
+fn finish_staged(
+    scratch: ScratchGuard,
+    build_tmp: PathBuf,
+    shard_path: PathBuf,
+    file_name: String,
+    chrom: &str,
+    rows: usize,
+    warm: usize,
+    cold: usize,
+) -> Result<StagedShard> {
+    if warm + cold == 0 {
+        let _ = std::fs::remove_file(&build_tmp);
+        return Ok(StagedShard {
+            entry: ChromEntry { chrom: canonical_chrom_label(chrom), file: file_name, rows: 0, warm: 0, cold: 0 },
+            staged: None,
+            live: shard_path,
+        });
+    }
+    scratch.disarm();
+    Ok(StagedShard {
+        staged: Some(build_tmp),
+        live: shard_path,
+        entry: ChromEntry { chrom: canonical_chrom_label(chrom), file: file_name, rows, warm, cold },
+    })
+}
+```
+
+and call it from the point path too (behaviour unchanged). New writer:
+
+```rust
+/// Interval shards skip the tier join: concatenate the deduped batches, order
+/// by `(start, arrival ordinal)`, append `tier = 1`, and write.
+async fn write_interval_shard(
+    deduped: Vec<RecordBatch>,
+    out_schema: &SchemaRef,
+    path: &Path,
+    chrom: &str,
+    plugin_name: &str,
+) -> Result<(usize, usize, usize)> {
+    use datafusion::arrow::array::{Int8Array, UInt64Array};
+    use datafusion::arrow::compute::{concat_batches, lexsort_to_indices, take, SortColumn};
+
+    let mut writer = PluginShardWriter::create(path, Arc::clone(out_schema))?;
+    let non_empty: Vec<RecordBatch> = deduped.into_iter().filter(|b| b.num_rows() > 0).collect();
+    if non_empty.is_empty() {
+        let rows = writer.finish()?;
+        return Ok((rows, 0, rows));
+    }
+    let all = concat_batches(&non_empty[0].schema(), &non_empty)
+        .map_err(|e| DataFusionError::Execution(format!("concat interval rows: {e}")))?;
+    let n = all.num_rows();
+    let ordinal: ArrayRef = Arc::new(UInt64Array::from_iter_values(0..n as u64));
+    let start_idx = all.schema().index_of("start")?;
+    let indices = lexsort_to_indices(
+        &[
+            SortColumn { values: Arc::clone(all.column(start_idx)), options: None },
+            SortColumn { values: ordinal, options: None },
+        ],
+        None,
+    )
+    .map_err(|e| DataFusionError::Execution(format!("sort interval rows: {e}")))?;
+    let mut columns: Vec<ArrayRef> = all
+        .columns()
+        .iter()
+        .map(|c| take(c.as_ref(), &indices, None))
+        .collect::<std::result::Result<_, _>>()
+        .map_err(|e| DataFusionError::Execution(format!("take interval rows: {e}")))?;
+    let mut fields: Vec<Field> = all.schema().fields().iter().map(|f| f.as_ref().clone()).collect();
+    fields.push(Field::new("tier", DataType::Int8, false));
+    columns.push(Arc::new(Int8Array::from(vec![1i8; n])));
+    let sorted = RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)
+        .map_err(|e| DataFusionError::Execution(format!("interval batch: {e}")))?;
+    let reordered = reproject_cast(&sorted, out_schema)?;
+    let tier_idx = out_schema.index_of("tier")?;
+    let out_start_idx = out_schema.index_of("start")?;
+    inspect_tier_start_order(&reordered, out_start_idx, tier_idx, chrom, plugin_name, None)?;
+    writer.write(&reordered)?;
+    let rows = writer.finish()?;
+    Ok((rows, 0, rows))
+}
+```
+
+`reproject_cast` already exists in `build.rs` (used at `:327`); it casts `start`/`end` BIGINT → UInt32 and orders columns to `out_schema`. Update the point path to pass `src.lookup` where `plugin_output_schema` / `wrap_normalization` are called.
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cargo test -p datafusion-bio-function-vep --features parquet-cache -- plugin_cache`
+Expected: PASS, including every pre-existing build/join test (point path unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add datafusion/bio-function-vep/src/plugin_cache/{normalize,write,dedup,build,provider}.rs
+git commit -m "feat(plugin-cache): build interval shards without allele or tier join"
+```
+
+### Task 6: Runtime `IntervalLookup`
+
+**Files:**
+- Modify: `datafusion/bio-function-vep/src/plugin_cache/lookup.rs` (new struct after `PluginBufferSlice`)
+- Test: `lookup.rs` `mod tests`
+
+**Interfaces:**
+- Produces:
+  ```rust
+  pub struct IntervalLookup { rows: HashMap<Vec<Option<String>>, Vec<IntervalRow>>, n_values: usize }
+  struct IntervalRow { start: u32, end: u32, values: Vec<PluginScalar> }
+  impl IntervalLookup {
+      pub async fn open(shard: &Path, match_columns: Vec<String>, value_columns: Vec<String>) -> Result<Self>;
+      pub fn probe(&self, span_start: u32, span_end: u32, match_values: &[Option<String>]) -> Option<&[PluginScalar]>;
+      pub fn n_values(&self) -> usize;
+  }
+  ```
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+    fn write_interval_shard(path: &std::path::Path) {
+        use crate::plugin_cache::cache_manifest::LookupKind;
+        let matches = vec![MatchColumn { column: "gene_id".into(), template: "{Gene}".into() }];
+        let vals = vec![ValueColumn { column: "rat".into(), csq_field: "PO_Rat".into(), ty: ValueType::Utf8, description: None }];
+        let schema = plugin_output_schema(LookupKind::Interval, &matches, &vals);
+        // Two rows for ENSG1 (file order: the wider one first) and one for ENSG2.
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from(vec!["1", "1", "1"])),
+                Arc::new(UInt32Array::from(vec![100u32, 150, 400])),
+                Arc::new(UInt32Array::from(vec![300u32, 200, 500])),
+                Arc::new(StringArray::from(vec!["ENSG1", "ENSG1", "ENSG2"])),
+                Arc::new(StringArray::from(vec![Some("wide"), Some("narrow"), None])),
+                Arc::new(Int8Array::from(vec![1i8, 1, 1])),
+            ],
+        )
+        .unwrap();
+        let mut w = PluginShardWriter::create(path, schema).unwrap();
+        w.write(&batch).unwrap();
+        w.finish().unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn interval_probe_overlaps_and_gates_on_discriminator() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("chr1.parquet");
+        write_interval_shard(&path);
+        let lk = IntervalLookup::open(&path, vec!["gene_id".into()], vec!["rat".into()]).await.unwrap();
+        let g1 = [Some("ENSG1".to_string())];
+        let g2 = [Some("ENSG2".to_string())];
+        // inside both spans → first in file order
+        assert_eq!(lk.probe(160, 160, &g1).unwrap(), &[PluginScalar::Str("wide".into())]);
+        // boundaries are inclusive
+        assert_eq!(lk.probe(300, 300, &g1).unwrap(), &[PluginScalar::Str("wide".into())]);
+        assert_eq!(lk.probe(99, 100, &g1).unwrap(), &[PluginScalar::Str("wide".into())]);
+        assert!(lk.probe(301, 301, &g1).is_none());
+        // a span that only touches the narrow row still returns it? no: 150-200 lies inside 100-300 too
+        // an insertion span [pos, pos+1] straddling a start boundary
+        assert_eq!(lk.probe(399, 400, &g2).unwrap(), &[PluginScalar::Null]);
+        // discriminator gate
+        assert!(lk.probe(160, 160, &[Some("ENSG9".to_string())]).is_none());
+        assert!(lk.probe(160, 160, &[None]).is_none());
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p datafusion-bio-function-vep --features parquet-cache -- plugin_cache::lookup::tests::interval`
+Expected: compile error, `IntervalLookup` undefined.
+
+- [ ] **Step 3: Implement** (append to `lookup.rs`)
+
+```rust
+/// One interval row: inclusive 1-based span plus its values in shard order.
+struct IntervalRow {
+    start: u32,
+    end: u32,
+    values: Vec<PluginScalar>,
+}
+
+/// Whole-shard, discriminator-keyed interval lookup for [`LookupKind::Interval`]
+/// plugins. Shards are small (one row per feature, thousands per chromosome), so
+/// the file is read once at open and probed synchronously. Rows keep file order
+/// inside each discriminator bucket; `probe` returns the first overlapping one,
+/// which is what a tabix-backed Ensembl plugin sees. A plugin with no match
+/// columns has a single bucket and scans it linearly.
+pub struct IntervalLookup {
+    rows: HashMap<Vec<Option<String>>, Vec<IntervalRow>>,
+    n_values: usize,
+}
+
+impl IntervalLookup {
+    pub async fn open(shard: &Path, match_columns: Vec<String>, value_columns: Vec<String>) -> Result<Self> {
+        let file = tokio::fs::File::open(shard).await.map_err(|e| {
+            DataFusionError::Execution(format!("open plugin shard '{}': {e}", shard.display()))
+        })?;
+        let builder = ParquetRecordBatchStreamBuilder::new(file)
+            .await
+            .map_err(|e| DataFusionError::Execution(format!("open interval shard: {e}")))?;
+        let arrow_schema = builder.schema().clone();
+        let mut wanted = vec!["start".to_string(), "end".to_string()];
+        wanted.extend(match_columns.iter().cloned());
+        wanted.extend(value_columns.iter().cloned());
+        let roots: Vec<usize> = wanted
+            .iter()
+            .map(|n| arrow_schema.index_of(n).map_err(|e| DataFusionError::Execution(format!("interval shard column {n}: {e}"))))
+            .collect::<Result<_>>()?;
+        let mask = ProjectionMask::roots(builder.parquet_schema(), roots);
+        let mut stream = builder
+            .with_projection(mask)
+            .with_batch_size(8192)
+            .build()
+            .map_err(|e| DataFusionError::Execution(format!("build interval stream: {e}")))?;
+        let n_match = match_columns.len();
+        let n_values = value_columns.len();
+        let mut rows: HashMap<Vec<Option<String>>, Vec<IntervalRow>> = HashMap::new();
+        while let Some(b) = stream.try_next().await.map_err(|e| DataFusionError::Execution(format!("read interval batch: {e}")))? {
+            // Projection keeps file column order: start, end, match…, value…
+            let schema = b.schema();
+            let col = |name: &str| -> Result<usize> { schema.index_of(name).map_err(|e| DataFusionError::Execution(e.to_string())) };
+            let start = b.column(col("start")?).as_any().downcast_ref::<UInt32Array>()
+                .ok_or_else(|| DataFusionError::Execution("start column must be UInt32".into()))?;
+            let end = b.column(col("end")?).as_any().downcast_ref::<UInt32Array>()
+                .ok_or_else(|| DataFusionError::Execution("end column must be UInt32".into()))?;
+            let match_idx: Vec<usize> = match_columns.iter().map(|n| col(n)).collect::<Result<_>>()?;
+            let value_idx: Vec<usize> = value_columns.iter().map(|n| col(n)).collect::<Result<_>>()?;
+            for r in 0..b.num_rows() {
+                let mut key = Vec::with_capacity(n_match);
+                for &i in &match_idx {
+                    key.push(string_value(b.column(i).as_ref(), r)?);
+                }
+                let mut values = Vec::with_capacity(n_values);
+                for &i in &value_idx {
+                    values.push(decode_scalar(b.column(i).as_ref(), r)?);
+                }
+                rows.entry(key).or_default().push(IntervalRow { start: start.value(r), end: end.value(r), values });
+            }
+        }
+        Ok(Self { rows, n_values })
+    }
+
+    pub fn n_values(&self) -> usize {
+        self.n_values
+    }
+
+    /// First row (file order) whose inclusive span overlaps `[span_start, span_end]`
+    /// under the given discriminators; `None` on a miss or a `None` discriminator
+    /// that the shard stores as `Some`.
+    pub fn probe(&self, span_start: u32, span_end: u32, match_values: &[Option<String>]) -> Option<&[PluginScalar]> {
+        self.rows
+            .get(match_values)?
+            .iter()
+            .find(|row| row.start <= span_end && row.end >= span_start)
+            .map(|row| row.values.as_slice())
+    }
+}
+```
+
+(`HashMap::get` with a `&[Option<String>]` key works because `Vec<T>: Borrow<[T]>`.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test -p datafusion-bio-function-vep --features parquet-cache -- plugin_cache::lookup`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add datafusion/bio-function-vep/src/plugin_cache/lookup.rs
+git commit -m "feat(plugin-cache): IntervalLookup, whole-shard span probe keyed by discriminators"
+```
+
+### Task 7: Registry branch and `probe_all` span
+
+**Files:**
+- Modify: `datafusion/bio-function-vep/src/plugin_cache/registry.rs:18-31` (`PluginEntry`), `:131-200` (`open`), `:281-302` (`take_buffer_all`), `:305-366` (`SliceEntry`, `probe_all`)
+- Test: `registry.rs` `mod tests`
+
+**Interfaces:**
+- `enum LookupHandle { Point(PluginLookup), Interval(Arc<IntervalLookup>) }` (private), `PluginEntry.lookup: Option<LookupHandle>`.
+- `BufferSlices::probe_all(&self, start: u32, allele_string: &str, fallback_key: Option<(u32, &str)>, span: (u32, u32), attrs: &[Option<&str>]) -> Vec<PluginScalar>` — `span` is the variant's VEP-normalised inclusive span with `span.0 <= span.1` (the caller swaps insertion coordinates).
+
+- [ ] **Step 1: Write the failing test** (in `registry.rs` tests; build the interval shard with the same helper as Task 6 — move `write_interval_shard` into a `pub(crate)` test helper module in `lookup.rs`, e.g. `pub(crate) mod test_support`)
+
+```rust
+    #[tokio::test(flavor = "multi_thread")]
+    async fn interval_plugin_probes_by_span_and_gene() {
+        use crate::plugin_cache::cache_manifest::LookupKind;
+        use crate::plugin_cache::lookup::test_support::write_interval_shard;
+        let dir = tempfile::tempdir().unwrap();
+        let cache_root = dir.path();
+        let plugin_dir = cache_root.join("plugin").join("po");
+        std::fs::create_dir_all(&plugin_dir).unwrap();
+        write_interval_shard(&plugin_dir.join("chr1.parquet"));
+        CacheManifest {
+            plugin_name: "po".into(),
+            source_manifest: "po.source.toml".into(),
+            key_columns: crate::plugin_cache::cache_manifest::key_columns(LookupKind::Interval),
+            match_columns: vec![MatchColumnRecord { column: "gene_id".into(), template: "{Gene}".into() }],
+            value_columns: vec![ValueColumnRecord { column: "rat".into(), csq_field: "PO_Rat".into(), ty: "Utf8".into(), description: None }],
+            chroms: vec![ChromEntry { chrom: "chr1".into(), file: "chr1.parquet".into(), rows: 3, warm: 0, cold: 3 }],
+            sources: vec![],
+            cache_source_version: None,
+            allele_match: Default::default(),
+            field_order: Default::default(),
+            assume_unique: Some(true),
+            lookup: LookupKind::Interval,
+        }
+        .write(&plugin_dir)
+        .unwrap();
+
+        let reg = PluginRegistry::open(cache_root, "1", None).await.unwrap();
+        assert_eq!(reg.csq_fields(), vec!["PO_Rat"]);
+        // Interval plugins ignore the buffer take; an empty start list is fine.
+        let slices = reg.take_buffer_all(&[]).await.unwrap();
+        let ns = build_attr_namespace(
+            "intron_variant", "ENSG1", "SYM", "Transcript", "ENST1", "lncRNA",
+            "", "", "", "", "", "", "", "A", "G",
+        );
+        assert_eq!(slices.probe_all(160, "A/G", None, (160, 160), &ns), vec![PluginScalar::Str("wide".into())]);
+        assert_eq!(slices.probe_all(350, "A/G", None, (350, 350), &ns), vec![PluginScalar::Null]);
+        let other = build_attr_namespace(
+            "intron_variant", "ENSG2", "SYM", "Transcript", "ENST2", "lncRNA",
+            "", "", "", "", "", "", "", "A", "G",
+        );
+        assert_eq!(slices.probe_all(160, "A/G", None, (160, 160), &other), vec![PluginScalar::Null]);
+        // No transcript → empty namespace → discriminator None → miss.
+        assert_eq!(slices.probe_all(160, "A/G", None, (160, 160), &[]), vec![PluginScalar::Null]);
+    }
+```
+
+`build_attr_namespace` (`template.rs:96`) takes exactly these 15 `&str` arguments in this order: consequence, gene, symbol, feature_type, feature, biotype, hgvsc, hgvsp, cdna_pos, cds_pos, protein_pos, amino_acids, codons, ref_allele, alt_allele; empty strings become `None`.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p datafusion-bio-function-vep --features parquet-cache -- plugin_cache::registry::tests::interval`
+Expected: FAIL (compile: `probe_all` arity / `lookup` field type).
+
+- [ ] **Step 3: Implement**
+
+`registry.rs`:
+
+```rust
+use std::sync::Arc;
+use crate::plugin_cache::cache_manifest::LookupKind;
+use crate::plugin_cache::lookup::{IntervalLookup, PluginBufferSlice, PluginLookup, PluginScalar};
+
+enum LookupHandle {
+    Point(PluginLookup),
+    Interval(Arc<IntervalLookup>),
+}
+
+struct PluginEntry {
+    ...
+    lookup: Option<LookupHandle>,
+}
+```
+
+In `open`, replace the `Some(PluginLookup::open(...).await?)` with:
+
+```rust
+                    Some(match m.lookup {
+                        LookupKind::Point => LookupHandle::Point(
+                            PluginLookup::open(&shard, match_columns, value_columns).await?,
+                        ),
+                        LookupKind::Interval => LookupHandle::Interval(Arc::new(
+                            IntervalLookup::open(&shard, match_columns, value_columns).await?,
+                        )),
+                    })
+```
+
+`take_buffer_all`:
+
+```rust
+        for p in &self.plugins {
+            let (slice, interval) = match &p.lookup {
+                Some(LookupHandle::Point(lk)) => {
+                    let batch = lk.take_buffer(sorted_unique_starts).await?;
+                    (Some(PluginBufferSlice::from_batch(&batch, p.n_match, p.n_values)?), None)
+                }
+                Some(LookupHandle::Interval(il)) => (None, Some(Arc::clone(il))),
+                None => (None, None),
+            };
+            entries.push(SliceEntry { csq_fields_len: p.csq_fields.len(), emit_order: p.emit_order.clone(), allele_match: p.allele_match, match_templates: p.match_templates.clone(), slice, interval });
+        }
+```
+
+`SliceEntry` gains `interval: Option<Arc<IntervalLookup>>`. `probe_all` gains `span: (u32, u32)` after `fallback_key`, and the hit computation becomes:
+
+```rust
+            let hit: Option<Vec<PluginScalar>> = if let Some(il) = &e.interval {
+                il.probe(span.0, span.1, &match_values).map(|v| v.to_vec())
+            } else {
+                e.slice.as_ref().and_then(|s| s.probe(start, allele_string, &match_values)).or_else(|| { /* existing minimised fallback */ })
+            };
+```
+
+Update the existing registry tests that call `probe_all` to pass a span (`(start, start)`).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test -p datafusion-bio-function-vep --features parquet-cache -- plugin_cache::registry`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add datafusion/bio-function-vep/src/plugin_cache/{registry,lookup}.rs
+git commit -m "feat(plugin-cache): registry opens interval lookups; probe_all takes the variant span"
+```
+
+### Task 8: Wire the variant span into `annotate_provider`
+
+**Files:**
+- Modify: `datafusion/bio-function-vep/src/annotate_provider.rs:7005-7016` (per-transcript probe) and `:7068-7077` (placeholder probe)
+- Test: `datafusion/bio-function-vep/src/annotate_provider.rs` existing `test_csq_field_projection_*` unaffected; new integration test in `tests/` is covered by vepyr's fixture (Task V2 of the vepyr plan). Add one unit test for the span helper.
+
+**Interfaces:**
+- Produces: `pub(crate) fn plugin_probe_span(vcf_pos: i64, ref_allele: &str, alt_allele: &str) -> (u32, u32)` in `allele.rs`, next to `vep_norm_end` (`allele.rs:981`).
+
+- [ ] **Step 1: Write the failing test** (in `allele.rs` tests)
+
+```rust
+    #[test]
+    fn plugin_probe_span_is_vep_span_with_insertions_swapped() {
+        // SNV
+        assert_eq!(plugin_probe_span(100, "A", "G"), (100, 100));
+        // deletion CT>C: VEP start 101, end 101
+        assert_eq!(plugin_probe_span(100, "CT", "C"), (101, 101));
+        // insertion C>CT: VEP start 101, end 100 → swapped [100, 101]
+        assert_eq!(plugin_probe_span(100, "C", "CT"), (100, 101));
+        // MNV
+        assert_eq!(plugin_probe_span(100, "AC", "GT"), (100, 101));
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p datafusion-bio-function-vep --features parquet-cache -- allele::tests::plugin_probe_span`
+Expected: compile error.
+
+- [ ] **Step 3: Implement**
+
+`allele.rs`:
+
+```rust
+/// The genomic span a tabix-backed Ensembl plugin queries for a variant: the
+/// VEP-normalised `[start, end]`, with an insertion's `start > end` swapped the
+/// way `PhenotypeOrthologous.pm` and `ReferenceQuality.pm` do before calling
+/// `get_data`. Inclusive, 1-based, clamped to `u32`.
+pub(crate) fn plugin_probe_span(vcf_pos: i64, ref_allele: &str, alt_allele: &str) -> (u32, u32) {
+    let s = vep_norm_start(vcf_pos, ref_allele, alt_allele);
+    let e = vep_norm_end(vcf_pos, ref_allele, alt_allele);
+    let (lo, hi) = if s > e { (e, s) } else { (s, e) };
+    (u32::try_from(lo).unwrap_or(0), u32::try_from(hi).unwrap_or(0))
+}
+```
+
+`annotate_provider.rs`, per-transcript block: before `let scalars = plugin_slices…` add
+
+```rust
+                            let probe_span = plugin_probe_span(start_val, &ref_al, &alt_allele);
+```
+
+and pass `probe_span` as the new fourth argument of `s.probe_all(...)`. Same two lines in the placeholder block. Import `plugin_probe_span` alongside `plugin_probe_input_allele`.
+
+- [ ] **Step 4: Run to verify**
+
+Run: `cargo test -p datafusion-bio-function-vep --features parquet-cache`
+Expected: PASS (whole crate).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add datafusion/bio-function-vep/src/{allele,annotate_provider}.rs
+git commit -m "feat(vep): probe interval plugins with the variant's VEP span"
+```
+
+### Task 9: PR 2 hygiene, docs, draft PR
+
+**Files:**
+- Modify: `datafusion/bio-function-vep/src/plugin_cache/mod.rs` (module doc: two lookup kinds), `datafusion/bio-function-vep/examples/build_plugin.rs` doc (interval builds still need `--variation-cache-dir` to enumerate chromosomes; no tier join runs)
+- Modify: `docs/superpowers/specs/2026-07-05-custom-vep-plugin-caches-design.md:582-598` (§9): replace the sentence declaring per-interval plugins secondary with a pointer: "Interval plugins are supported since PR #<n> via `lookup = \"interval\"`; see vepyr's 2026-09-11 spec."
+
+- [ ] **Step 1: fmt, clippy, full tests**
+
+Run: `cargo fmt --all && cargo clippy -p datafusion-bio-function-vep --features parquet-cache --all-targets -- -D warnings && cargo test -p datafusion-bio-function-vep --features parquet-cache`
+Expected: clean.
+
+- [ ] **Step 2: Golden regression** (the existing benchmark test that pins CSQ layouts must be untouched)
+
+Run: `cargo test -p datafusion-bio-function-vep --features parquet-cache -- golden`
+Expected: PASS.
+
+- [ ] **Step 3: Commit and open the stacked draft PR**
+
+```bash
+git add -A datafusion/bio-function-vep/src/plugin_cache/mod.rs datafusion/bio-function-vep/examples/build_plugin.rs docs/superpowers/specs/2026-07-05-custom-vep-plugin-caches-design.md
+git commit -m "docs(plugin-cache): document lookup = interval"
+git push -u origin feat/plugin-interval-lookup
+gh pr create --draft --base feat/plugin-gff-provider --title "feat(plugin-cache): interval lookup kind for span-keyed plugins" --body-file <(cat <<'EOF'
+Adds `lookup = "interval"` to plugin manifests. Interval shards carry `(chrom, start, end, <match…>, <values…>, tier=1)`, skip the variation tier join, and are probed at runtime by overlap with the variant's VEP-normalised span plus the usual match discriminators (first row in file order wins, as a tabix-backed Ensembl plugin returns records).
+
+Second half of the PhenotypeOrthologous port (gene-keyed via `{Gene}`). Stacked on #<PR1>. Spec: vepyr `docs/superpowers/specs/2026-09-11-gff-plugin-source-and-phenotypeorthologous-design.md`.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+https://claude.ai/code/session_01Ybip12LHW1qoorZjs3TwYT
+EOF
+)
+```
+
+- [ ] **Step 4: Hand off** — record both PR numbers and head SHAs in the vepyr plan's Task V1 (the pin), then drive the bot review loop per the vepyr-fix skill ("@codex review" / "@claude review", gate every reply on `git rev-parse HEAD` changing).

--- a/docs/superpowers/plans/2026-09-11-engine-gff-provider-and-interval-lookup.md
+++ b/docs/superpowers/plans/2026-09-11-engine-gff-provider-and-interval-lookup.md
@@ -4,9 +4,9 @@
 
 **Goal:** Let a plugin source manifest read a GFF3 file (`provider = "gff"`) and declare an interval-keyed lookup (`lookup = "interval"`) so the PhenotypeOrthologous plugin can be built and probed by the engine.
 
-**Architecture:** Two stacked PRs on `biodatageeks/datafusion-bio-functions`. PR 1 adds a `ProviderKind::Gff` arm on top of `datafusion-bio-format-gff`'s `GffTableProvider` (flat attribute columns, per-chromosome slicing through the existing tabix materialiser). PR 2 adds a `LookupKind` (`point` today, new `interval`) that drops `allele_string`, skips the variation tier join at build time, and at runtime loads the whole per-chromosome shard into a discriminator-keyed interval map probed with the variant's VEP-normalised span.
+**Architecture:** Two stacked PRs on `biodatageeks/datafusion-bio-functions`. PR 1 adds a `ProviderKind::Gff` arm on top of `datafusion-bio-format-gff`'s `GffTableProvider` (flat attribute columns, per-chromosome slicing through the existing tabix materialiser). PR 2 adds a `LookupKind` (`point` today, new `interval`) that drops `allele_string`, skips the variation tier join at build time, and at runtime loads the whole per-chromosome shard into per-discriminator COITrees probed with the variant's VEP-normalised span (first overlapping row in file order wins).
 
-**Tech Stack:** Rust 2021, DataFusion 53, Arrow/Parquet 58, `datafusion-bio-format-gff` tag `v1.12.1`, noodles (bgzf/tabix/csi) at the workspace revs, serde/toml.
+**Tech Stack:** Rust 2021, DataFusion 53, Arrow/Parquet 58, `datafusion-bio-format-gff` tag `v1.12.1`, `coitrees` 0.4 (already a dependency; same `COITree<usize, u32>` idiom as `transcript_consequence.rs:886-963`), noodles (bgzf/tabix/csi) at the workspace revs, serde/toml.
 
 **Spec:** `docs/superpowers/specs/2026-09-11-gff-plugin-source-and-phenotypeorthologous-design.md` (in vepyr).
 
@@ -965,8 +965,8 @@ git commit -m "feat(plugin-cache): build interval shards without allele or tier 
 **Interfaces:**
 - Produces:
   ```rust
-  pub struct IntervalLookup { rows: HashMap<Vec<Option<String>>, Vec<IntervalRow>>, n_values: usize }
-  struct IntervalRow { start: u32, end: u32, values: Vec<PluginScalar> }
+  pub struct IntervalLookup { rows: Vec<IntervalRow>, trees: HashMap<Vec<Option<String>>, COITree<usize, u32>>, n_values: usize }
+  struct IntervalRow { values: Vec<PluginScalar> }   // file order == Vec index == tree metadata
   impl IntervalLookup {
       pub async fn open(shard: &Path, match_columns: Vec<String>, value_columns: Vec<String>) -> Result<Self>;
       pub fn probe(&self, span_start: u32, span_end: u32, match_values: &[Option<String>]) -> Option<&[PluginScalar]>;
@@ -982,16 +982,18 @@ git commit -m "feat(plugin-cache): build interval shards without allele or tier 
         let matches = vec![MatchColumn { column: "gene_id".into(), template: "{Gene}".into() }];
         let vals = vec![ValueColumn { column: "rat".into(), csq_field: "PO_Rat".into(), ty: ValueType::Utf8, description: None }];
         let schema = plugin_output_schema(LookupKind::Interval, &matches, &vals);
-        // Two rows for ENSG1 (file order: the wider one first) and one for ENSG2.
+        // Three rows for ENSG1 in file order wide, narrow, late (all cover 160;
+        // a tree visits them in its own order, so the ordinal tie-break is what
+        // makes "wide" win) and one row for ENSG2 with no value.
         let batch = RecordBatch::try_new(
             schema.clone(),
             vec![
-                Arc::new(StringArray::from(vec!["1", "1", "1"])),
-                Arc::new(UInt32Array::from(vec![100u32, 150, 400])),
-                Arc::new(UInt32Array::from(vec![300u32, 200, 500])),
-                Arc::new(StringArray::from(vec!["ENSG1", "ENSG1", "ENSG2"])),
-                Arc::new(StringArray::from(vec![Some("wide"), Some("narrow"), None])),
-                Arc::new(Int8Array::from(vec![1i8, 1, 1])),
+                Arc::new(StringArray::from(vec!["1", "1", "1", "1"])),
+                Arc::new(UInt32Array::from(vec![100u32, 150, 155, 400])),
+                Arc::new(UInt32Array::from(vec![300u32, 200, 350, 500])),
+                Arc::new(StringArray::from(vec!["ENSG1", "ENSG1", "ENSG1", "ENSG2"])),
+                Arc::new(StringArray::from(vec![Some("wide"), Some("narrow"), Some("late"), None])),
+                Arc::new(Int8Array::from(vec![1i8, 1, 1, 1])),
             ],
         )
         .unwrap();
@@ -1008,13 +1010,14 @@ git commit -m "feat(plugin-cache): build interval shards without allele or tier 
         let lk = IntervalLookup::open(&path, vec!["gene_id".into()], vec!["rat".into()]).await.unwrap();
         let g1 = [Some("ENSG1".to_string())];
         let g2 = [Some("ENSG2".to_string())];
-        // inside both spans → first in file order
+        // inside all three ENSG1 spans → first in FILE order, whatever the tree visits first
         assert_eq!(lk.probe(160, 160, &g1).unwrap(), &[PluginScalar::Str("wide".into())]);
+        // only "late" covers 320..350
+        assert_eq!(lk.probe(320, 320, &g1).unwrap(), &[PluginScalar::Str("late".into())]);
         // boundaries are inclusive
         assert_eq!(lk.probe(300, 300, &g1).unwrap(), &[PluginScalar::Str("wide".into())]);
         assert_eq!(lk.probe(99, 100, &g1).unwrap(), &[PluginScalar::Str("wide".into())]);
-        assert!(lk.probe(301, 301, &g1).is_none());
-        // a span that only touches the narrow row still returns it? no: 150-200 lies inside 100-300 too
+        assert!(lk.probe(351, 351, &g1).is_none());
         // an insertion span [pos, pos+1] straddling a start boundary
         assert_eq!(lk.probe(399, 400, &g2).unwrap(), &[PluginScalar::Null]);
         // discriminator gate
@@ -1031,21 +1034,22 @@ Expected: compile error, `IntervalLookup` undefined.
 - [ ] **Step 3: Implement** (append to `lookup.rs`)
 
 ```rust
-/// One interval row: inclusive 1-based span plus its values in shard order.
+/// One interval row's values, in shard column order. Its position in
+/// `IntervalLookup::rows` is the file ordinal, which is also the COITree
+/// metadata, so the tie-break "first record in file order" is a `min` over
+/// the ordinals the tree reports.
 struct IntervalRow {
-    start: u32,
-    end: u32,
     values: Vec<PluginScalar>,
 }
 
-/// Whole-shard, discriminator-keyed interval lookup for [`LookupKind::Interval`]
-/// plugins. Shards are small (one row per feature, thousands per chromosome), so
-/// the file is read once at open and probed synchronously. Rows keep file order
-/// inside each discriminator bucket; `probe` returns the first overlapping one,
-/// which is what a tabix-backed Ensembl plugin sees. A plugin with no match
-/// columns has a single bucket and scans it linearly.
+/// Whole-shard interval lookup for [`LookupKind::Interval`] plugins: one
+/// `COITree` per discriminator tuple over closed 1-based spans, read once at
+/// open and probed synchronously. `probe` returns the overlapping row with the
+/// smallest file ordinal, which is the record a tabix-backed Ensembl plugin
+/// takes. A plugin with no match columns has a single tree.
 pub struct IntervalLookup {
-    rows: HashMap<Vec<Option<String>>, Vec<IntervalRow>>,
+    rows: Vec<IntervalRow>,
+    trees: HashMap<Vec<Option<String>>, COITree<usize, u32>>,
     n_values: usize,
 }
 
@@ -1073,7 +1077,8 @@ impl IntervalLookup {
             .map_err(|e| DataFusionError::Execution(format!("build interval stream: {e}")))?;
         let n_match = match_columns.len();
         let n_values = value_columns.len();
-        let mut rows: HashMap<Vec<Option<String>>, Vec<IntervalRow>> = HashMap::new();
+        let mut rows: Vec<IntervalRow> = Vec::new();
+        let mut intervals: HashMap<Vec<Option<String>>, Vec<Interval<usize>>> = HashMap::new();
         while let Some(b) = stream.try_next().await.map_err(|e| DataFusionError::Execution(format!("read interval batch: {e}")))? {
             // Projection keeps file column order: start, end, match…, value…
             let schema = b.schema();
@@ -1093,10 +1098,21 @@ impl IntervalLookup {
                 for &i in &value_idx {
                     values.push(decode_scalar(b.column(i).as_ref(), r)?);
                 }
-                rows.entry(key).or_default().push(IntervalRow { start: start.value(r), end: end.value(r), values });
+                let ordinal = rows.len();
+                rows.push(IntervalRow { values });
+                // Closed 1-based span; positions fit i32 for every contig.
+                intervals.entry(key).or_default().push(Interval::new(
+                    i32::try_from(start.value(r)).unwrap_or(i32::MAX),
+                    i32::try_from(end.value(r)).unwrap_or(i32::MAX),
+                    ordinal,
+                ));
             }
         }
-        Ok(Self { rows, n_values })
+        let trees = intervals
+            .into_iter()
+            .map(|(key, ivs)| (key, COITree::new(&ivs)))
+            .collect();
+        Ok(Self { rows, trees, n_values })
     }
 
     pub fn n_values(&self) -> usize {
@@ -1107,16 +1123,22 @@ impl IntervalLookup {
     /// under the given discriminators; `None` on a miss or a `None` discriminator
     /// that the shard stores as `Some`.
     pub fn probe(&self, span_start: u32, span_end: u32, match_values: &[Option<String>]) -> Option<&[PluginScalar]> {
-        self.rows
-            .get(match_values)?
-            .iter()
-            .find(|row| row.start <= span_end && row.end >= span_start)
-            .map(|row| row.values.as_slice())
+        let tree = self.trees.get(match_values)?;
+        let (first, last) = (
+            i32::try_from(span_start).unwrap_or(i32::MAX),
+            i32::try_from(span_end).unwrap_or(i32::MAX),
+        );
+        let mut best: Option<usize> = None;
+        tree.query(first, last, |node| {
+            let ordinal = *GenericInterval::<usize>::metadata(node);
+            best = Some(best.map_or(ordinal, |b| b.min(ordinal)));
+        });
+        best.map(|i| self.rows[i].values.as_slice())
     }
 }
 ```
 
-(`HashMap::get` with a `&[Option<String>]` key works because `Vec<T>: Borrow<[T]>`.)
+Imports: `use coitrees::{COITree, GenericInterval, Interval, IntervalTree};` (the `IntervalTree` trait provides `query`). `HashMap::get` with a `&[Option<String>]` key works because `Vec<T>: Borrow<[T]>`.
 
 - [ ] **Step 4: Run to verify it passes**
 
@@ -1127,7 +1149,7 @@ Expected: PASS.
 
 ```bash
 git add datafusion/bio-function-vep/src/plugin_cache/lookup.rs
-git commit -m "feat(plugin-cache): IntervalLookup, whole-shard span probe keyed by discriminators"
+git commit -m "feat(plugin-cache): IntervalLookup, per-discriminator COITrees probed by variant span"
 ```
 
 ### Task 7: Registry branch and `probe_all` span
@@ -1359,7 +1381,7 @@ git add -A datafusion/bio-function-vep/src/plugin_cache/mod.rs datafusion/bio-fu
 git commit -m "docs(plugin-cache): document lookup = interval"
 git push -u origin feat/plugin-interval-lookup
 gh pr create --draft --base feat/plugin-gff-provider --title "feat(plugin-cache): interval lookup kind for span-keyed plugins" --body-file <(cat <<'EOF'
-Adds `lookup = "interval"` to plugin manifests. Interval shards carry `(chrom, start, end, <match…>, <values…>, tier=1)`, skip the variation tier join, and are probed at runtime by overlap with the variant's VEP-normalised span plus the usual match discriminators (first row in file order wins, as a tabix-backed Ensembl plugin returns records).
+Adds `lookup = "interval"` to plugin manifests. Interval shards carry `(chrom, start, end, <match…>, <values…>, tier=1)`, skip the variation tier join, and are probed at runtime through per-discriminator COITrees by overlap with the variant's VEP-normalised span (first row in file order wins, as a tabix-backed Ensembl plugin returns records).
 
 Second half of the PhenotypeOrthologous port (gene-keyed via `{Gene}`). Stacked on #<PR1>. Spec: vepyr `docs/superpowers/specs/2026-09-11-gff-plugin-source-and-phenotypeorthologous-design.md`.
 

--- a/docs/superpowers/plans/2026-09-11-vepyr-phenotypeorthologous-parity-and-publish.md
+++ b/docs/superpowers/plans/2026-09-11-vepyr-phenotypeorthologous-parity-and-publish.md
@@ -35,7 +35,7 @@ uv run python e2e-testing/scripts/run_comparison.py --release 116 --profile merg
   --plugin-cache ~/workspace/data_vepyr/plugin_cache_v0.1.1 --workers 4 --bgzf --force
 uv run python e2e-testing/scripts/md5_concordance.py \
   --pair e2e-testing/results/116/fast_chr22/vep_chr22_merged_plugins.vcf \
-         e2e-testing/results/116/fast_chr22/vepyr_chr22_merged_plugins.vcf.gz --mode strict
+         e2e-testing/results/116/fast_chr22/vepyr_parquet_chr22_merged_plugins.vcf.gz --mode strict
 ```
 
 Expected: report `124/124 fields at 100%`, strict concordance exit 0. Copy the two md5 lines into `e2e-testing/reports/baseline_merged_plugins_chr22_2026-09-11.txt` (untracked, reports/ is gitignored) for the re-check in Task V9.
@@ -254,6 +254,10 @@ git commit -m "test: interval (gene-span) plugin fixture — span gating and VEP
 - Modify: `e2e-testing/scripts/comparison/profiles.py:63-70` (constants), `:138-152` (profiles dict)
 - Modify: `tests/test_comparison_profiles.py:188-196` (`_write_plugin_reference(tmp_path, chrom=22, profile="merged_plugins")`) and new tests
 - Modify: `tests/test_verify_parity_gate.py:364-382` (add `merged_phenotypeorthologous` to the refusal parametrisation)
+- Modify: `e2e-testing/scripts/comparison/cli.py:14-21` (`DESCRIPTION` example) and `:136-141` (`--plugin-cache` help)
+- Modify: `tests/test_comparison_cli.py:350-372` (parametrise the two plugin-profile tests over both plugin profiles)
+
+`run_comparison.py` is a 16-line shim over `comparison.cli.main`, and the CLI's `--profile` choices are `sorted(profiles.PROFILES)` (`cli.py:44-46`), so registering the profile in `profiles.py` is what exposes `--profile merged_phenotypeorthologous`; the steps below make that visible in the help text and pin it with tests.
 
 - [ ] **Step 1: Write the failing tests** (`tests/test_comparison_profiles.py`)
 
@@ -272,6 +276,32 @@ def test_phenotypeorthologous_profile_attaches_only_that_plugin(tmp_path, monkey
 ```
 
 Generalise `_write_plugin_reference` to take `profile="merged_plugins"` and use `profiles.PROFILES[profile].vep_per_contig`.
+
+In `tests/test_comparison_cli.py`, parametrise the two existing plugin-profile tests and add a choices test:
+
+```python
+@pytest.mark.parametrize("profile", ["merged_plugins", "merged_phenotypeorthologous"])
+def test_main_passes_the_single_requested_contig_to_resolve(monkeypatch, profile):
+    seen = {}
+
+    def fake_resolve(*args, **kwargs):
+        seen.update(kwargs)
+        raise profiles.ProfileUnavailable("stop here")
+
+    monkeypatch.setattr(profiles, "resolve", fake_resolve)
+    rc = cli.main(["--release", "116", "--profile", profile, "--chroms", "22"])
+    assert rc == 2
+    assert seen["chrom"] == "chr22"
+
+
+def test_phenotypeorthologous_profile_is_a_cli_choice(capsys):
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(["--release", "116", "--profile", "no_such_profile"])
+    assert excinfo.value.code == 2
+    assert "merged_phenotypeorthologous" in capsys.readouterr().err
+```
+
+(argparse lists the valid choices in its error, so the second test proves the new profile is selectable from `run_comparison.py`.)
 
 - [ ] **Step 2: Run to verify it fails**
 
@@ -302,16 +332,25 @@ and in `PROFILES`:
 
 In `tests/test_verify_parity_gate.py`, extend the plugin-refusal test's parametrisation with `"merged_phenotypeorthologous"`.
 
+In `cli.py`, add to `DESCRIPTION`:
+
+```
+    run_comparison.py --release 116 --profile merged_phenotypeorthologous --chroms 22 \
+        --plugin-cache ~/workspace/data_vepyr/plugin_cache_v0.2.0   # one plugin, its own reference
+```
+
+and change the `--plugin-cache` help to `"Plugin cache root, used only by plugin profiles (merged_plugins, merged_phenotypeorthologous); default: $DATA/cache/plugin_cache_<release>"`.
+
 - [ ] **Step 4: Run to verify**
 
-Run: `uv run pytest tests/test_comparison_profiles.py tests/test_verify_parity_gate.py -q`
-Expected: PASS.
+Run: `uv run pytest tests/test_comparison_profiles.py tests/test_comparison_cli.py tests/test_verify_parity_gate.py -q && uv run python e2e-testing/scripts/run_comparison.py --help | grep -c phenotypeorthologous`
+Expected: tests PASS; the help mentions the profile at least twice (choices + example).
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add e2e-testing/scripts/comparison/profiles.py tests/test_comparison_profiles.py tests/test_verify_parity_gate.py
-git commit -m "feat(e2e): merged_phenotypeorthologous comparison profile"
+git add e2e-testing/scripts/comparison/profiles.py e2e-testing/scripts/comparison/cli.py tests/test_comparison_profiles.py tests/test_comparison_cli.py tests/test_verify_parity_gate.py
+git commit -m "feat(e2e): merged_phenotypeorthologous profile in run_comparison.py"
 ```
 
 ### Task V4: Oracle scripts
@@ -519,6 +558,96 @@ git add e2e-testing/scripts/build_vep_phenotypeorthologous_reference.sh e2e-test
 git commit -m "feat(e2e): VEP 116 PhenotypeOrthologous reference builder and resumable driver"
 ```
 
+### Task V4b: End-to-end comparison runner for the profile
+
+**Files:**
+- Create: `e2e-testing/scripts/run_phenotypeorthologous_comparison.sh`
+
+**Interfaces:**
+- `./run_phenotypeorthologous_comparison.sh [chroms…]` (default `1..22`). Env: `DATA_VEPYR_DIR`, `VEPYR_PLUGIN_REPO` (default `~/research/git/vepyr-plugins`), `VEPYR_PLUGIN_REF` (git ref of the catalog manifest, default `v0.2.0`), `VEPYR_PLUGIN_CACHE` (default `$DATA/plugin_cache_po_<ref>`), `VEP_COMPARISON_WORKERS` (default 4). Per chromosome: builds the reference if missing (Task V4 builder), builds the shard through `vepyr.build_plugin_cache` with strict verification, runs `run_comparison.py --profile merged_phenotypeorthologous`, then `md5_concordance.py --mode strict`, and records `strict_chr<N>.exit` under `$DATA/output/116/plugins/po_comparison_logs/`. Exit code 1 if any chromosome fails. This is the single command behind Tasks V5 and V6.
+- Result files it reads (written by `run_comparison.py`): `e2e-testing/results/116/fast_chr<N>/vep_chr<N>_merged_phenotypeorthologous.vcf` (`vcfio.slice_vep`, `vcfio.py:366`) and `…/vepyr_parquet_chr<N>_merged_phenotypeorthologous.vcf.gz` (`cli.py:394-397`: `vepyr_{BACKEND}_{chrom}_{suffix}{ext}` with `BACKEND = "parquet"`, `chrom` canonical `chrN`, `ext = .vcf.gz` under `--bgzf`).
+
+- [ ] **Step 1: Write the runner**
+
+```bash
+#!/usr/bin/env bash
+# Build the PhenotypeOrthologous shard(s), compare vepyr with the VEP 116
+# reference through run_comparison.py --profile merged_phenotypeorthologous,
+# and gate each chromosome on strict body/header md5 concordance.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DATA="${DATA_VEPYR_DIR:-$HOME/workspace/data_vepyr}"
+export DATA_VEPYR_DIR="$DATA"
+PLUGIN_REPO="${VEPYR_PLUGIN_REPO:-$HOME/research/git/vepyr-plugins}"
+PLUGIN_REF="${VEPYR_PLUGIN_REF:-v0.2.0}"
+PLUGIN_CACHE="${VEPYR_PLUGIN_CACHE:-$DATA/plugin_cache_po_${PLUGIN_REF//\//_}}"
+CACHE_DIR="$DATA/cache/116_GRCh38_merged"
+SRC="$DATA/plugin_input/phenotypeorthologous/PhenotypesOrthologous_homo_sapiens_112_GRCh38.gff3.gz"
+REF_DIR="$DATA/output/116/plugins"
+LOG_DIR="$REF_DIR/po_comparison_logs"
+WORKERS="${VEP_COMPARISON_WORKERS:-4}"
+BUILDER="$SCRIPT_DIR/build_vep_phenotypeorthologous_reference.sh"
+mkdir -p "$LOG_DIR"
+
+if [[ "$#" -gt 0 ]]; then chroms=("$@"); else chroms=({1..22}); fi
+
+# One build call for every requested chromosome: the builder verifies the
+# source once and stages all shards before committing any of them.
+build_shards() {
+  local list; list="$(printf '"%s",' "${chroms[@]}")"
+  (cd "$REPO_DIR" && uv run python - <<PYBUILD
+import vepyr
+print(vepyr.build_plugin_cache(
+    "phenotypeorthologous", "$PLUGIN_REF",
+    source_path="$SRC", cache_dir="$CACHE_DIR", plugin_cache_root="$PLUGIN_CACHE",
+    chroms=[${list%,}], plugins_repo="$PLUGIN_REPO", overwrite=True, verify_source="strict"))
+PYBUILD
+  )
+}
+
+fail=0
+[[ -s "$SRC" ]] || "$BUILDER" 22 >/dev/null   # the builder downloads and md5-checks the source
+build_shards | tee "$LOG_DIR/build.log"
+for chrom in "${chroms[@]}"; do
+  ref="$REF_DIR/HG002_chr${chrom}_phenotypeorthologous_vep116.vcf.gz"
+  [[ -s "$ref" && -s "$ref.tbi" ]] || "$BUILDER" "$chrom" > "$LOG_DIR/reference_chr${chrom}.log" 2>&1
+  if ! (cd "$REPO_DIR" && uv run python e2e-testing/scripts/run_comparison.py \
+      --release 116 --profile merged_phenotypeorthologous --chroms "$chrom" \
+      --plugin-cache "$PLUGIN_CACHE" --workers "$WORKERS" --bgzf --force) \
+      > "$LOG_DIR/compare_chr${chrom}.log" 2>&1; then
+    echo "FAIL chr${chrom}: comparison error, see $LOG_DIR/compare_chr${chrom}.log" >&2; fail=1; continue
+  fi
+  results="$REPO_DIR/e2e-testing/results/116/fast_chr${chrom}"
+  if (cd "$REPO_DIR" && uv run python e2e-testing/scripts/md5_concordance.py \
+        --pair "$results/vep_chr${chrom}_merged_phenotypeorthologous.vcf" \
+               "$results/vepyr_parquet_chr${chrom}_merged_phenotypeorthologous.vcf.gz" \
+        --mode strict --explain --explain-limit 0) > "$LOG_DIR/strict_chr${chrom}.log" 2>&1; then
+    echo 0 > "$LOG_DIR/strict_chr${chrom}.exit"; echo "PASS chr${chrom}: strict md5 concordant"
+  else
+    echo 1 > "$LOG_DIR/strict_chr${chrom}.exit"; echo "FAIL chr${chrom}: see $LOG_DIR/strict_chr${chrom}.log" >&2; fail=1
+  fi
+done
+exit "$fail"
+```
+
+- [ ] **Step 2: Smoke-run on chr22 against the catalog branch** (before `v0.2.0` exists)
+
+```bash
+chmod +x e2e-testing/scripts/run_phenotypeorthologous_comparison.sh
+VEPYR_PLUGIN_REF=feat/phenotypeorthologous e2e-testing/scripts/run_phenotypeorthologous_comparison.sh 22
+```
+
+Expected: `PASS chr22: strict md5 concordant` and a `e2e-testing/reports/fast_chr22_merged_phenotypeorthologous_116_report.json` showing the four fields with `both_nonempty_unequal = 0`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add e2e-testing/scripts/run_phenotypeorthologous_comparison.sh
+git commit -m "feat(e2e): one-command PhenotypeOrthologous build + compare + strict gate"
+```
+
 ### Task V5: Build the chr22 cache and run the parity gate
 
 - [ ] **Step 1: Build chr22 + chr1 from the catalog branch** (the manifest lives on the vepyr-plugins branch until `v0.2.0` exists; `_resolve_plugin_manifest` accepts any git ref)
@@ -540,17 +669,14 @@ EOF
 
 Expected: `[('chr22', 377, 0, 377)]` then `[('chr1', 1754, 0, 1754)]`.
 
-- [ ] **Step 2: chr22 comparison, strict md5, workers 1 vs 4**
+- [ ] **Step 2: chr22 comparison, strict md5, workers 1 vs 4** (the Task V4b runner does build + compare + strict; run it twice with different worker counts and compare the two vepyr outputs)
 
 ```bash
 for w in 1 4; do
-  uv run python e2e-testing/scripts/run_comparison.py --release 116 --profile merged_phenotypeorthologous \
-    --chroms 22 --plugin-cache ~/workspace/data_vepyr/plugin_cache_dev_po --workers $w --bgzf --force
-  cp e2e-testing/results/116/fast_chr22/vepyr_chr22_merged_phenotypeorthologous.vcf.gz /tmp/po_w$w.vcf.gz
+  VEPYR_PLUGIN_REF=feat/phenotypeorthologous VEPYR_PLUGIN_CACHE=~/workspace/data_vepyr/plugin_cache_dev_po \
+    VEP_COMPARISON_WORKERS=$w e2e-testing/scripts/run_phenotypeorthologous_comparison.sh 22
+  cp e2e-testing/results/116/fast_chr22/vepyr_parquet_chr22_merged_phenotypeorthologous.vcf.gz /tmp/po_w$w.vcf.gz
 done
-uv run python e2e-testing/scripts/md5_concordance.py --pair \
-  e2e-testing/results/116/fast_chr22/vep_chr22_merged_phenotypeorthologous.vcf \
-  /tmp/po_w4.vcf.gz --mode strict --explain --explain-limit 0
 uv run python e2e-testing/scripts/md5_concordance.py --pair /tmp/po_w1.vcf.gz /tmp/po_w4.vcf.gz --mode strict
 ```
 
@@ -558,7 +684,7 @@ Expected: the field report shows the four `PhenotypeOrthologous_*` fields with `
 
 - [ ] **Step 3: chr1**
 
-Run the V4 builder for chr1, then the same comparison with `--chroms 1 --workers 4`. Expected: 100% and strict PASS.
+`VEPYR_PLUGIN_REF=feat/phenotypeorthologous VEPYR_PLUGIN_CACHE=~/workspace/data_vepyr/plugin_cache_dev_po e2e-testing/scripts/run_phenotypeorthologous_comparison.sh 1` (builds the chr1 reference on first use, about an hour). Expected: 100% and `PASS chr1`.
 
 - [ ] **Step 4: Record** the report paths and md5s in the PR description draft (`e2e-testing/reports/fast_chr22_merged_phenotypeorthologous_116_*`).
 
@@ -578,26 +704,12 @@ Re-running the same command after an interruption skips completed contigs. Progr
 - [ ] **Step 2: When complete, per-contig gate**
 
 ```bash
-uv run python - <<'EOF'
-import vepyr, os
-D = os.path.expanduser("~/workspace/data_vepyr")
-vepyr.build_plugin_cache("phenotypeorthologous", "feat/phenotypeorthologous",
-    source_path=f"{D}/plugin_input/phenotypeorthologous/PhenotypesOrthologous_homo_sapiens_112_GRCh38.gff3.gz",
-    cache_dir=f"{D}/cache/116_GRCh38_merged", plugin_cache_root=f"{D}/plugin_cache_dev_po",
-    chroms=[str(c) for c in range(1, 23)], plugins_repo=os.path.expanduser("~/research/git/vepyr-plugins"),
-    overwrite=True, verify_source="strict")
-EOF
-for c in $(seq 1 22); do
-  uv run python e2e-testing/scripts/run_comparison.py --release 116 --profile merged_phenotypeorthologous \
-    --chroms $c --plugin-cache ~/workspace/data_vepyr/plugin_cache_dev_po --workers 4 --bgzf --force
-  uv run python e2e-testing/scripts/md5_concordance.py --pair \
-    e2e-testing/results/116/fast_chr$c/vep_chr${c}_merged_phenotypeorthologous.vcf \
-    e2e-testing/results/116/fast_chr$c/vepyr_chr${c}_merged_phenotypeorthologous.vcf.gz --mode strict \
-    && echo "chr$c strict PASS" || echo "chr$c strict FAIL"
-done | tee ~/workspace/data_vepyr/output/116/plugins/logs/po_strict_summary.txt
+VEPYR_PLUGIN_REF=feat/phenotypeorthologous VEPYR_PLUGIN_CACHE=~/workspace/data_vepyr/plugin_cache_dev_po \
+  e2e-testing/scripts/run_phenotypeorthologous_comparison.sh 2>&1 \
+  | tee ~/workspace/data_vepyr/output/116/plugins/logs/po_strict_summary.txt
 ```
 
-Expected: 22 × `strict PASS`. This is the gate for tagging the Hub cache (Task V8).
+Expected: 22 × `PASS chr<N>: strict md5 concordant` and exit 0. This is the gate for tagging the Hub cache (Task V8).
 
 ### Task V7: Docs
 
@@ -640,6 +752,9 @@ Emitted-order row: `PhenotypeOrthologous_Mouse_geneid`, `PhenotypeOrthologous_Mo
     (`HG002_chr{N}_phenotypeorthologous_vep116.vcf.gz`), produced by
     `build_vep_phenotypeorthologous_reference.sh <chrom>` or, for chr1–22,
     the resumable `generate_vep_phenotypeorthologous_references.sh`.
+    `run_phenotypeorthologous_comparison.sh [chroms…]` chains the shard
+    build, `run_comparison.py --profile merged_phenotypeorthologous` and the
+    strict md5 gate in one command.
 ```
 
 - [ ] **Step 3: Build docs and commit**
@@ -668,7 +783,7 @@ EOF
 
 Expected: 25 entries; `chrY` with `rows=0` and no shard; `chrMT` 13 rows; total rows 16,404 (the four unplaced contigs' 5 rows are outside the 25). `manifest.json` has `"lookup": "interval"`, `cache_source_version: "v0.2.0@<sha>"`, `sources[0].verified_md5 == md5`.
 
-- [ ] **Step 2: Re-run the chr22 strict gate against this exact root** (`--plugin-cache ~/workspace/data_vepyr/plugin_cache_v0.2.0`). Expected: PASS.
+- [ ] **Step 2: Re-run the chr22 strict gate against this exact root**: `VEPYR_PLUGIN_REF=v0.2.0 VEPYR_PLUGIN_CACHE=~/workspace/data_vepyr/plugin_cache_v0.2.0 e2e-testing/scripts/run_phenotypeorthologous_comparison.sh 22` (the build step rebuilds chr22 in place from the same tag, byte-identical). Expected: `PASS chr22`.
 
 - [ ] **Step 3: Write the card** `~/workspace/data_vepyr/plugin_cache_v0.2.0/plugin/phenotypeorthologous/README.md`, following `biodatageeks/vepyr_116_GRCh38_plugin_clinvar`'s card structure (download it with `hf download … README.md`): title, what it is, source url/md5/verified md5/.tbi md5, `cache_source_version`, lookup kind + match rule, CSQ fields and header descriptions, per-contig row table (from `manifest.json`), licence (Ensembl data, free use), how to download into `<root>/plugin/phenotypeorthologous/`, parity statement (chr1–22 strict concordance against VEP 116.0, date).
 

--- a/docs/superpowers/plans/2026-09-11-vepyr-phenotypeorthologous-parity-and-publish.md
+++ b/docs/superpowers/plans/2026-09-11-vepyr-phenotypeorthologous-parity-and-publish.md
@@ -1,0 +1,726 @@
+# vepyr: PhenotypeOrthologous parity, oracle references and publish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Pin vepyr to the engine with `gff` + `interval` support, add the `merged_phenotypeorthologous` comparison profile with its VEP 116 oracle scripts, prove parity on chr22/chr1 and the whole normalized HG002 sample, document it, and publish the 25-contig cache to Hugging Face.
+
+**Architecture:** One vepyr PR on branch `feat/gff-plugin-source-phenotypeorthologous` (already created; holds the spec and these plans). Oracle references are produced by two new bash scripts modelled on the five-plugin pair, writing BGZF directly. The comparison reuses `run_comparison.py` / `md5_concordance.py` unchanged through a new profile. Publishing is a manual `hf upload` with a hand-written card (the cache QA tool does not know interval shards yet).
+
+**Tech Stack:** Python 3.12 / uv / maturin, Polars, pytest, bash, docker `ensemblorg/ensembl-vep:release_116.0`, `hf` CLI.
+
+**Spec:** `docs/superpowers/specs/2026-09-11-gff-plugin-source-and-phenotypeorthologous-design.md`.
+
+## Global Constraints
+
+- Repo `/Users/mwiewior/research/git/vepyr`, branch `feat/gff-plugin-source-phenotypeorthologous`. GSD is bypassed for this work (user approval 2026-09-11).
+- Rebuild the extension after any pin change with `env -u CONDA_PREFIX -u VIRTUAL_ENV uv run --no-sync maturin develop --release` (both env vars are set in this shell; with them maturin refuses and the stale `.venv` extension silently keeps running).
+- Lint only through pre-commit: `uv run pre-commit run ruff --all-files` and `ruff-format` (`uv run ruff` falls through to pyenv). Note the hook's `--fix` strips imports whose consumer is added in a later commit.
+- `DATA=~/workspace/data_vepyr`. Inputs: `input/HG002_norm.vcf.gz` (+`.tbi`), `input/Homo_sapiens.GRCh38.dna.primary_assembly.fa`, raw merged cache `homo_sapiens_merged/116_GRCh38`, Parquet cache `cache/116_GRCh38_merged`. The HG002 benchmark VCF covers chr1–22 only.
+- VEP oracle recipe (do not vary): image `release_116.0`, `--cache --cache_version 116 --dir_cache /data --offline --merged --everything --no_stats --force_overwrite --vcf --compress_output bgzip --fasta …`, plugin code pinned by sha256 `89be8f30dd464f81913bef367831e8a08258e4085207f8291c956487f47de8ac` (VEP_plugins `a7e03a5c6497e29e0598eed7b4795f953d9a1b5f`).
+- Source file md5 `20e5401a198d7d3db66a982c037d3ad4`, `.tbi` md5 `1eb833a26c247418910685289c6528cc`.
+- Disk: 107 GiB free on 2026-09-11 after cleanup; the whole-sample references need ~1.5 GB, the cache < 50 MB.
+- Commit trailers as in the engine plan. Draft PR; the human merges.
+
+---
+
+### Task V0: Baseline before any engine change lands (run once, first)
+
+Record the current five-plugin chr22 parity so the engine PRs can be shown not to regress the point path.
+
+- [ ] **Step 1: Run the existing comparison on master's extension**
+
+```bash
+cd /Users/mwiewior/research/git/vepyr
+uv run python e2e-testing/scripts/run_comparison.py --release 116 --profile merged_plugins --chroms 22 \
+  --plugin-cache ~/workspace/data_vepyr/plugin_cache_v0.1.1 --workers 4 --bgzf --force
+uv run python e2e-testing/scripts/md5_concordance.py \
+  --pair e2e-testing/results/116/fast_chr22/vep_chr22_merged_plugins.vcf \
+         e2e-testing/results/116/fast_chr22/vepyr_chr22_merged_plugins.vcf.gz --mode strict
+```
+
+Expected: report `124/124 fields at 100%`, strict concordance exit 0. Copy the two md5 lines into `e2e-testing/reports/baseline_merged_plugins_chr22_2026-09-11.txt` (untracked, reports/ is gitignored) for the re-check in Task V9.
+
+### Task V1: Pin the engine
+
+**Files:**
+- Modify: `Cargo.toml` (the `datafusion-bio-function-vep` `rev`), `Cargo.lock`
+
+- [ ] **Step 1: Point at the engine PR 2 head** (interim; re-pin to the master squash SHA after both engine PRs merge)
+
+```bash
+sed -i '' 's/rev = "4b0bd00b5f4c5a40a40886cd6c0d230bb91a5554"/rev = "<PR2 head sha>"/' Cargo.toml
+cargo update -p datafusion-bio-function-vep
+env -u CONDA_PREFIX -u VIRTUAL_ENV uv run --no-sync maturin develop --release
+uv run pytest tests/test_build_plugin_cache.py tests/test_annotate.py -q -x
+```
+
+Expected: builds; existing tests pass (point-lookup behaviour unchanged).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock
+git commit -m "chore: pin engine with gff provider and interval lookup"
+```
+
+### Task V2: Synthetic GFF fixture and interval-plugin tests
+
+**Files:**
+- Create: `tests/data/plugin_gff/demo.gff3` (plain text, 3 lines)
+- Modify: `tests/test_build_plugin_cache.py:12-67` (add `_GFF_MANIFEST` next to `_UTF8_MANIFEST`)
+- Modify: `tests/test_annotate.py:158-198` (new fixture `interval_plugin_cache` after `text_plugin_cache`) and a new class `TestIntervalPlugin`
+
+**Interfaces:**
+- Consumes: `_init_full_repo(root, manifest=...)` (writes `plugins/demo/demo.source.toml`, tags `v0.1.0`), `metadata_cache_dir`, `INPUT_VCF` (golden chr1, 100 records).
+- Golden facts used: variants chr1:604358 G>C and chr1:604360 T>C are intronic in genes `ENSG00000225880` (LINC00115) and `ENSG00000293331`; chr1:611317 A>G is intronic in the same two genes.
+
+- [ ] **Step 1: Write the fixture GFF**
+
+`tests/data/plugin_gff/demo.gff3`:
+
+```
+##gff-version 3
+1	test	gene	600000	605000	.	-	.	ID=gene:ENSG00000225880;gene_id=ENSG00000225880;Rat_gene_id=ENSRNOG00000000001;Rat_Orthologous_phenotype= leading space|two, comma;Mouse_gene_id=ENSMUSG00000000001;Mouse_Orthologous_phenotype=abnormal coat/hair pigmentation|hyperactivity
+1	test	gene	604360	604360	.	+	.	ID=gene:ENSG00000293331;gene_id=ENSG00000293331;Rat_gene_id=ENSRNOG00000000002;Rat_Orthologous_phenotype=rat only
+```
+
+(tab-separated; the first row's span covers 604358 and 604360 but not 611317; the second row's one-base span covers only 604360 and has no mouse attributes.)
+
+- [ ] **Step 2: Write the manifest constant** in `tests/test_build_plugin_cache.py` after `_UTF8_MANIFEST`:
+
+```python
+# A gene-span GFF source with an interval lookup keyed by {Gene}. Mirrors
+# plugins/phenotypeorthologous in vepyr-plugins, at fixture scale.
+_GFF_MANIFEST = '''\
+plugin_name = "demo"
+coordinate_system = "1-based"
+lookup = "interval"
+field_order = "alphabetical"
+ingest_sql = """
+SELECT chrom, start, "end", gene_id,
+       "Mouse_gene_id" AS mouse_gene_id, "Mouse_Orthologous_phenotype" AS mouse_phenotype,
+       "Rat_gene_id" AS rat_gene_id, "Rat_Orthologous_phenotype" AS rat_phenotype
+FROM plugin_demo_src
+"""
+
+[[source]]
+provider = "gff"
+path = "placeholder.gff3"
+  [source.gff]
+  attributes = ["gene_id", "Mouse_gene_id", "Mouse_Orthologous_phenotype", "Rat_gene_id", "Rat_Orthologous_phenotype"]
+
+[[match_column]]
+column = "gene_id"
+template = "{Gene}"
+
+[[value_columns]]
+column = "mouse_gene_id"
+csq_field = "Demo_Mouse_geneid"
+type = "Utf8"
+[[value_columns]]
+column = "mouse_phenotype"
+csq_field = "Demo_Mouse_phenotype"
+type = "Utf8"
+[[value_columns]]
+column = "rat_gene_id"
+csq_field = "Demo_Rat_geneid"
+type = "Utf8"
+[[value_columns]]
+column = "rat_phenotype"
+csq_field = "Demo_Rat_phenotype"
+type = "Utf8"
+'''
+```
+
+- [ ] **Step 3: Write the failing fixture and tests** in `tests/test_annotate.py`:
+
+```python
+@pytest.fixture(scope="module")
+def interval_plugin_cache(metadata_cache_dir, tmp_path_factory):
+    """An interval (gene-span) plugin built from tests/data/plugin_gff/demo.gff3."""
+    from tests.test_build_plugin_cache import _GFF_MANIFEST, _init_full_repo
+
+    import vepyr
+
+    root = tmp_path_factory.mktemp("interval_plugin")
+    repo = _init_full_repo(root, manifest=_GFF_MANIFEST)
+    plugin_root = root / "pc"
+    built = vepyr.build_plugin_cache(
+        "demo",
+        "v0.1.0",
+        source_path=str(TESTS_DIR / "data" / "plugin_gff" / "demo.gff3"),
+        cache_dir=metadata_cache_dir,
+        plugin_cache_root=str(plugin_root),
+        plugins_repo=str(repo),
+        chroms=["1"],
+    )
+    # Interval shards carry no tier information: every row is cold.
+    assert built == [("chr1", 2, 0, 2)]
+    return str(plugin_root)
+
+
+def _plugin_tails(vcf_path, n_fields):
+    """{(pos, gene): plugin tail} for every CSQ entry, tail = last n_fields tokens."""
+    out = {}
+    for line in Path(vcf_path).read_text().splitlines():
+        if line.startswith("#"):
+            continue
+        cols = line.split("\t")
+        pos = int(cols[1])
+        csq = next((f[len("CSQ=") :] for f in cols[7].split(";") if f.startswith("CSQ=")), None)
+        if csq is None:
+            continue
+        for entry in csq.split(","):
+            tokens = entry.split("|")
+            gene = tokens[4]  # Allele|Consequence|IMPACT|SYMBOL|Gene|...
+            out[(pos, gene)] = "|".join(tokens[-n_fields:])
+    return out
+
+
+class TestIntervalPlugin:
+    """lookup = "interval": span overlap + {Gene}, first row in file order, VEP escaping."""
+
+    def test_gene_span_gates_and_values_escape_like_vep(
+        self, interval_plugin_cache, metadata_cache_dir, tmp_path
+    ):
+        import vepyr
+
+        output = tmp_path / "interval.vcf"
+        vepyr.annotate(
+            INPUT_VCF,
+            metadata_cache_dir,
+            fields="core",
+            plugin_cache_root=interval_plugin_cache,
+            plugins=["demo"],
+            output_vcf=str(output),
+            show_progress=False,
+        )
+        header = next(l for l in output.read_text().splitlines() if l.startswith("##INFO=<ID=CSQ"))
+        assert header.rstrip('">').endswith(
+            "Demo_Mouse_geneid|Demo_Mouse_phenotype|Demo_Rat_geneid|Demo_Rat_phenotype"
+        ), "alphabetical field order"
+        tails = _plugin_tails(output, 4)
+        # Inside the LINC00115 span: all four fields; VEP escaping of the
+        # leading space, the comma, the pipe and the whitespace runs.
+        assert tails[(604358, "ENSG00000225880")] == (
+            "ENSMUSG00000000001|abnormal_coat/hair_pigmentation&hyperactivity"
+            "|ENSRNOG00000000001|_leading_space&two&_comma"
+        )
+        # Same variant, the other gene: its one-base span starts at 604360 → miss.
+        assert tails[(604358, "ENSG00000293331")] == "|||"
+        # Boundary: span [604360, 604360] overlaps the variant at 604360; no mouse attrs → empty.
+        assert tails[(604360, "ENSG00000293331")] == "||ENSRNOG00000000002|rat_only"
+        # Gene id matches but the variant lies outside the span (VEP's flank rule) → miss.
+        assert tails[(611317, "ENSG00000225880")] == "|||"
+
+    def test_lazyframe_columns_are_per_transcript_lists(
+        self, interval_plugin_cache, metadata_cache_dir
+    ):
+        import polars as pl
+        import vepyr
+
+        lf = vepyr.annotate(
+            INPUT_VCF,
+            metadata_cache_dir,
+            plugin_cache_root=interval_plugin_cache,
+            plugins=["demo"],
+            show_progress=False,
+        )
+        df = lf.select("pos", "Gene", "Demo_Rat_geneid", "Demo_Rat_phenotype").collect()
+        assert df.schema["Demo_Rat_geneid"] == pl.List(pl.String)
+        row = df.filter(pl.col("pos") == 604358).row(0, named=True)
+        genes, rat = row["Gene"], row["Demo_Rat_geneid"]
+        assert rat[genes.index("ENSG00000225880")] == "ENSRNOG00000000001"
+        assert rat[genes.index("ENSG00000293331")] is None
+```
+
+`Gene` is a `List(String)` column in the LazyFrame (`docs/dataframes.md:50`), aligned per transcript with `Consequence` and with every plugin column of a match-column plugin, so indexing the plugin list by the gene's position is valid.
+
+- [ ] **Step 4: Run to verify the tests fail before the pin (or pass after Task V1)**
+
+Run: `uv run pytest tests/test_annotate.py -k Interval -q`
+Expected before V1: the build fails (`provider must be one of …` / unknown key `lookup`). After V1: PASS. If the escaping assertion fails on `_leading_space`, inspect the actual tail: the shared escaper's whitespace rule is `\s+ → _`; a difference means the GFF reader trimmed the value (fix in the engine's provider test first).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/data/plugin_gff/demo.gff3 tests/test_build_plugin_cache.py tests/test_annotate.py
+git commit -m "test: interval (gene-span) plugin fixture — span gating and VEP escaping"
+```
+
+### Task V3: Comparison profile
+
+**Files:**
+- Modify: `e2e-testing/scripts/comparison/profiles.py:63-70` (constants), `:138-152` (profiles dict)
+- Modify: `tests/test_comparison_profiles.py:188-196` (`_write_plugin_reference(tmp_path, chrom=22, profile="merged_plugins")`) and new tests
+- Modify: `tests/test_verify_parity_gate.py:364-382` (add `merged_phenotypeorthologous` to the refusal parametrisation)
+
+- [ ] **Step 1: Write the failing tests** (`tests/test_comparison_profiles.py`)
+
+```python
+def test_phenotypeorthologous_profile_attaches_only_that_plugin(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_VEPYR_DIR", str(tmp_path))
+    (tmp_path / "cache" / "116_GRCh38_merged").mkdir(parents=True)
+    plugin_cache = tmp_path / "cache" / "plugin_cache_116"
+    plugin_cache.mkdir(parents=True)
+    _write_plugin_reference(tmp_path, chrom=22, profile="merged_phenotypeorthologous")
+
+    resolved = profiles.resolve("merged_phenotypeorthologous", "116", chrom=22)
+    assert resolved.annotate_kwargs["plugins"] == ["phenotypeorthologous"]
+    assert resolved.vep_vcf.endswith("HG002_chr22_phenotypeorthologous_vep116.vcf.gz")
+    assert "/plugins/" in resolved.vep_vcf
+```
+
+Generalise `_write_plugin_reference` to take `profile="merged_plugins"` and use `profiles.PROFILES[profile].vep_per_contig`.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `uv run pytest tests/test_comparison_profiles.py -k phenotypeorthologous -q`
+Expected: `ProfileUnavailable: Unknown profile 'merged_phenotypeorthologous'`.
+
+- [ ] **Step 3: Implement** (`profiles.py`)
+
+```python
+# PhenotypeOrthologous is compared on its own reference (only that plugin
+# loaded), one file per contig like the five-plugin set.
+_PO_REFERENCE = "HG002_annotated_wgs_everything_hgvs_merged_phenotypeorthologous"
+_PO_PER_CONTIG = "HG002_chr{chrom}_phenotypeorthologous_vep116"
+```
+
+and in `PROFILES`:
+
+```python
+    "merged_phenotypeorthologous": Profile(
+        flavour="merged",
+        vep_basename=_PO_REFERENCE,
+        suffix="merged_phenotypeorthologous",
+        plugins=("phenotypeorthologous",),
+        vep_per_contig=_PO_PER_CONTIG,
+        vep_subdir="plugins",
+    ),
+```
+
+In `tests/test_verify_parity_gate.py`, extend the plugin-refusal test's parametrisation with `"merged_phenotypeorthologous"`.
+
+- [ ] **Step 4: Run to verify**
+
+Run: `uv run pytest tests/test_comparison_profiles.py tests/test_verify_parity_gate.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e-testing/scripts/comparison/profiles.py tests/test_comparison_profiles.py tests/test_verify_parity_gate.py
+git commit -m "feat(e2e): merged_phenotypeorthologous comparison profile"
+```
+
+### Task V4: Oracle scripts
+
+**Files:**
+- Create: `e2e-testing/scripts/build_vep_phenotypeorthologous_reference.sh`
+- Create: `e2e-testing/scripts/generate_vep_phenotypeorthologous_references.sh`
+
+**Interfaces:**
+- Builder: `./build_vep_phenotypeorthologous_reference.sh <chrom> [workdir]`; env `DATA_VEPYR_DIR`, `VEP_NORMALIZED_VCF` (default `$DATA/input/HG002_norm.vcf.gz`), `VEP_OUTPUT_VCF` (default `$DATA/output/116/plugins/HG002_chr<N>_phenotypeorthologous_vep116.vcf.gz`), `VEP_PLUGIN_DIR` (default `$DATA/output/116/plugins/plugin_code`). Writes `<out>.vcf.gz`, `.tbi`, `.plugins` sidecar (`PLUGIN PhenotypeOrthologous <sha256>` and `SOURCE <url> md5=<md5>`).
+- Driver: `./generate_vep_phenotypeorthologous_references.sh [chroms…]` (default `1..22`), env `VEP_REFERENCE_JOBS` (default 2), resumable through the same 4-field header check + sidecar diff.
+
+- [ ] **Step 1: Write the builder**
+
+```bash
+#!/usr/bin/env bash
+#
+# Build the Ensembl VEP 116 PhenotypeOrthologous reference for one chromosome:
+# the golden output `run_comparison.py --profile merged_phenotypeorthologous`
+# compares against. Same recipe as build_vep_plugin_reference.sh (merged cache,
+# --everything, normalized input), with exactly one plugin loaded and BGZF
+# written by VEP itself.
+#
+# Usage: ./build_vep_phenotypeorthologous_reference.sh 22 [workdir]
+set -euo pipefail
+
+CHROM="${1:?usage: $0 <chrom> [workdir]}"
+DATA="${DATA_VEPYR_DIR:-$HOME/workspace/data_vepyr}"
+WORK="${2:-$DATA/vep116_po_chr${CHROM}}"
+IMAGE="ensemblorg/ensembl-vep:release_116.0"
+REF_DIR="$DATA/output/116/plugins"
+PLUGIN_DIR="${VEP_PLUGIN_DIR:-$REF_DIR/plugin_code}"
+SRC_DIR="$DATA/plugin_input/phenotypeorthologous"
+SRC_NAME="PhenotypesOrthologous_homo_sapiens_112_GRCh38.gff3.gz"
+SRC_URL="https://ftp.ensembl.org/pub/release-116/variation/PhenotypeOrthologous/$SRC_NAME"
+SRC_MD5="20e5401a198d7d3db66a982c037d3ad4"
+TBI_MD5="1eb833a26c247418910685289c6528cc"
+PLUGIN_COMMIT="a7e03a5c6497e29e0598eed7b4795f953d9a1b5f"
+PLUGIN_SHA256="89be8f30dd464f81913bef367831e8a08258e4085207f8291c956487f47de8ac"
+OUT="${VEP_OUTPUT_VCF:-$REF_DIR/HG002_chr${CHROM}_phenotypeorthologous_vep116.vcf.gz}"
+
+mkdir -p "$WORK/input" "$REF_DIR" "$PLUGIN_DIR" "$SRC_DIR"
+
+md5_file() {
+  if command -v md5sum >/dev/null 2>&1; then md5sum "$1" | awk '{print $1}'; else md5 -q "$1"; fi
+}
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | awk '{print $1}'; else shasum -a 256 "$1" | awk '{print $1}'; fi
+}
+
+# ---------------------------------------------------------------------------
+# 1. Source data and plugin code, both pinned by digest
+# ---------------------------------------------------------------------------
+for f in "$SRC_NAME" "$SRC_NAME.tbi"; do
+  if [[ ! -s "$SRC_DIR/$f" ]]; then
+    curl --fail --silent --show-error -o "$SRC_DIR/$f.partial" "$SRC_URL${f#"$SRC_NAME"}"
+    mv "$SRC_DIR/$f.partial" "$SRC_DIR/$f"
+  fi
+done
+[[ "$(md5_file "$SRC_DIR/$SRC_NAME")" == "$SRC_MD5" ]] || { echo "ERROR: $SRC_NAME md5 mismatch" >&2; exit 1; }
+[[ "$(md5_file "$SRC_DIR/$SRC_NAME.tbi")" == "$TBI_MD5" ]] || { echo "ERROR: $SRC_NAME.tbi md5 mismatch" >&2; exit 1; }
+
+if [[ ! -s "$PLUGIN_DIR/PhenotypeOrthologous.pm" ]]; then
+  curl --fail --silent --show-error \
+    -o "$PLUGIN_DIR/PhenotypeOrthologous.pm" \
+    "https://raw.githubusercontent.com/Ensembl/VEP_plugins/$PLUGIN_COMMIT/PhenotypeOrthologous.pm"
+fi
+actual="$(sha256_file "$PLUGIN_DIR/PhenotypeOrthologous.pm")"
+[[ "$actual" == "$PLUGIN_SHA256" ]] || { echo "ERROR: PhenotypeOrthologous.pm sha256 $actual != $PLUGIN_SHA256" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# 2. Normalized input slice
+# ---------------------------------------------------------------------------
+NORM="${VEP_NORMALIZED_VCF:-$DATA/input/HG002_norm.vcf.gz}"
+[[ -s "$NORM" && -s "$NORM.tbi" ]] || { echo "ERROR: normalized input $NORM (+.tbi) missing; see build_vep_plugin_reference.sh" >&2; exit 1; }
+IN="$WORK/input/HG002_norm_chr${CHROM}.vcf.gz"
+{ tabix -H "$NORM"; tabix "$NORM" "chr${CHROM}"; } | bgzip -c > "$IN"
+tabix -f -p vcf "$IN"
+
+# ---------------------------------------------------------------------------
+# 3. Annotate (BGZF written by VEP, --compress_output bgzip)
+# ---------------------------------------------------------------------------
+to_container() {  # host path under $DATA → /data/...
+  local p; p="$(cd "$(dirname "$1")" && pwd -P)/$(basename "$1")"
+  local d; d="$(cd "$DATA" && pwd -P)"
+  [[ "$p" == "$d/"* ]] || { echo "ERROR: $1 must live under $DATA" >&2; exit 1; }
+  printf '/data/%s\n' "${p#"$d/"}"
+}
+IN_C="$(to_container "$IN")"
+OUT_C="$(to_container "$OUT")"
+SRC_C="$(to_container "$SRC_DIR/$SRC_NAME")"
+
+docker run --rm --user "$(id -u):$(id -g)" \
+  -v "$DATA":/data -v "$PLUGIN_DIR":/plugins:ro "$IMAGE" \
+  vep --cache --cache_version 116 --dir_cache /data --offline --merged \
+      --everything --no_stats --force_overwrite --vcf --compress_output bgzip \
+      --fasta /data/input/Homo_sapiens.GRCh38.dna.primary_assembly.fa \
+      --input_file "$IN_C" --output_file "$OUT_C" \
+      --dir_plugins /plugins \
+      --plugin "PhenotypeOrthologous,file=$SRC_C"
+
+# ---------------------------------------------------------------------------
+# 4. Index and check the four plugin fields landed
+# ---------------------------------------------------------------------------
+tabix -f -p vcf "$OUT"
+n_plugin=$(tabix -H "$OUT" | grep -m1 '^##INFO=<ID=CSQ' | tr '|' '\n' | grep -c '^PhenotypeOrthologous_')
+if [[ "$n_plugin" -ne 4 ]]; then
+  echo "ERROR: expected 4 PhenotypeOrthologous CSQ fields, found $n_plugin" >&2
+  grep -i 'failed to instantiate' "${OUT%.vcf.gz}.vcf_warnings.txt" >&2 || true
+  exit 1
+fi
+{
+  printf 'PLUGIN PhenotypeOrthologous %s\n' "$PLUGIN_SHA256"
+  printf 'SOURCE %s md5=%s\n' "$SRC_URL" "$SRC_MD5"
+} > "$OUT.plugins"
+echo "OK: chr${CHROM} — $(bgzip -dc "$OUT" | grep -vc '^#') records, $n_plugin plugin CSQ fields"
+echo "     $OUT"
+```
+
+If VEP rejects `--compress_output` in the 116.0 image, replace that flag with a pipe: write to `"${OUT%.gz}"` and follow with `bgzip -f "${OUT%.gz}"`; note the deviation in the script header.
+
+- [ ] **Step 2: Write the driver**
+
+```bash
+#!/usr/bin/env bash
+# Resumable per-contig VEP 116 PhenotypeOrthologous references (default chr1-22).
+set -euo pipefail
+
+DATA="${DATA_VEPYR_DIR:-$HOME/workspace/data_vepyr}"
+TARGET="$DATA/output/116/plugins"
+JOBS="${VEP_REFERENCE_JOBS:-2}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILDER="$SCRIPT_DIR/build_vep_phenotypeorthologous_reference.sh"
+WORK_ROOT="$TARGET/.work_po"
+LOG_DIR="$TARGET/logs"
+mkdir -p "$TARGET" "$WORK_ROOT" "$LOG_DIR"
+
+expected_provenance() {
+  sed -n 's/^PLUGIN_SHA256="\([0-9a-f]\{64\}\)"$/PLUGIN PhenotypeOrthologous \1/p' "$BUILDER"
+  local url md5
+  url="$(sed -n 's/^SRC_URL="\(.*\)"$/\1/p' "$BUILDER")"
+  md5="$(sed -n 's/^SRC_MD5="\([0-9a-f]\{32\}\)"$/\1/p' "$BUILDER")"
+  # SRC_URL is composed from $SRC_NAME in the builder; expand it the same way.
+  url="${url//\$SRC_NAME/PhenotypesOrthologous_homo_sapiens_112_GRCh38.gff3.gz}"
+  printf 'SOURCE %s md5=%s\n' "$url" "$md5"
+}
+
+is_complete() {
+  local out="$TARGET/HG002_chr${1}_phenotypeorthologous_vep116.vcf.gz"
+  [[ -s "$out" && -s "$out.tbi" && -s "$out.plugins" ]] || return 1
+  local n; n=$(tabix -H "$out" | grep -m1 '^##INFO=<ID=CSQ' | tr '|' '\n' | grep -c '^PhenotypeOrthologous_')
+  [[ "$n" -eq 4 ]] || return 1
+  diff -q <(sort "$out.plugins") <(expected_provenance | sort) >/dev/null
+}
+
+run_one() {
+  local chrom="$1" log="$LOG_DIR/po_chr${1}.log"
+  if is_complete "$chrom"; then echo "SKIP chr${chrom}"; return; fi
+  local work; work=$(mktemp -d "$WORK_ROOT/chr${chrom}.XXXXXX")
+  echo "START chr${chrom}: log=$log"
+  if "$BUILDER" "$chrom" "$work" > "$log" 2>&1 && is_complete "$chrom"; then
+    rm -rf "$work"; echo "DONE chr${chrom}"
+  else
+    echo "ERROR chr${chrom}: see $log (work kept at $work)" >&2; return 1
+  fi
+}
+
+if [[ "$#" -gt 0 ]]; then chroms=("$@"); else chroms=({1..22}); fi
+fail=0; pids=(); labels=()
+for chrom in "${chroms[@]}"; do
+  run_one "$chrom" & pids+=("$!"); labels+=("$chrom")
+  if [[ "${#pids[@]}" -eq "$JOBS" ]]; then
+    for i in "${!pids[@]}"; do wait "${pids[$i]}" || { echo "FAILED chr${labels[$i]}" >&2; fail=1; }; done
+    pids=(); labels=()
+  fi
+done
+for i in "${!pids[@]}"; do wait "${pids[$i]}" || { echo "FAILED chr${labels[$i]}" >&2; fail=1; }; done
+[[ "$fail" -eq 0 ]] && echo "All requested PhenotypeOrthologous references are complete under $TARGET"
+exit "$fail"
+```
+
+- [ ] **Step 3: Make executable, shellcheck, run chr22**
+
+```bash
+chmod +x e2e-testing/scripts/build_vep_phenotypeorthologous_reference.sh e2e-testing/scripts/generate_vep_phenotypeorthologous_references.sh
+shellcheck e2e-testing/scripts/build_vep_phenotypeorthologous_reference.sh e2e-testing/scripts/generate_vep_phenotypeorthologous_references.sh || true
+e2e-testing/scripts/build_vep_phenotypeorthologous_reference.sh 22
+```
+
+Expected: `OK: chr22 — 50861 records, 4 plugin CSQ fields` (record count equals the five-plugin chr22 reference) and the file under `output/116/plugins/`.
+
+- [ ] **Step 4: Confirm the gene-id assumption on the oracle** (spec §11)
+
+```bash
+OUT=~/workspace/data_vepyr/output/116/plugins/HG002_chr22_phenotypeorthologous_vep116.vcf.gz
+bgzip -dc "$OUT" | grep -v '^#' | head -2000 | tr ',' '\n' | awk -F'|' '$(NF-3)!="" || $(NF-1)!=""' | cut -d'|' -f5,7,$(( $(bgzip -dc "$OUT" | grep -m1 '##INFO=<ID=CSQ' | tr '|' '\n' | wc -l) - 3 ))- | head -5
+```
+
+Expected: populated lines whose Gene column is an `ENSG…` id present in the GFF for that gene; RefSeq lines (`Feature` starting `NM_`/`NR_`/`XM_`) always empty. If a populated line shows a gene id that is **not** in the GFF row overlapping that position, stop and report: the `_gene` object diverges from the Gene column and the discriminator needs a different attribute.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e-testing/scripts/build_vep_phenotypeorthologous_reference.sh e2e-testing/scripts/generate_vep_phenotypeorthologous_references.sh
+git commit -m "feat(e2e): VEP 116 PhenotypeOrthologous reference builder and resumable driver"
+```
+
+### Task V5: Build the chr22 cache and run the parity gate
+
+- [ ] **Step 1: Build chr22 + chr1 from the catalog branch** (the manifest lives on the vepyr-plugins branch until `v0.2.0` exists; `_resolve_plugin_manifest` accepts any git ref)
+
+```bash
+uv run python - <<'EOF'
+import vepyr, os
+D = os.path.expanduser("~/workspace/data_vepyr")
+for c in ["22", "1"]:
+    print(vepyr.build_plugin_cache(
+        "phenotypeorthologous", "feat/phenotypeorthologous",
+        source_path=f"{D}/plugin_input/phenotypeorthologous/PhenotypesOrthologous_homo_sapiens_112_GRCh38.gff3.gz",
+        cache_dir=f"{D}/cache/116_GRCh38_merged",
+        plugin_cache_root=f"{D}/plugin_cache_dev_po",
+        chroms=[c], plugins_repo=os.path.expanduser("~/research/git/vepyr-plugins"),
+        verify_source="strict"))
+EOF
+```
+
+Expected: `[('chr22', 377, 0, 377)]` then `[('chr1', 1754, 0, 1754)]`.
+
+- [ ] **Step 2: chr22 comparison, strict md5, workers 1 vs 4**
+
+```bash
+for w in 1 4; do
+  uv run python e2e-testing/scripts/run_comparison.py --release 116 --profile merged_phenotypeorthologous \
+    --chroms 22 --plugin-cache ~/workspace/data_vepyr/plugin_cache_dev_po --workers $w --bgzf --force
+  cp e2e-testing/results/116/fast_chr22/vepyr_chr22_merged_phenotypeorthologous.vcf.gz /tmp/po_w$w.vcf.gz
+done
+uv run python e2e-testing/scripts/md5_concordance.py --pair \
+  e2e-testing/results/116/fast_chr22/vep_chr22_merged_phenotypeorthologous.vcf \
+  /tmp/po_w4.vcf.gz --mode strict --explain --explain-limit 0
+uv run python e2e-testing/scripts/md5_concordance.py --pair /tmp/po_w1.vcf.gz /tmp/po_w4.vcf.gz --mode strict
+```
+
+Expected: the field report shows the four `PhenotypeOrthologous_*` fields with `both_nonempty_unequal = 0` and `vepyr_empty_only = vep_empty_only = 0`; both strict concordance runs exit 0. On a mismatch, read the JSONL ledger in `e2e-testing/reports/` for the first differing entry and classify: value escaping (engine `csq_escape`), span boundary (insertion swap), or gene id (see V4 step 4). Fix in the engine PR branch, re-pin, repeat.
+
+- [ ] **Step 3: chr1**
+
+Run the V4 builder for chr1, then the same comparison with `--chroms 1 --workers 4`. Expected: 100% and strict PASS.
+
+- [ ] **Step 4: Record** the report paths and md5s in the PR description draft (`e2e-testing/reports/fast_chr22_merged_phenotypeorthologous_116_*`).
+
+### Task V6: Whole-sample oracle (hours; start early, in the background)
+
+- [ ] **Step 1: Launch**
+
+```bash
+mkdir -p ~/workspace/data_vepyr/output/116/plugins/logs
+VEP_REFERENCE_JOBS=2 nohup e2e-testing/scripts/generate_vep_phenotypeorthologous_references.sh \
+  > ~/workspace/data_vepyr/output/116/plugins/logs/po_all.log 2>&1 &
+echo $! > ~/workspace/data_vepyr/output/116/plugins/logs/po_all.pid
+```
+
+Re-running the same command after an interruption skips completed contigs. Progress: `grep -E 'START|DONE|ERROR|SKIP' …/logs/po_all.log`.
+
+- [ ] **Step 2: When complete, per-contig gate**
+
+```bash
+uv run python - <<'EOF'
+import vepyr, os
+D = os.path.expanduser("~/workspace/data_vepyr")
+vepyr.build_plugin_cache("phenotypeorthologous", "feat/phenotypeorthologous",
+    source_path=f"{D}/plugin_input/phenotypeorthologous/PhenotypesOrthologous_homo_sapiens_112_GRCh38.gff3.gz",
+    cache_dir=f"{D}/cache/116_GRCh38_merged", plugin_cache_root=f"{D}/plugin_cache_dev_po",
+    chroms=[str(c) for c in range(1, 23)], plugins_repo=os.path.expanduser("~/research/git/vepyr-plugins"),
+    overwrite=True, verify_source="strict")
+EOF
+for c in $(seq 1 22); do
+  uv run python e2e-testing/scripts/run_comparison.py --release 116 --profile merged_phenotypeorthologous \
+    --chroms $c --plugin-cache ~/workspace/data_vepyr/plugin_cache_dev_po --workers 4 --bgzf --force
+  uv run python e2e-testing/scripts/md5_concordance.py --pair \
+    e2e-testing/results/116/fast_chr$c/vep_chr${c}_merged_phenotypeorthologous.vcf \
+    e2e-testing/results/116/fast_chr$c/vepyr_chr${c}_merged_phenotypeorthologous.vcf.gz --mode strict \
+    && echo "chr$c strict PASS" || echo "chr$c strict FAIL"
+done | tee ~/workspace/data_vepyr/output/116/plugins/logs/po_strict_summary.txt
+```
+
+Expected: 22 × `strict PASS`. This is the gate for tagging the Hub cache (Task V8).
+
+### Task V7: Docs
+
+**Files:**
+- Modify: `docs/plugins.md:188-243` (manifest tables: `lookup` row, `provider` list, `[source.gff]` table), `:555-650` (Cache format: interval shard schema and "no tier join" note), `:682-733` (Supported plugins: sixth row, emitted-order row, note that `PhenotypeOrthologous` needs no licence caveat)
+- Modify: `docs/downloads.md:183-200` (fifth dataset row + contig note: this cache covers chr1–22, X, MT; chrY has no rows)
+- Modify: `docs/testing-vep.md:396-425` (profile note + the two new scripts)
+- Modify: `docs/architecture.md:42` (one clause: "point or interval lookups"), `README.md:35` (plugin list), `e2e-testing/README.md:295-310` (two profile rows: `merged_plugins`, `merged_phenotypeorthologous`), `docs/dataframes.md:148` ("Plugin columns": interval plugins are per-transcript lists, gated by gene span)
+
+- [ ] **Step 1: `docs/plugins.md` edits**
+
+Top-level table, new row:
+
+```markdown
+| `lookup` | `point` \| `interval` | no (default `point`) | `point`: exact probe on `(start, allele_string, discriminators)` with variation-inherited tiering. `interval`: rows are genomic spans with no allele; a row matches when its `[start, end]` overlaps the variant's VEP-normalised span and every discriminator agrees, first row in file order. Use it for gene/region tracks (PhenotypeOrthologous). `ingest_sql` then projects `chrom, start, end` plus discriminator and value columns, and `allele_match` is rejected. |
+```
+
+`[[source]]` `provider` row: `csv \| tsv \| parquet \| vcf \| bed \| gff`, and a new `[source.gff]` table after `[source.csv]`:
+
+```markdown
+### `[source.gff]`
+
+| Key | Type | Required | Description |
+|---|---|---|---|
+| `attributes` | array of strings | yes | GFF3 attribute keys exposed as flat nullable `Utf8` columns named exactly like the key (quote them in SQL: `"Rat_gene_id"`). Values are percent-decoded and not trimmed. The fixed columns are `chrom, start, end, type, source, score, strand, phase`. With `index = "tabix"` the BGZF file is sliced per chromosome; plain or gzip GFF is read whole. |
+```
+
+Shard schema section: add "For `lookup = "interval"` caches `allele_string` is absent and `tier` is always `1`: interval rows have no allele to inherit a tier from, so the variation join is skipped and rows are written in `(start, file order)`." Supported-plugins table row:
+
+```markdown
+| **PhenotypeOrthologous** | 4 | `{Gene}` + gene-span overlap | — (`interval`) | [`…plugin_phenotypeorthologous`](downloads.md#plugin-caches) | [Ensembl FTP](https://ftp.ensembl.org/pub/release-116/variation/PhenotypeOrthologous/) |
+```
+
+Emitted-order row: `PhenotypeOrthologous_Mouse_geneid`, `PhenotypeOrthologous_Mouse_phenotype`, `PhenotypeOrthologous_Rat_geneid`, `PhenotypeOrthologous_Rat_phenotype`. Update "All five" → "All six", "Four have a prebuilt cache" → "Five".
+
+- [ ] **Step 2: Other docs** as listed in Files; in `docs/testing-vep.md` add:
+
+```markdown
+    `merged_phenotypeorthologous` reads its own per-contig reference
+    (`HG002_chr{N}_phenotypeorthologous_vep116.vcf.gz`), produced by
+    `build_vep_phenotypeorthologous_reference.sh <chrom>` or, for chr1–22,
+    the resumable `generate_vep_phenotypeorthologous_references.sh`.
+```
+
+- [ ] **Step 3: Build docs and commit**
+
+Run: `uv run mkdocs build --strict` (if mkdocs is in the venv; otherwise `uvx --with mkdocs-material mkdocs build --strict`).
+
+```bash
+git add docs/plugins.md docs/downloads.md docs/testing-vep.md docs/architecture.md docs/dataframes.md README.md e2e-testing/README.md
+git commit -m "docs: gff sources, interval lookups and the PhenotypeOrthologous plugin"
+```
+
+### Task V8: Publish the cache (after vepyr-plugins `v0.2.0` is tagged and V6 is green)
+
+- [ ] **Step 1: Build all 25 contigs from the tag, strict**
+
+```bash
+uv run python - <<'EOF'
+import vepyr, os
+D = os.path.expanduser("~/workspace/data_vepyr")
+print(vepyr.build_plugin_cache("phenotypeorthologous", "v0.2.0",
+    source_path=f"{D}/plugin_input/phenotypeorthologous/PhenotypesOrthologous_homo_sapiens_112_GRCh38.gff3.gz",
+    cache_dir=f"{D}/cache/116_GRCh38_merged", plugin_cache_root=f"{D}/plugin_cache_v0.2.0",
+    chroms=[str(c) for c in range(1, 23)] + ["X", "Y", "MT"], overwrite=True, verify_source="strict"))
+EOF
+```
+
+Expected: 25 entries; `chrY` with `rows=0` and no shard; `chrMT` 13 rows; total rows 16,404 (the four unplaced contigs' 5 rows are outside the 25). `manifest.json` has `"lookup": "interval"`, `cache_source_version: "v0.2.0@<sha>"`, `sources[0].verified_md5 == md5`.
+
+- [ ] **Step 2: Re-run the chr22 strict gate against this exact root** (`--plugin-cache ~/workspace/data_vepyr/plugin_cache_v0.2.0`). Expected: PASS.
+
+- [ ] **Step 3: Write the card** `~/workspace/data_vepyr/plugin_cache_v0.2.0/plugin/phenotypeorthologous/README.md`, following `biodatageeks/vepyr_116_GRCh38_plugin_clinvar`'s card structure (download it with `hf download … README.md`): title, what it is, source url/md5/verified md5/.tbi md5, `cache_source_version`, lookup kind + match rule, CSQ fields and header descriptions, per-contig row table (from `manifest.json`), licence (Ensembl data, free use), how to download into `<root>/plugin/phenotypeorthologous/`, parity statement (chr1–22 strict concordance against VEP 116.0, date).
+
+- [ ] **Step 4: Upload, tag, verify**
+
+```bash
+hf auth whoami
+hf repos create biodatageeks/vepyr_116_GRCh38_plugin_phenotypeorthologous --type dataset
+hf upload biodatageeks/vepyr_116_GRCh38_plugin_phenotypeorthologous \
+  ~/workspace/data_vepyr/plugin_cache_v0.2.0/plugin/phenotypeorthologous . --type dataset \
+  --commit-message "PhenotypeOrthologous cache v0.2.0 (VEP 116 GRCh38 merged, 25 contigs)"
+hf repos tag create biodatageeks/vepyr_116_GRCh38_plugin_phenotypeorthologous v0.2.0 --type dataset --message "vepyr-plugins v0.2.0"
+hf datasets info biodatageeks/vepyr_116_GRCh38_plugin_phenotypeorthologous --expand siblings --format json | jq '.siblings[].rfilename'
+hf download biodatageeks/vepyr_116_GRCh38_plugin_phenotypeorthologous manifest.json --repo-type dataset --local-dir /tmp/po_check && diff /tmp/po_check/manifest.json ~/workspace/data_vepyr/plugin_cache_v0.2.0/plugin/phenotypeorthologous/manifest.json && echo manifest identical
+```
+
+Expected: 24 shards + `manifest.json` + `README.md` listed; the manifest diff is empty. Uploading is outward-facing: confirm with the user before `hf upload` unless they have already said to proceed.
+
+### Task V9: Regression re-check, PR body, handoff
+
+- [ ] **Step 1: Re-run V0** with the pinned extension and diff the md5 lines against `e2e-testing/reports/baseline_merged_plugins_chr22_2026-09-11.txt`. Expected: identical (point path unchanged).
+
+- [ ] **Step 2: Full local test suite and lint**
+
+```bash
+uv run pytest -q
+uv run pre-commit run ruff --all-files && uv run pre-commit run ruff-format --all-files
+cargo clippy && cargo fmt --check
+```
+
+- [ ] **Step 3: Re-pin to the engine master SHA** once the engine PRs are squash-merged (`cargo update -p datafusion-bio-function-vep`, rebuild, `uv run pytest tests/test_annotate.py -k "Interval or Plugin" -q`), commit `chore: re-pin engine to master <sha>`.
+
+- [ ] **Step 4: Push and open the draft PR**
+
+```bash
+git push -u origin feat/gff-plugin-source-phenotypeorthologous
+gh pr create --draft --title "feat: PhenotypeOrthologous plugin via a GFF source and interval lookup" --body-file <(cat <<'EOF'
+Pins the engine with `provider = "gff"` and `lookup = "interval"` (datafusion-bio-functions #<PR1>, #<PR2>), adds the `merged_phenotypeorthologous` comparison profile, the VEP 116 oracle scripts (BGZF output), a synthetic gene-span fixture test, and docs. Catalog manifest: vepyr-plugins #<PR3>, tagged v0.2.0.
+
+Parity (VEP 116.0, merged cache, normalized HG002):
+- chr22: 4/4 fields 100%, strict md5 PASS, workers 1 == 4 (<report path>)
+- chr1: 4/4 fields 100%, strict md5 PASS
+- chr1–22: 22/22 strict PASS (<summary path>)
+- merged_plugins chr22 baseline unchanged (<md5>)
+
+Cache: `biodatageeks/vepyr_116_GRCh38_plugin_phenotypeorthologous` @ v0.2.0 (25 contigs; chrY has no rows).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+https://claude.ai/code/session_01Ybip12LHW1qoorZjs3TwYT
+EOF
+)
+```
+
+- [ ] **Step 5: Review loop** per the vepyr-fix skill until green; hand the merge to the human.

--- a/docs/superpowers/specs/2026-09-05-plugin-cache-qa-profile-design.md
+++ b/docs/superpowers/specs/2026-09-05-plugin-cache-qa-profile-design.md
@@ -1,0 +1,291 @@
+# Plugin cache QA profile: invariants, content profile, and dataset-card publishing
+
+**Date:** 2026-09-05
+**Status:** Approved (design)
+**Implementation repo:** `vepyr` (`e2e-testing/scripts/cache_qa/`)
+**Related:** `docs/plugins.md` (cache layout), `docs/downloads.md` (published caches),
+`e2e-testing/scripts/comparison/` (package pattern to follow)
+
+## Problem
+
+A plugin cache is a directory of per-contig Parquet shards plus a `manifest.json`
+(see `docs/plugins.md`). The builder records row, warm and cold counts per shard and,
+since engine PR #228, the verified source digests, but nothing checks the shards
+themselves after a build, and the Hugging Face dataset cards
+(`biodatageeks/vepyr_116_GRCh38_plugin_<name>`) describe the data by hand.
+
+Two gaps follow:
+
+1. A shard that violates a structural assumption the runtime relies on (row order,
+   allele form, schema, contig) is only caught when an annotation run mismatches VEP.
+2. Nothing on the card tells a user what is actually in the files: null shares,
+   value ranges, category mixes, per-contig sizes.
+
+This design adds one Polars-based tool that verifies the structural invariants,
+profiles the content, writes a machine-readable `qa_profile.json`, regenerates a
+`## Quality profile` section in the dataset card, and, on request, publishes shards,
+manifest, JSON and card as one Hugging Face commit tagged with the vepyr-plugins
+release. A failed invariant blocks publishing.
+
+Polars is the engine deliberately: the repo already depends on it, most checks are
+domain-specific and would be custom code under dbt, Soda or Great Expectations as
+well, and the Polars streaming engine handles the 8.4 billion CADD rows without a
+second runtime. Revisit Soda Core over DuckDB only if plugin QA becomes recurring
+monitoring with alerting and history.
+
+## Scope
+
+In scope:
+
+- Structural invariants (hard failures) and a content profile (informational) over a
+  local cache root `<root>/plugin/<name>/`.
+- `qa_profile.json` written next to the shards' staging copy and uploaded with them.
+- A regenerated card section between marker comments in the plugin's `README.md`.
+- A `--publish` path that stages shards, `manifest.json`, `qa_profile.json` and
+  `README.md` by hard link and runs one `hf upload` commit plus a tag move.
+- Unit tests on synthetic shards; no network in tests.
+
+Out of scope for this version:
+
+- Source coverage (needs the source file; a build-time concern).
+- Lookup smoke tests through `annotate()`.
+- Thresholds on profile metrics (null share, ranges). Profile numbers are reported,
+  never judged.
+- Reading shards from `hf://` paths. The scan source is one function argument, so this
+  is a later addition without redesign.
+- Rewriting the hand-written `Total ≈ … rows` line in the card's `## Contents`
+  section. The new section carries the same numbers.
+
+## Inputs
+
+- `<root>/plugin/<name>/manifest.json` as written by `build_plugin_cache`. Fields used:
+  `plugin_name`, `key_columns`, `match_columns[].column`, `value_columns[].column`,
+  `value_columns[].type`, `chroms[]` (`chrom`, `file`, `rows`, `warm`, `cold`),
+  `cache_source_version`, `allele_match`.
+- The shards named by `chroms[].file`. A contig listed with `rows == 0` may have no
+  file (SpliceAI chrMT); any other missing file is an invariant failure.
+- The vepyr-plugins source manifest is *not* read. Everything needed is in
+  `manifest.json`, so the tool works on a downloaded cache too.
+
+Dedup policy comes from the manifest's `assume_unique` key, which engine PR
+biodatageeks/datafusion-bio-functions#234 adds to `CacheManifest` as an optional
+boolean: `true` when the build skipped dedup on the source's claim, `false` when dedup
+ran, absent when unknown (a cache built before the key existed, or one that carried
+chromosomes from such a cache). `false` fails on duplicates; `true` reports them as a
+warning. When the key is absent the tool falls back to a per-plugin table
+(`clinvar`, `alphamissense`, `dbnsfp` deduplicated; `spliceai`, `cadd` assume unique)
+and says so in the invariant detail; an unknown plugin without the key is treated as
+deduplicated (strict).
+
+## Invariants
+
+Each invariant yields `pass`, `fail` or `warn`, a one-line detail, and where useful a
+per-contig breakdown. Any `fail` makes the run exit 1 and disables `--publish`.
+`warn` never blocks.
+
+| id | check | failure detail |
+|---|---|---|
+| `schema` | Shard columns are exactly key columns, match columns, value columns and `tier`, in that order, with the manifest's types (`Utf8`→`String`, `Float32`, `Int32`, …; `chrom` String, `start`/`end` UInt32, `tier` Int8). | first differing column per shard |
+| `contig` | Every `chrom` value equals the shard's contig (`chr22.parquet` → `chr22`). | count of foreign rows per shard |
+| `order` | Rows are non-decreasing on the lexicographic key `(tier, start, allele_string, match columns…)`. This is the total order the tier stage emits since engine #230 and what `PageDir` lookups assume for `(tier, start)`. | count of descending steps per shard |
+| `tier_domain` | `tier` is 0 or 1 and never null. | count of other values |
+| `manifest_counts` | Per contig, `rows`, warm (`tier == 0`) and cold (`tier == 1`) counts equal `manifest.json`. | expected vs found per contig |
+| `manifest_files` | Every manifest contig with `rows > 0` has its file; no `chr*.parquet` exists that the manifest does not list. | missing / unlisted names |
+| `positions` | `start >= 1` and `end >= start - 1` (an insertion has `end = start - 1`). | count of violations per shard |
+| `allele_form` | `allele_string` is `REF/ALT` with both parts non-empty. For `allele_match == "minimised"` plugins, REF and ALT do not share a first base unless one of them is `-`. | count of violations per shard |
+| `duplicates` | No two rows share (key columns + match columns). `fail` for deduplicated plugins, `warn` for `assume_unique` plugins. | duplicate row count per shard |
+
+Implementation notes:
+
+- `order` and `positions` are per-shard lazy scans reduced to counts:
+  `pl.col(c).shift(1)` comparisons combined into one lexicographic
+  "descending step" expression, then `.sum()`. No sort, no collect of the shard.
+- `duplicates` groups by the key on the streaming engine and counts groups with
+  `len > 1`; the per-shard grouping fits because a shard holds one contig.
+- `allele_form` uses `str.split_exact("/", 1)` and first-character comparison.
+- `schema` uses `scan_parquet(...).collect_schema()` and reads no data.
+
+## Content profile
+
+Computed once over all shards with one `pl.scan_parquet([files])`, grouped by `chrom`
+for the contig table and ungrouped for the plugin totals, collected on the streaming
+engine (`collect(engine="streaming")`).
+
+Per contig: `rows`, `warm`, `cold`, `warm_share`, `bytes` (file size), `start_min`,
+`start_max`.
+
+Per column, for every match and value column (key columns and `tier` get only the
+null share):
+
+- `null_share`, `empty_share` (empty string or `.`), both per contig and overall.
+- `distinct`: exact `n_unique` when the overall value is at most 10,000, otherwise
+  `approx_n_unique`, flagged `approx: true`.
+- `numeric`: present when the column is numeric, or is text and at least one value
+  casts to Float64 (`cast(pl.Float64, strict=False)`). Holds `parsable_share`, `min`,
+  `max`, `mean`, `p50`, `p95`. Quantiles come from the streaming engine and are
+  approximate; `min`, `max`, `mean` and the shares are exact.
+- `top_values`: the ten most frequent values with counts when `distinct <= 50`.
+
+Scores stored as text (CADD, SpliceAI DS, most dbNSFP columns) are stored that way so
+the CSQ output reproduces the source formatting; `parsable_share` is the useful
+signal for them, and the numeric summary describes the parsable part only.
+
+## Outputs
+
+### `qa_profile.json`
+
+```json
+{
+  "plugin": "clinvar",
+  "cache_source_version": "v0.1.1@3e1c0394…",
+  "generated_at": "2026-09-05T12:00:00Z",
+  "tool": {"vepyr": "0.4.0", "polars": "1.39.3", "schema_version": 1},
+  "status": "pass",
+  "invariants": [
+    {"id": "order", "status": "pass", "detail": "0 descending steps in 25 shards"},
+    {"id": "duplicates", "status": "warn", "detail": "412 duplicate keys (assume_unique source)",
+     "per_contig": {"chr1": 40, "chr2": 33}}
+  ],
+  "summary": {"rows": 4439569, "warm": 113018, "cold": 4326551, "bytes": 85012345, "contigs": 25},
+  "contigs": [
+    {"chrom": "chr1", "file": "chr1.parquet", "rows": 401099, "warm": 10445, "cold": 390654,
+     "warm_share": 0.026, "bytes": 7400000, "start_min": 925952, "start_max": 248936893}
+  ],
+  "columns": [
+    {"name": "clnsig", "role": "value", "dtype": "String", "null_share": 0.0, "empty_share": 0.0012,
+     "distinct": 31, "approx": false,
+     "top_values": [["Uncertain_significance", 1900000], ["Likely_benign", 1200000]],
+     "numeric": null,
+     "per_contig": {"chr1": {"null_share": 0.0, "empty_share": 0.001}}}
+  ]
+}
+```
+
+`status` is `fail` if any invariant failed, else `warn` if any warned, else `pass`.
+`schema_version` lets a later reader tell the layout apart.
+
+### Card section
+
+Regenerated between `<!-- qa-profile:start -->` and `<!-- qa-profile:end -->`. If the
+markers are absent the section is inserted before `## Usage`; if that heading is
+absent it is appended. The section is:
+
+```markdown
+## Quality profile
+
+Generated 2026-09-05 by `profile_plugin_cache.py` (vepyr 0.4.0, Polars 1.39.3) from
+the shards in this commit; machine-readable copy in [`qa_profile.json`](qa_profile.json).
+
+### Invariants
+
+| check | status | detail |
+|---|---|---|
+| schema | ✅ pass | 25 shards match the manifest |
+| duplicates | ⚠️ warn | 412 duplicate keys (assume_unique source) |
+
+### Contigs
+
+| contig | rows | warm | cold | warm % | size |
+|---|--:|--:|--:|--:|--:|
+| chr1 | 401,099 | 10,445 | 390,654 | 2.6% | 7.4 MB |
+| … | | | | | |
+| **total** | **4,439,569** | **113,018** | **4,326,551** | **2.5%** | **85 MB** |
+
+### Columns
+
+| column | role | type | null % | empty % | distinct | numeric (min / p50 / p95 / max) | top values |
+|---|---|---|--:|--:|--:|---|---|
+| clnsig | value | String | 0.00 | 0.12 | 31 | — | Uncertain_significance (1.9M), Likely_benign (1.2M), … |
+| am_pathogenicity | value | Float32 | 0.00 | — | ~68M | 0.000 / 0.121 / 0.912 / 1.000 | — |
+```
+
+Per-contig column detail stays in the JSON only; the card shows plugin-wide column
+stats to keep the section readable for dbNSFP's 19 value columns.
+
+Rendering is idempotent: running the tool twice on the same shards yields the same
+README bytes except for `generated_at`.
+
+## Package layout and CLI
+
+```
+e2e-testing/scripts/profile_plugin_cache.py     entry point (argparse, calls cache_qa.cli.main)
+e2e-testing/scripts/cache_qa/__init__.py
+e2e-testing/scripts/cache_qa/manifest.py        load + validate manifest.json, contig/file resolution, dedup policy table
+e2e-testing/scripts/cache_qa/invariants.py      one function per invariant -> InvariantResult
+e2e-testing/scripts/cache_qa/profile.py         contig table + column stats (Polars, streaming)
+e2e-testing/scripts/cache_qa/report.py          assemble qa_profile.json (dataclasses -> dict)
+e2e-testing/scripts/cache_qa/card.py            render section, splice into README between markers
+e2e-testing/scripts/cache_qa/stage.py           hard-link staging dir, hf upload + tag move via injected runner
+e2e-testing/scripts/cache_qa/cli.py             argument parsing, orchestration, exit codes
+```
+
+```
+profile_plugin_cache.py <plugin> --root <plugin_cache_root>
+    [--out <qa_profile.json>]          default: <root>/plugin/<name>/qa_profile.json
+    [--readme <README.md>]             card to update in place; default: none
+    [--readme-from-hub <repo>]         fetch the current card from the Hub first, then update it
+    [--publish <repo> --tag <tag>]     stage + upload + tag; requires a README source
+    [--commit-message <text>]
+    [--json-only]                      skip the card even if --readme is given
+```
+
+Exit codes: 0 pass or warn; 1 an invariant failed (nothing uploaded); 2 usage or
+I/O error (missing manifest, unreadable shard).
+
+`--publish` sequence: verify `status != "fail"`; build the staging directory
+(`<scratch>/stage_<plugin>/`) with hard links to every listed shard plus
+`manifest.json`, the freshly written `qa_profile.json` and `README.md`; run
+`hf upload <repo> <stage> . --repo-type dataset --commit-message …`; delete and
+recreate `<tag>` on the new head; read the repo back through the Hub API and confirm
+every staged file's size (and LFS sha256 where present) matches, and that the tag
+points at the new head. Any mismatch exits 1 after printing what differed.
+
+The Hub commands go through a small `Runner` protocol (`run(argv) -> CompletedProcess`)
+injected by `cli.py`, so tests substitute a fake and the real path shells out to `hf`.
+
+## Error handling
+
+- Missing or malformed `manifest.json`: exit 2 with the path and the missing key.
+- A shard the manifest lists but the file is absent with `rows > 0`: `manifest_files`
+  fails; the profile still runs on the shards present so the report is complete.
+- A shard that Polars cannot open: exit 2 naming the file; no partial JSON is written.
+- `--publish` without `--readme` or `--readme-from-hub`: exit 2 (the card would be
+  stale on the Hub).
+- `hf` not on PATH or not logged in: exit 2 before any upload with the command that
+  failed.
+- Verification after upload failing: exit 1; the commit stays on the Hub (uploads are
+  not reverted) and the message says which file or tag to inspect.
+
+## Testing
+
+Unit tests under `tests/test_cache_qa_*.py`, following `tests/test_comparison_*.py`:
+Polars builds three-contig synthetic caches (a few hundred rows) in `tmp_path`
+together with a matching `manifest.json`, through one fixture that returns a builder
+so a test can perturb a single aspect.
+
+- `invariants`: one passing case and one failing case per invariant (wrong column
+  type, foreign contig row, one swapped row pair, `tier = 2`, off-by-one manifest
+  count, unlisted shard, `end < start - 1`, shared leading base, duplicate key), plus
+  the `assume_unique` warn path and the missing-file-with-zero-rows allowance.
+- `profile`: known-answer stats (null and empty shares, exact distinct, numeric
+  min/max/mean on parsable text, top values, per-contig rows and bytes).
+- `report`: JSON keys and `status` aggregation.
+- `card`: insertion before `## Usage`, replacement between existing markers,
+  idempotence, and the fallback append.
+- `stage`: hard links exist for every listed file; the fake runner receives the
+  expected `hf upload` and tag argv; verification failure surfaces as exit 1.
+- `cli`: exit codes 0, 1 and 2 for the three outcomes; `--publish` refused on `fail`.
+
+Runtime target on the build host: seconds for ClinVar and AlphaMissense, under a
+minute for dbNSFP and SpliceAI, single-digit minutes for CADD. Peak memory bounded by
+the streaming engine; no shard is collected whole.
+
+## Rollout
+
+1. Land the package and tests.
+2. Run it on the five v0.1.1 caches in `~/workspace/data_vepyr/plugin_cache_v0.1.1`;
+   publish the four public ones with `--publish … --tag v0.1.1` so the cards gain the
+   section; dbNSFP stays local (cannot be published, see `docs/downloads.md`).
+3. Replace the ad-hoc publish script used on 2026-09-05 with `--publish`.
+4. Add a short "Quality profile" paragraph to `docs/downloads.md` pointing at the
+   section and the JSON.

--- a/docs/superpowers/specs/2026-09-11-gff-plugin-source-and-phenotypeorthologous-design.md
+++ b/docs/superpowers/specs/2026-09-11-gff-plugin-source-and-phenotypeorthologous-design.md
@@ -1,0 +1,352 @@
+# GFF plugin sources and the PhenotypeOrthologous plugin
+
+Date: 2026-09-11. Status: approved in chat, implementation not started.
+
+## 1. Goal
+
+Add a `gff` source provider to the VEP plugin-cache machinery and port the
+Ensembl VEP `PhenotypeOrthologous` plugin (VEP_plugins release/116) to the
+vepyr-plugins catalog, gated byte-for-byte against Ensembl VEP 116 on the
+normalized HG002 input with the merged cache. Publish the resulting cache on
+Hugging Face.
+
+The plugin was chosen over `GO` because GO's GFF is not a published file: VEP
+generates it from the Ensembl core MySQL database on first run. (The 2026_04
+geneset on `ftp.ebi.ac.uk/pub/ensemblorganisms` does carry `xref.tsv.gz` with
+GO rows and `genes.gff3.gz` with transcript spans, both md5-pinned, so GO can
+follow later on the same `gff` provider once a transcript-keyed lookup exists.)
+
+## 2. Scope
+
+In scope:
+
+- `provider = "gff"` in plugin source manifests (engine + catalog validator).
+- A second lookup kind, `lookup = "interval"`, next to today's exact-position
+  probe.
+- `plugins/phenotypeorthologous/phenotypeorthologous.source.toml`.
+- VEP 116 oracle references for chr22 and chr1, plus a resumable whole-sample
+  driver (chr1-22; the HG002 benchmark VCF has no sex chromosomes).
+- A `merged_phenotypeorthologous` comparison profile in vepyr.
+- Docs in vepyr and vepyr-plugins; a published cache
+  `biodatageeks/vepyr_116_GRCh38_plugin_phenotypeorthologous`.
+
+Out of scope:
+
+- The plugin's `model=rat|mouse` option: all four fields are always emitted.
+- GO, or any transcript-keyed lookup.
+- Teaching the cache-QA tool (branch `feat/cache-qa-profile`) the interval
+  shard shape. The cache is published by hand, as the v0.1.1 caches were.
+- A COITree-backed interval index. See §4.3.
+
+## 3. Reference behaviour (VEP_plugins release/116, `PhenotypeOrthologous.pm`)
+
+Source file, pinned:
+
+| item | value |
+|---|---|
+| url | `https://ftp.ensembl.org/pub/release-116/variation/PhenotypeOrthologous/PhenotypesOrthologous_homo_sapiens_112_GRCh38.gff3.gz` |
+| md5 (computed locally; Ensembl's `CHECKSUMS` uses BSD `sum`) | `20e5401a198d7d3db66a982c037d3ad4` |
+| `.tbi` md5 | `1eb833a26c247418910685289c6528cc` |
+| size | 3,424,946 bytes, 16,409 features (`gene` 16,167, `ncRNA_gene` 242) |
+| contigs | 1-22, X, MT, GL000220.1, KI270721.1, KI270728.1, KI270734.1 (no Y) |
+| gene_id | unique per row; file sorted by start within contig |
+| plugin code | `PhenotypeOrthologous.pm` at VEP_plugins `a7e03a5c6497e29e0598eed7b4795f953d9a1b5f`, sha256 `89be8f30dd464f81913bef367831e8a08258e4085207f8291c956487f47de8ac` |
+
+Attributes used: `gene_id`, `Rat_gene_id`, `Rat_Orthologous_phenotype`,
+`Mouse_gene_id`, `Mouse_Orthologous_phenotype`. 12,375 rows carry mouse
+values, 15,869 carry rat values, 11,835 both. Phenotype values contain `|`
+separators, commas (6,772 rows) and at least one leading space.
+
+Matching, per transcript consequence line (`feature_types` is `Transcript`):
+
+1. `get_data($vf->{chr}, $vf_start, $vf_end)` with `expand_left(0)` and
+   `expand_right(0)`: a tabix region query with the **variant's** span. For
+   insertions VEP has `start = end + 1`; the plugin swaps them, so the query
+   span is `[end, start]`. The `chr` prefix is stripped to match the file.
+2. Of the records overlapping that span, in file order, the first whose
+   `gene_id` equals `$transcript->{_gene}->stable_id` wins.
+3. Result: up to four keys, absent when the attribute is absent.
+
+Output: VEP sorts plugin header keys, so the CSQ tail is, in order,
+`PhenotypeOrthologous_Mouse_geneid`, `PhenotypeOrthologous_Mouse_phenotype`,
+`PhenotypeOrthologous_Rat_geneid`, `PhenotypeOrthologous_Rat_phenotype`.
+Header descriptions (verbatim):
+
+- `PhenotypeOrthologous_Rat_geneid`: `PhenotypeOrthologous RatGene associated with Rat`
+- `PhenotypeOrthologous_Rat_phenotype`: `PhenotypeOrthologous RatPhenotypes associated with orthologous genes in Rat`
+- `PhenotypeOrthologous_Mouse_geneid`: `PhenotypeOrthologous MouseGene associated with Mouse`
+- `PhenotypeOrthologous_Mouse_phenotype`: `PhenotypeOrthologous MousePhenotypes associated with orthologous genes in Mouse`
+
+VCF escaping (`OutputFactory/VCF.pm`): `,` and `|` become `&`, `;` becomes
+`%3B`, whitespace runs become `_`. The engine's shared `csq_escape` already
+implements these rules, so a leading space renders as a leading `_`.
+
+Consequences for the port: a flanking (upstream/downstream) variant only
+matches when it still lies inside the gene span; RefSeq transcripts in the
+merged cache never match (their gene id is not an ENSG id); regulatory,
+motif and intergenic lines are empty.
+
+## 4. Engine design (datafusion-bio-functions, `plugin_cache/`)
+
+Base: `origin/master` at `4b0bd00`, which is also vepyr's pin.
+
+### 4.1 `gff` provider (PR 1)
+
+- `ProviderKind::Gff` in `source_manifest.rs`. New optional table
+  `[source.gff]` with `attributes: Vec<String>` (required, non-empty for
+  gff). `index = "tabix"` becomes legal for gff (BGZF + sibling `.tbi`).
+  `record_layout` stays VCF-only.
+- `provider.rs::register_sources_impl` arm: with `index = "tabix"`, slice the
+  chromosome through the existing `materialize_tabix_chrom` (records are
+  copied verbatim, so the temp file is valid GFF3) and open the temp path;
+  otherwise open the manifest path directly (plain or gzip, detected by
+  content, not extension). Construct
+  `GffTableProvider::new(path, Some(attributes), None, zero_based)` from
+  `datafusion-bio-format-gff` at the already-pinned tag `v1.12.1` (tag form,
+  never `rev`, per the Cargo.toml note in vepyr). `zero_based` follows the
+  manifest `coordinate_system` exactly as the VCF/BED arms do.
+- The table exposes `chrom, start, end, type, source, score, strand, phase`
+  plus one nullable Utf8 column per requested attribute. The reader
+  percent-decodes attribute values and does not trim them.
+- Tests: a synthetic 3-feature GFF3 as plain text, gzip and BGZF+tbi; an
+  attribute containing `%3B`; a value with a leading space; a missing
+  attribute yields NULL; a contig absent from the index yields zero rows.
+
+### 4.2 `lookup = "interval"` (PR 2, stacked on PR 1)
+
+Manifest:
+
+- Top-level `lookup = "point" | "interval"`, default `point`, serialised
+  lowercase. `interval` requires at least one `[[source]]` whose rows carry
+  `start` and `end`; `allele_match` must be left at its default (validator
+  error otherwise, it has no meaning without an allele); `assume_unique` and
+  `field_order` keep their meaning; `match_column` templates are optional.
+- `CacheManifest` gains `lookup` (serde default `point`, so existing caches
+  read unchanged) and `key_columns` becomes `["chrom","start","end"]` for
+  interval caches. `ChromEntry.warm` is 0 and `cold` equals `rows`.
+
+Build (`build.rs`, `normalize.rs`, `join.rs`, `write.rs`):
+
+- Normalised projection is `chrom, start, end, <match…>, <value…>`, no
+  `allele_string`; the coordinate shift for `0-based-half-open` applies to
+  `start` as today.
+- Dedup keeps the first row per `(start, end, <match…>)` in arrival order.
+- The variation tier join is skipped; `tier` is written as the literal
+  `CAST(1 AS TINYINT)`. The shard must preserve tabix order, so an ordinal
+  is attached at ingest and the final `ORDER BY` is `(start, ordinal)`. The
+  existing `inspect_tier_start_order` guard and the `(tier, start)` writer
+  properties remain valid.
+- `plugin_output_schema` for interval caches:
+  `chrom, start, end, <match…>, <value…>, tier`.
+- `PluginCacheBuilder` still takes the variation cache dir; it is used only
+  to enumerate chromosomes for interval builds.
+
+Runtime (`lookup.rs`, `registry.rs`, `annotate_provider.rs`):
+
+- New `IntervalLookup::open(shard)`: reads the whole per-chromosome shard
+  once (projection `start, end, <match…>, <value…>`) into
+  `HashMap<Vec<Option<String>>, Vec<IntervalRow>>` keyed by the discriminator
+  tuple, each vector in file order. Shards are small (PhenotypeOrthologous:
+  at most 1,754 rows on chr1).
+- `probe(vf_start, vf_end, &match_values) -> Option<&[PluginScalar]>`
+  returns the first row with `start <= vf_end && end >= vf_start`.
+- `PluginRegistry::open` branches on `manifest.lookup` into
+  `PluginLookupKind::{Point(PluginLookup), Interval(IntervalLookup)}`;
+  `take_buffer_all` skips interval plugins; `probe_all` receives the
+  variant's VEP-normalised span in addition to the existing point key.
+- The variant span passed to the probe is derived from the same
+  VEP-normalised allele the point key uses: SNV/MNV/deletion
+  `[vep_start, vep_start + len(ref) - 1]`; insertion (empty trimmed ref)
+  `[vep_start - 1, vep_start]`, which is VEP's swapped `[end, start]`.
+- The no-transcript placeholder line probes with an empty attribute
+  namespace, exactly like point plugins: a plugin with a discriminator gates
+  to empty, a discriminator-less interval plugin still populates.
+- Values go through `csq::format_scalar`, so escaping is the shared engine
+  rule. Header descriptions come from `value_columns[].description`.
+
+Limitation, documented: a discriminator-less interval plugin scans its
+chromosome's rows linearly per probe. Acceptable for tracks of a few thousand
+intervals; a COITree index is the upgrade path if a large track arrives.
+
+### 4.3 Tests (engine)
+
+- Manifest: `lookup` parsing and defaults; `interval` rejects
+  `allele_match = "minimised"`; old `manifest.json` without `lookup` reads
+  as `point`.
+- Build: an interval manifest over the synthetic GFF yields the expected
+  schema, order and `tier = 1`; dedup keeps the first of two identical keys.
+- Runtime: overlap at both boundaries, insertion span, discriminator miss,
+  first-in-file-order tie-break, escaping of `,`, `|`, whitespace and a
+  leading space.
+- Regression: the existing point-lookup tests and the golden benchmark are
+  untouched; enabling an interval plugin adds exactly its four columns.
+
+## 5. Catalog (vepyr-plugins)
+
+`plugins/phenotypeorthologous/phenotypeorthologous.source.toml`:
+
+```toml
+plugin_name       = "phenotypeorthologous"
+coordinate_system = "1-based"
+lookup            = "interval"
+field_order       = "alphabetical"        # VEP sorts plugin header keys
+assume_unique     = true                  # one row per gene_id in the file
+ingest_sql = """
+SELECT chrom, start, "end",
+       gene_id,
+       "Mouse_gene_id"               AS mouse_gene_id,
+       "Mouse_Orthologous_phenotype" AS mouse_phenotype,
+       "Rat_gene_id"                 AS rat_gene_id,
+       "Rat_Orthologous_phenotype"   AS rat_phenotype
+FROM plugin_phenotypeorthologous_src
+"""
+
+[[source]]
+provider = "gff"
+path     = "PhenotypesOrthologous_homo_sapiens_112_GRCh38.gff3.gz"
+url      = "https://ftp.ensembl.org/pub/release-116/variation/PhenotypeOrthologous/PhenotypesOrthologous_homo_sapiens_112_GRCh38.gff3.gz"
+md5      = "20e5401a198d7d3db66a982c037d3ad4"   # computed locally; Ensembl's CHECKSUMS is BSD sum
+index    = "tabix"
+  [source.gff]
+  attributes = ["gene_id", "Mouse_gene_id", "Mouse_Orthologous_phenotype",
+                "Rat_gene_id", "Rat_Orthologous_phenotype"]
+
+[[match_column]]
+column   = "gene_id"
+template = "{Gene}"
+
+[[value_columns]]
+column = "mouse_gene_id"
+csq_field = "PhenotypeOrthologous_Mouse_geneid"
+type = "Utf8"
+description = "PhenotypeOrthologous MouseGene associated with Mouse"
+# … mouse_phenotype, rat_gene_id, rat_phenotype likewise (descriptions in §3)
+```
+
+Validator (`scripts/validate_manifests.py`): add `gff` to `PROVIDERS`;
+require `[source.gff].attributes` (non-empty list of strings) for gff and
+reject it elsewhere; allow `index = "tabix"` for gff; accept top-level
+`lookup ∈ {point, interval}` and reject `allele_match` when `interval`.
+README manifest table, the "Supported plugins" list and
+`.claude/skills/adding-a-plugin/SKILL.md` gain the GFF and interval sections.
+Release: `minor` bump → `v0.2.0` after merge.
+
+## 6. vepyr
+
+- `Cargo.toml` pin → engine master after PR 1 and PR 2 merge.
+- Python: no functional change is required. `per_variant = not
+  match_columns` already types the plugin columns as per-transcript
+  `List(String)`. Validation messages that list plugin names pick the new one
+  up from the manifest.
+- `e2e-testing/scripts/comparison/profiles.py`: profile
+  `merged_phenotypeorthologous` = merged cache + `plugins=("phenotypeorthologous",)`,
+  per-contig reference template
+  `output/116/plugins/HG002_chr{chrom}_phenotypeorthologous_vep116`.
+- `e2e-testing/scripts/build_vep_phenotypeorthologous_reference.sh <chrom>`:
+  downloads and md5-checks the GFF and `.tbi` into
+  `$DATA/plugin_input/phenotypeorthologous/`, pins `PhenotypeOrthologous.pm`
+  by sha256 under `output/116/plugins/plugin_code/`, slices
+  `HG002_norm.vcf.gz` per contig, runs VEP with **BGZF output**
+  (`--compress_output bgzip`), indexes it, asserts exactly four plugin
+  sub-fields in the CSQ header, and writes a `.plugins` sidecar.
+- `e2e-testing/scripts/generate_vep_phenotypeorthologous_references.sh [chroms]`:
+  resumable per-contig driver, default chr1-22, `VEP_REFERENCE_JOBS=2`.
+- `source_identity.sh`: add the GFF path.
+- Tests: `tests/data/plugin_gff/` synthetic GFF3 covering two golden chr1
+  variants (one inside a gene span with a matching gene, one transcript
+  whose variant lies outside its gene span) and a value with `,`, `|` and a
+  leading space; assertions in `tests/test_annotate.py` on the exact CSQ
+  tail and the LazyFrame columns; profile tests in
+  `tests/test_comparison_profiles.py`.
+- Docs: `docs/plugins.md` (GFF source table, `[source.gff]`, `lookup`
+  kinds, supported-plugins row and field order), `docs/downloads.md` (new
+  dataset repo), `docs/testing-vep.md` (new profile and scripts),
+  `docs/architecture.md`, `README.md` plugin line, `e2e-testing/README.md`.
+
+## 7. Oracle procedure
+
+Recipe identical to the five-plugin references except for the plugin flag
+and BGZF output. `DATA=~/workspace/data_vepyr`.
+
+```bash
+# chr22 (iteration), then chr1
+e2e-testing/scripts/build_vep_phenotypeorthologous_reference.sh 22
+e2e-testing/scripts/build_vep_phenotypeorthologous_reference.sh 1
+
+# whole normalized HG002 sample (chr1-22), resumable, hours
+VEP_REFERENCE_JOBS=2 nohup e2e-testing/scripts/generate_vep_phenotypeorthologous_references.sh \
+  > $DATA/output/116/plugins/logs/phenotypeorthologous_all.log 2>&1 &
+```
+
+The VEP invocation inside the builder:
+
+```bash
+docker run --rm --user "$(id -u):$(id -g)" \
+  -v "$DATA":/data -v "$DATA/output/116/plugins/plugin_code":/plugins:ro \
+  ensemblorg/ensembl-vep:release_116.0 \
+  vep --cache --cache_version 116 --dir_cache /data --offline --merged \
+      --everything --no_stats --force_overwrite --vcf --compress_output bgzip \
+      --fasta /data/input/Homo_sapiens.GRCh38.dna.primary_assembly.fa \
+      --input_file  /data/input/slices/HG002_norm_chr${CHROM}.vcf.gz \
+      --output_file /data/output/116/plugins/HG002_chr${CHROM}_phenotypeorthologous_vep116.vcf.gz \
+      --dir_plugins /plugins \
+      --plugin PhenotypeOrthologous,file=/data/plugin_input/phenotypeorthologous/PhenotypesOrthologous_homo_sapiens_112_GRCh38.gff3.gz
+```
+
+Comparison:
+
+```bash
+uv run python e2e-testing/scripts/run_comparison.py --release 116 \
+  --profile merged_phenotypeorthologous --chroms 22 \
+  --plugin-cache $DATA/plugin_cache_v0.2.0 --workers 4 --bgzf --force
+uv run python e2e-testing/scripts/md5_concordance.py \
+  --pair <vep slice> <vepyr bgzf> --mode strict --explain --explain-limit 0
+```
+
+## 8. Publishing
+
+- Build all 25 contigs (chr1-22, X, Y, MT) with
+  `build_plugin_cache("phenotypeorthologous", "v0.2.0", …,
+  verify_source="strict")` into `$DATA/plugin_cache_v0.2.0`. chrY has no
+  rows and is listed with 0 rows and no shard, like SpliceAI's chrMT.
+- `hf upload biodatageeks/vepyr_116_GRCh38_plugin_phenotypeorthologous
+  <dir> . --type dataset`, then tag `v0.2.0`; card lists source url, md5,
+  verified md5, contig row counts and the Ensembl data licence. Verify by
+  `hf datasets info --expand siblings` and a fresh download of `manifest.json`.
+
+## 9. Gates
+
+1. Before any engine change: `merged_plugins` chr22 strict md5 concordance
+   recorded as the regression baseline.
+2. After PR 1 + PR 2: baseline unchanged.
+3. PhenotypeOrthologous chr22 and chr1: 100% `both_nonempty_equal` on the
+   four fields, strict md5 concordance PASS, `--workers 1` vs `--workers 4`
+   body byte-identical, CSQ header byte-identical.
+4. Whole sample: per-contig strict concordance on chr1-22 before the cache
+   is tagged on the Hub.
+
+## 10. PR series
+
+| # | repo | content | depends on |
+|---|---|---|---|
+| 1 | datafusion-bio-functions | `gff` provider arm + tests | — |
+| 2 | datafusion-bio-functions | `lookup = "interval"` build + runtime + tests | 1 |
+| 3 | vepyr-plugins | validator, manifest, README, skill doc | 2 (for the build to run) |
+| 4 | vepyr | pin bump, profile, scripts, fixtures, docs | 1, 2 merged; 3 tagged |
+| 5 | Hub | cache upload + card | 3 tagged, 4 green |
+
+Per the vepyr-fix discipline: draft PRs, bot review loop to green, no merges
+by the agent; the human merges and re-pins.
+
+## 11. Risks
+
+- `$transcript->{_gene}->stable_id` versus the CSQ `Gene` column: assumed
+  equal for Ensembl transcripts. The chr22 oracle confirms it before engine
+  code is written (grep the reference for a populated line on a
+  well-known gene and compare with the `Gene` column).
+- Engine repo local checkout is on `fix/mnv-allele-trim-parity`, which has
+  diverged from the pin; the work branches from `origin/master`.
+- VEP's `--compress_output bgzip` must exist in the 116.0 image; fall back to
+  piping through `bgzip` if not.
+- GSD is not initialised in vepyr; the user approved bypassing it for this
+  work on 2026-09-11.

--- a/docs/superpowers/specs/2026-09-11-gff-plugin-source-and-phenotypeorthologous-design.md
+++ b/docs/superpowers/specs/2026-09-11-gff-plugin-source-and-phenotypeorthologous-design.md
@@ -251,7 +251,9 @@ Release: `minor` bump → `v0.2.0` after merge.
   sub-fields in the CSQ header, and writes a `.plugins` sidecar.
 - `e2e-testing/scripts/generate_vep_phenotypeorthologous_references.sh [chroms]`:
   resumable per-contig driver, default chr1-22, `VEP_REFERENCE_JOBS=2`.
-- `source_identity.sh`: add the GFF path.
+- The reference builder records its own provenance sidecar (plugin sha256 and
+  the source url + md5); the file is md5-pinned rather than rolling, so
+  `source_identity.sh` is not extended.
 - Tests: `tests/data/plugin_gff/` synthetic GFF3 covering two golden chr1
   variants (one inside a gene span with a matching gene, one transcript
   whose variant lies outside its gene span) and a value with `,`, `|` and a

--- a/docs/superpowers/specs/2026-09-11-gff-plugin-source-and-phenotypeorthologous-design.md
+++ b/docs/superpowers/specs/2026-09-11-gff-plugin-source-and-phenotypeorthologous-design.md
@@ -36,7 +36,6 @@ Out of scope:
 - GO, or any transcript-keyed lookup.
 - Teaching the cache-QA tool (branch `feat/cache-qa-profile`) the interval
   shard shape. The cache is published by hand, as the v0.1.1 caches were.
-- A COITree-backed interval index. See §4.3.
 
 ## 3. Reference behaviour (VEP_plugins release/116, `PhenotypeOrthologous.pm`)
 
@@ -144,12 +143,14 @@ Build (`build.rs`, `normalize.rs`, `join.rs`, `write.rs`):
 Runtime (`lookup.rs`, `registry.rs`, `annotate_provider.rs`):
 
 - New `IntervalLookup::open(shard)`: reads the whole per-chromosome shard
-  once (projection `start, end, <match…>, <value…>`) into
-  `HashMap<Vec<Option<String>>, Vec<IntervalRow>>` keyed by the discriminator
-  tuple, each vector in file order. Shards are small (PhenotypeOrthologous:
-  at most 1,754 rows on chr1).
+  once (projection `start, end, <match…>, <value…>`) into a `Vec<IntervalRow>`
+  in file order plus one `coitrees::COITree<usize, u32>` per discriminator
+  tuple (`HashMap<Vec<Option<String>>, COITree>`), the tree metadata being
+  the row's file ordinal. The crate already depends on `coitrees` and uses
+  the same `COITree<usize, u32>` shape for transcripts.
 - `probe(vf_start, vf_end, &match_values) -> Option<&[PluginScalar]>`
-  returns the first row with `start <= vf_end && end >= vf_start`.
+  queries the bucket's tree for the closed span and returns the overlapping
+  row with the smallest ordinal, which is VEP's first-in-file record.
 - `PluginRegistry::open` branches on `manifest.lookup` into
   `PluginLookupKind::{Point(PluginLookup), Interval(IntervalLookup)}`;
   `take_buffer_all` skips interval plugins; `probe_all` receives the
@@ -164,9 +165,8 @@ Runtime (`lookup.rs`, `registry.rs`, `annotate_provider.rs`):
 - Values go through `csq::format_scalar`, so escaping is the shared engine
   rule. Header descriptions come from `value_columns[].description`.
 
-Limitation, documented: a discriminator-less interval plugin scans its
-chromosome's rows linearly per probe. Acceptable for tracks of a few thousand
-intervals; a COITree index is the upgrade path if a large track arrives.
+A discriminator-less interval plugin has a single bucket and the same
+`O(log n + k)` query, so dense region tracks cost no more than gene tracks.
 
 ### 4.3 Tests (engine)
 
@@ -176,7 +176,8 @@ intervals; a COITree index is the upgrade path if a large track arrives.
 - Build: an interval manifest over the synthetic GFF yields the expected
   schema, order and `tier = 1`; dedup keeps the first of two identical keys.
 - Runtime: overlap at both boundaries, insertion span, discriminator miss,
-  first-in-file-order tie-break, escaping of `,`, `|`, whitespace and a
+  first-in-file-order tie-break with three overlapping rows (the tree's
+  visit order is not file order), escaping of `,`, `|`, whitespace and a
   leading space.
 - Regression: the existing point-lookup tests and the golden benchmark are
   untouched; enabling an interval plugin adds exactly its four columns.

--- a/docs/testing-vep.md
+++ b/docs/testing-vep.md
@@ -419,6 +419,14 @@ uv run python run_comparison.py --release 116 --profile merged_plugins --chroms 
     restricts itself to the shared fields, which separates a core-field
     difference from anything the plugin machinery introduced.
 
+    `merged_phenotypeorthologous` reads its own per-contig reference
+    (`HG002_chr{N}_phenotypeorthologous_vep116.vcf.gz`), produced by
+    `build_vep_phenotypeorthologous_reference.sh <chrom>` or, for chr1–22,
+    the resumable `generate_vep_phenotypeorthologous_references.sh`.
+    `run_phenotypeorthologous_comparison.sh [chroms…]` chains the shard
+    build, `run_comparison.py --profile merged_phenotypeorthologous` and the
+    strict md5 gate in one command.
+
     These are comparison scenarios, not release gates. `verify_parity_gate.py`
     pins the Ensembl core CSQ contract and refuses a plugin profile outright
     rather than silently gating a field set it does not describe.

--- a/e2e-testing/README.md
+++ b/e2e-testing/README.md
@@ -306,6 +306,8 @@ the runner works before and after those files are reorganised.
 | `merged_flag_pick_allele` | `--merged --flag_pick_allele` | `HG002_annotated_wgs_everything_hgvs_merged_flag_pick_allele.vcf.gz` |
 | `merged_flag_pick_allele_gene` | `--merged --flag_pick_allele_gene` | `HG002_annotated_wgs_everything_hgvs_merged_pick.vcf.gz` |
 | `refseq` | `--refseq` baseline | `HG002_annotated_wgs_everything_hgvs_refseq.vcf.gz` |
+| `merged_plugins` | `--merged` + SpliceAI, CADD, AlphaMissense, dbNSFP, ClinVar | `plugins/HG002_chr{N}_5plugins_vep116_caddfix.vcf.gz` (per contig) |
+| `merged_phenotypeorthologous` | `--merged --plugin PhenotypeOrthologous` | `plugins/HG002_chr{N}_phenotypeorthologous_vep116.vcf.gz` (per contig) |
 
 The baseline Ensembl, merged, and RefSeq profiles are qualified and available
 for both supported releases:

--- a/e2e-testing/scripts/build_vep_phenotypeorthologous_reference.sh
+++ b/e2e-testing/scripts/build_vep_phenotypeorthologous_reference.sh
@@ -40,20 +40,25 @@ sha256_file() {
 # ---------------------------------------------------------------------------
 # 1. Source data and plugin code, both pinned by digest
 # ---------------------------------------------------------------------------
+# Several builders may run at once (the generator's default is two jobs), so
+# every download goes to a per-process partial and is only moved into place if
+# nobody else got there first; the digest checks below validate whichever copy
+# won. `mv -n` never overwrites, so a concurrent winner is left untouched.
+fetch_once() {  # $1 = url, $2 = destination
+  local partial="$2.partial.$$"
+  [[ -s "$2" ]] && return 0
+  curl --fail --silent --show-error -o "$partial" "$1"
+  mv -n "$partial" "$2" 2>/dev/null || true
+  rm -f "$partial"
+}
 for f in "$SRC_NAME" "$SRC_NAME.tbi"; do
-  if [[ ! -s "$SRC_DIR/$f" ]]; then
-    curl --fail --silent --show-error -o "$SRC_DIR/$f.partial" "$SRC_URL${f#"$SRC_NAME"}"
-    mv "$SRC_DIR/$f.partial" "$SRC_DIR/$f"
-  fi
+  fetch_once "$SRC_URL${f#"$SRC_NAME"}" "$SRC_DIR/$f"
 done
 [[ "$(md5_file "$SRC_DIR/$SRC_NAME")" == "$SRC_MD5" ]] || { echo "ERROR: $SRC_NAME md5 mismatch" >&2; exit 1; }
 [[ "$(md5_file "$SRC_DIR/$SRC_NAME.tbi")" == "$TBI_MD5" ]] || { echo "ERROR: $SRC_NAME.tbi md5 mismatch" >&2; exit 1; }
 
-if [[ ! -s "$PLUGIN_DIR/PhenotypeOrthologous.pm" ]]; then
-  curl --fail --silent --show-error \
-    -o "$PLUGIN_DIR/PhenotypeOrthologous.pm" \
-    "https://raw.githubusercontent.com/Ensembl/VEP_plugins/$PLUGIN_COMMIT/PhenotypeOrthologous.pm"
-fi
+fetch_once "https://raw.githubusercontent.com/Ensembl/VEP_plugins/$PLUGIN_COMMIT/PhenotypeOrthologous.pm" \
+  "$PLUGIN_DIR/PhenotypeOrthologous.pm"
 actual="$(sha256_file "$PLUGIN_DIR/PhenotypeOrthologous.pm")"
 [[ "$actual" == "$PLUGIN_SHA256" ]] || { echo "ERROR: PhenotypeOrthologous.pm sha256 $actual != $PLUGIN_SHA256" >&2; exit 1; }
 

--- a/e2e-testing/scripts/build_vep_phenotypeorthologous_reference.sh
+++ b/e2e-testing/scripts/build_vep_phenotypeorthologous_reference.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Build the Ensembl VEP 116 PhenotypeOrthologous reference for one chromosome:
+# the golden output `run_comparison.py --profile merged_phenotypeorthologous`
+# compares against. Same recipe as build_vep_plugin_reference.sh (merged cache,
+# --everything, normalized input), with exactly one plugin loaded and BGZF
+# written by VEP itself.
+#
+# Usage: ./build_vep_phenotypeorthologous_reference.sh 22 [workdir]
+#   DATA_VEPYR_DIR      data root (default ~/workspace/data_vepyr)
+#   VEP_NORMALIZED_VCF  normalized input (default $DATA/input/HG002_norm.vcf.gz)
+#   VEP_OUTPUT_VCF      output .vcf.gz (default $DATA/output/116/plugins/HG002_chr<N>_phenotypeorthologous_vep116.vcf.gz)
+#   VEP_PLUGIN_DIR      directory holding PhenotypeOrthologous.pm (default $DATA/output/116/plugins/plugin_code)
+set -euo pipefail
+
+CHROM="${1:?usage: $0 <chrom> [workdir]}"
+DATA="${DATA_VEPYR_DIR:-$HOME/workspace/data_vepyr}"
+WORK="${2:-$DATA/vep116_po_chr${CHROM}}"
+IMAGE="ensemblorg/ensembl-vep:release_116.0"
+REF_DIR="$DATA/output/116/plugins"
+PLUGIN_DIR="${VEP_PLUGIN_DIR:-$REF_DIR/plugin_code}"
+SRC_DIR="$DATA/plugin_input/phenotypeorthologous"
+SRC_NAME="PhenotypesOrthologous_homo_sapiens_112_GRCh38.gff3.gz"
+SRC_URL="https://ftp.ensembl.org/pub/release-116/variation/PhenotypeOrthologous/$SRC_NAME"
+SRC_MD5="20e5401a198d7d3db66a982c037d3ad4"
+TBI_MD5="1eb833a26c247418910685289c6528cc"
+PLUGIN_COMMIT="a7e03a5c6497e29e0598eed7b4795f953d9a1b5f"
+PLUGIN_SHA256="89be8f30dd464f81913bef367831e8a08258e4085207f8291c956487f47de8ac"
+OUT="${VEP_OUTPUT_VCF:-$REF_DIR/HG002_chr${CHROM}_phenotypeorthologous_vep116.vcf.gz}"
+
+mkdir -p "$WORK/input" "$REF_DIR" "$PLUGIN_DIR" "$SRC_DIR"
+
+md5_file() {
+  if command -v md5sum >/dev/null 2>&1; then md5sum "$1" | awk '{print $1}'; else md5 -q "$1"; fi
+}
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | awk '{print $1}'; else shasum -a 256 "$1" | awk '{print $1}'; fi
+}
+
+# ---------------------------------------------------------------------------
+# 1. Source data and plugin code, both pinned by digest
+# ---------------------------------------------------------------------------
+for f in "$SRC_NAME" "$SRC_NAME.tbi"; do
+  if [[ ! -s "$SRC_DIR/$f" ]]; then
+    curl --fail --silent --show-error -o "$SRC_DIR/$f.partial" "$SRC_URL${f#"$SRC_NAME"}"
+    mv "$SRC_DIR/$f.partial" "$SRC_DIR/$f"
+  fi
+done
+[[ "$(md5_file "$SRC_DIR/$SRC_NAME")" == "$SRC_MD5" ]] || { echo "ERROR: $SRC_NAME md5 mismatch" >&2; exit 1; }
+[[ "$(md5_file "$SRC_DIR/$SRC_NAME.tbi")" == "$TBI_MD5" ]] || { echo "ERROR: $SRC_NAME.tbi md5 mismatch" >&2; exit 1; }
+
+if [[ ! -s "$PLUGIN_DIR/PhenotypeOrthologous.pm" ]]; then
+  curl --fail --silent --show-error \
+    -o "$PLUGIN_DIR/PhenotypeOrthologous.pm" \
+    "https://raw.githubusercontent.com/Ensembl/VEP_plugins/$PLUGIN_COMMIT/PhenotypeOrthologous.pm"
+fi
+actual="$(sha256_file "$PLUGIN_DIR/PhenotypeOrthologous.pm")"
+[[ "$actual" == "$PLUGIN_SHA256" ]] || { echo "ERROR: PhenotypeOrthologous.pm sha256 $actual != $PLUGIN_SHA256" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# 2. Normalized input slice
+# ---------------------------------------------------------------------------
+NORM="${VEP_NORMALIZED_VCF:-$DATA/input/HG002_norm.vcf.gz}"
+[[ -s "$NORM" && -s "$NORM.tbi" ]] || { echo "ERROR: normalized input $NORM (+.tbi) missing; see build_vep_plugin_reference.sh" >&2; exit 1; }
+IN="$WORK/input/HG002_norm_chr${CHROM}.vcf.gz"
+{ tabix -H "$NORM"; tabix "$NORM" "chr${CHROM}"; } | bgzip -c > "$IN"
+tabix -f -p vcf "$IN"
+
+# ---------------------------------------------------------------------------
+# 3. Annotate (BGZF written by VEP, --compress_output bgzip)
+# ---------------------------------------------------------------------------
+# --assembly is load-bearing: PhenotypeOrthologous.pm reads config->{assembly}
+# in new() and dies with "Assembly is not GRCh38" when it is unset, which VEP
+# only reports as a warning ("Failed to instantiate plugin") and then runs on
+# without the plugin. The 4-field header check below is the backstop.
+to_container() {  # host path under $DATA -> /data/...
+  local p d
+  p="$(cd "$(dirname "$1")" && pwd -P)/$(basename "$1")"
+  d="$(cd "$DATA" && pwd -P)"
+  [[ "$p" == "$d/"* ]] || { echo "ERROR: $1 must live under $DATA" >&2; exit 1; }
+  printf '/data/%s\n' "${p#"$d/"}"
+}
+IN_C="$(to_container "$IN")"
+OUT_C="$(to_container "$OUT")"
+SRC_C="$(to_container "$SRC_DIR/$SRC_NAME")"
+
+docker run --rm --user "$(id -u):$(id -g)" \
+  -v "$DATA":/data -v "$PLUGIN_DIR":/plugins:ro "$IMAGE" \
+  vep --cache --cache_version 116 --dir_cache /data --offline --merged \
+      --assembly GRCh38 \
+      --everything --no_stats --force_overwrite --vcf --compress_output bgzip \
+      --fasta /data/input/Homo_sapiens.GRCh38.dna.primary_assembly.fa \
+      --input_file "$IN_C" --output_file "$OUT_C" \
+      --dir_plugins /plugins \
+      --plugin "PhenotypeOrthologous,file=$SRC_C"
+
+# ---------------------------------------------------------------------------
+# 4. Index and check the four plugin fields landed
+# ---------------------------------------------------------------------------
+tabix -f -p vcf "$OUT"
+n_plugin=$(tabix -H "$OUT" | grep -m1 '^##INFO=<ID=CSQ' | tr '|' '\n' | grep -c '^PhenotypeOrthologous_' || true)
+if [[ "$n_plugin" -ne 4 ]]; then
+  echo "ERROR: expected 4 PhenotypeOrthologous CSQ fields, found $n_plugin" >&2
+  grep -i 'failed to instantiate' "${OUT%.vcf.gz}.vcf_warnings.txt" >&2 || true
+  exit 1
+fi
+{
+  printf 'PLUGIN PhenotypeOrthologous %s\n' "$PLUGIN_SHA256"
+  printf 'SOURCE %s md5=%s\n' "$SRC_URL" "$SRC_MD5"
+} > "$OUT.plugins"
+echo "OK: chr${CHROM} - $(bgzip -dc "$OUT" | grep -vc '^#') records, $n_plugin plugin CSQ fields"
+echo "     $OUT"

--- a/e2e-testing/scripts/comparison/cli.py
+++ b/e2e-testing/scripts/comparison/cli.py
@@ -18,6 +18,8 @@ Examples:
     run_comparison.py --release 115 --chroms 22            # one contig
     run_comparison.py --release 116 --profile merged --chroms 1 2 22
     run_comparison.py --release 115 --bgzf --workers 4 --force
+    run_comparison.py --release 116 --profile merged_phenotypeorthologous --chroms 22 \\
+        --plugin-cache ~/workspace/data_vepyr/plugin_cache_v0.2.0   # one plugin, its own reference
 """
 
 
@@ -137,7 +139,8 @@ def parse_args(argv=None):
         "--plugin-cache",
         default=None,
         help="Plugin cache root, used only by plugin profiles "
-        "(default: $DATA/cache/plugin_cache_<release>)",
+        "(merged_plugins, merged_phenotypeorthologous); "
+        "default: $DATA/cache/plugin_cache_<release>",
     )
 
     args = p.parse_args(argv)

--- a/e2e-testing/scripts/comparison/profiles.py
+++ b/e2e-testing/scripts/comparison/profiles.py
@@ -68,6 +68,11 @@ _PLUGIN_REFERENCE = (
 )
 # What generate_vep_plugin_references.sh actually writes, per contig.
 _PLUGIN_PER_CONTIG = "HG002_chr{chrom}_5plugins_vep116_caddfix"
+# PhenotypeOrthologous is compared on its own reference (only that plugin
+# loaded), one file per contig like the five-plugin set; written by
+# generate_vep_phenotypeorthologous_references.sh.
+_PO_REFERENCE = "HG002_annotated_wgs_everything_hgvs_merged_phenotypeorthologous"
+_PO_PER_CONTIG = "HG002_chr{chrom}_phenotypeorthologous_vep116"
 
 
 def plugin_reference_basename():
@@ -148,6 +153,14 @@ PROFILES = {
         vep_basename=_PLUGIN_REFERENCE,
         suffix="merged_plugins_base",
         vep_per_contig=_PLUGIN_PER_CONTIG,
+        vep_subdir="plugins",
+    ),
+    "merged_phenotypeorthologous": Profile(
+        flavour="merged",
+        vep_basename=_PO_REFERENCE,
+        suffix="merged_phenotypeorthologous",
+        plugins=("phenotypeorthologous",),
+        vep_per_contig=_PO_PER_CONTIG,
         vep_subdir="plugins",
     ),
     "merged_pick_allele_gene": Profile(

--- a/e2e-testing/scripts/generate_vep_phenotypeorthologous_references.sh
+++ b/e2e-testing/scripts/generate_vep_phenotypeorthologous_references.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Resumable per-contig VEP 116 PhenotypeOrthologous references (default chr1-22).
+#   VEP_REFERENCE_JOBS  concurrent chromosomes (default 2)
+set -euo pipefail
+
+DATA="${DATA_VEPYR_DIR:-$HOME/workspace/data_vepyr}"
+TARGET="$DATA/output/116/plugins"
+JOBS="${VEP_REFERENCE_JOBS:-2}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILDER="$SCRIPT_DIR/build_vep_phenotypeorthologous_reference.sh"
+WORK_ROOT="$TARGET/.work_po"
+LOG_DIR="$TARGET/logs"
+mkdir -p "$TARGET" "$WORK_ROOT" "$LOG_DIR"
+
+expected_provenance() {
+  sed -n 's/^PLUGIN_SHA256="\([0-9a-f]\{64\}\)"$/PLUGIN PhenotypeOrthologous \1/p' "$BUILDER"
+  local url md5 name
+  name="$(sed -n 's/^SRC_NAME="\(.*\)"$/\1/p' "$BUILDER")"
+  url="$(sed -n 's/^SRC_URL="\(.*\)"$/\1/p' "$BUILDER")"
+  md5="$(sed -n 's/^SRC_MD5="\([0-9a-f]\{32\}\)"$/\1/p' "$BUILDER")"
+  url="${url//\$SRC_NAME/$name}"
+  printf 'SOURCE %s md5=%s\n' "$url" "$md5"
+}
+
+is_complete() {
+  local out="$TARGET/HG002_chr${1}_phenotypeorthologous_vep116.vcf.gz"
+  [[ -s "$out" && -s "$out.tbi" && -s "$out.plugins" ]] || return 1
+  local n
+  n=$(tabix -H "$out" | grep -m1 '^##INFO=<ID=CSQ' | tr '|' '\n' | grep -c '^PhenotypeOrthologous_' || true)
+  [[ "$n" -eq 4 ]] || return 1
+  diff -q <(sort "$out.plugins") <(expected_provenance | sort) >/dev/null
+}
+
+run_one() {
+  local chrom="$1" log="$LOG_DIR/po_chr${1}.log"
+  if is_complete "$chrom"; then echo "SKIP chr${chrom}"; return; fi
+  local work
+  work=$(mktemp -d "$WORK_ROOT/chr${chrom}.XXXXXX")
+  echo "START chr${chrom}: log=$log"
+  if "$BUILDER" "$chrom" "$work" > "$log" 2>&1 && is_complete "$chrom"; then
+    rm -rf "$work"; echo "DONE chr${chrom}"
+  else
+    echo "ERROR chr${chrom}: see $log (work kept at $work)" >&2; return 1
+  fi
+}
+
+if [[ "$#" -gt 0 ]]; then chroms=("$@"); else chroms=({1..22}); fi
+fail=0; pids=(); labels=()
+for chrom in "${chroms[@]}"; do
+  run_one "$chrom" & pids+=("$!"); labels+=("$chrom")
+  if [[ "${#pids[@]}" -eq "$JOBS" ]]; then
+    for i in "${!pids[@]}"; do wait "${pids[$i]}" || { echo "FAILED chr${labels[$i]}" >&2; fail=1; }; done
+    pids=(); labels=()
+  fi
+done
+for i in "${!pids[@]}"; do wait "${pids[$i]}" || { echo "FAILED chr${labels[$i]}" >&2; fail=1; }; done
+[[ "$fail" -eq 0 ]] && echo "All requested PhenotypeOrthologous references are complete under $TARGET"
+exit "$fail"

--- a/e2e-testing/scripts/run_phenotypeorthologous_comparison.sh
+++ b/e2e-testing/scripts/run_phenotypeorthologous_comparison.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Build the PhenotypeOrthologous shard(s), compare vepyr with the VEP 116
+# reference through run_comparison.py --profile merged_phenotypeorthologous,
+# and gate each chromosome on strict body/header md5 concordance.
+#
+# Usage: ./run_phenotypeorthologous_comparison.sh [chroms...]   (default 1..22)
+#   DATA_VEPYR_DIR          data root (default ~/workspace/data_vepyr)
+#   VEPYR_PLUGIN_REPO       local vepyr-plugins clone (default ~/research/git/vepyr-plugins)
+#   VEPYR_PLUGIN_REF        git ref of the manifest to build from (default v0.2.0)
+#   VEPYR_PLUGIN_CACHE      plugin cache root (default $DATA/plugin_cache_po_<ref>)
+#   VEP_COMPARISON_WORKERS  vepyr workers (default 4)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DATA="${DATA_VEPYR_DIR:-$HOME/workspace/data_vepyr}"
+export DATA_VEPYR_DIR="$DATA"
+PLUGIN_REPO="${VEPYR_PLUGIN_REPO:-$HOME/research/git/vepyr-plugins}"
+PLUGIN_REF="${VEPYR_PLUGIN_REF:-v0.2.0}"
+PLUGIN_CACHE="${VEPYR_PLUGIN_CACHE:-$DATA/plugin_cache_po_${PLUGIN_REF//\//_}}"
+CACHE_DIR="$DATA/cache/116_GRCh38_merged"
+SRC="$DATA/plugin_input/phenotypeorthologous/PhenotypesOrthologous_homo_sapiens_112_GRCh38.gff3.gz"
+REF_DIR="$DATA/output/116/plugins"
+LOG_DIR="$REF_DIR/po_comparison_logs"
+WORKERS="${VEP_COMPARISON_WORKERS:-4}"
+BUILDER="$SCRIPT_DIR/build_vep_phenotypeorthologous_reference.sh"
+mkdir -p "$LOG_DIR"
+
+if [[ "$#" -gt 0 ]]; then chroms=("$@"); else chroms=({1..22}); fi
+
+# One build call for every requested chromosome: the builder verifies the
+# source once and stages all shards before committing any of them.
+build_shards() {
+  local list; list="$(printf '"%s",' "${chroms[@]}")"
+  (cd "$REPO_DIR" && uv run python - <<PYBUILD
+import vepyr
+print(vepyr.build_plugin_cache(
+    "phenotypeorthologous", "$PLUGIN_REF",
+    source_path="$SRC", cache_dir="$CACHE_DIR", plugin_cache_root="$PLUGIN_CACHE",
+    chroms=[${list%,}], plugins_repo="$PLUGIN_REPO", overwrite=True, verify_source="strict"))
+PYBUILD
+  )
+}
+
+fail=0
+[[ -s "$SRC" ]] || "$BUILDER" 22 >/dev/null   # the builder downloads and md5-checks the source
+build_shards | tee "$LOG_DIR/build.log"
+for chrom in "${chroms[@]}"; do
+  ref="$REF_DIR/HG002_chr${chrom}_phenotypeorthologous_vep116.vcf.gz"
+  [[ -s "$ref" && -s "$ref.tbi" ]] || "$BUILDER" "$chrom" > "$LOG_DIR/reference_chr${chrom}.log" 2>&1
+  if ! (cd "$REPO_DIR" && uv run python e2e-testing/scripts/run_comparison.py \
+      --release 116 --profile merged_phenotypeorthologous --chroms "$chrom" \
+      --plugin-cache "$PLUGIN_CACHE" --workers "$WORKERS" --bgzf --force) \
+      > "$LOG_DIR/compare_chr${chrom}.log" 2>&1; then
+    echo "FAIL chr${chrom}: comparison error, see $LOG_DIR/compare_chr${chrom}.log" >&2; fail=1; continue
+  fi
+  results="$REPO_DIR/e2e-testing/results/116/fast_chr${chrom}"
+  if (cd "$REPO_DIR" && uv run python e2e-testing/scripts/md5_concordance.py \
+        --pair "$results/vep_chr${chrom}_merged_phenotypeorthologous.vcf" \
+               "$results/vepyr_parquet_chr${chrom}_merged_phenotypeorthologous.vcf.gz" \
+        --mode strict --explain --explain-limit 0) > "$LOG_DIR/strict_chr${chrom}.log" 2>&1; then
+    echo 0 > "$LOG_DIR/strict_chr${chrom}.exit"; echo "PASS chr${chrom}: strict md5 concordant"
+  else
+    echo 1 > "$LOG_DIR/strict_chr${chrom}.exit"; echo "FAIL chr${chrom}: see $LOG_DIR/strict_chr${chrom}.log" >&2; fail=1
+  fi
+done
+exit "$fail"

--- a/e2e-testing/scripts/run_phenotypeorthologous_comparison.sh
+++ b/e2e-testing/scripts/run_phenotypeorthologous_comparison.sh
@@ -24,6 +24,7 @@ REF_DIR="$DATA/output/116/plugins"
 LOG_DIR="$REF_DIR/po_comparison_logs"
 WORKERS="${VEP_COMPARISON_WORKERS:-4}"
 BUILDER="$SCRIPT_DIR/build_vep_phenotypeorthologous_reference.sh"
+GENERATOR="$SCRIPT_DIR/generate_vep_phenotypeorthologous_references.sh"
 mkdir -p "$LOG_DIR"
 
 if [[ "$#" -gt 0 ]]; then chroms=("$@"); else chroms=({1..22}); fi
@@ -46,8 +47,13 @@ fail=0
 [[ -s "$SRC" ]] || "$BUILDER" 22 >/dev/null   # the builder downloads and md5-checks the source
 build_shards | tee "$LOG_DIR/build.log"
 for chrom in "${chroms[@]}"; do
-  ref="$REF_DIR/HG002_chr${chrom}_phenotypeorthologous_vep116.vcf.gz"
-  [[ -s "$ref" && -s "$ref.tbi" ]] || "$BUILDER" "$chrom" > "$LOG_DIR/reference_chr${chrom}.log" 2>&1
+  # The generator validates an existing reference against the builder's pinned
+  # plugin sha256 and source md5 (its `.plugins` sidecar) and the four-field
+  # header, rebuilding a stale one, so a reference from an older plugin file or
+  # source can never be compared against the freshly built cache.
+  if ! VEP_REFERENCE_JOBS=1 "$GENERATOR" "$chrom" > "$LOG_DIR/reference_chr${chrom}.log" 2>&1; then
+    echo "FAIL chr${chrom}: reference build/validation failed, see $LOG_DIR/reference_chr${chrom}.log" >&2; fail=1; continue
+  fi
   if ! (cd "$REPO_DIR" && uv run python e2e-testing/scripts/run_comparison.py \
       --release 116 --profile merged_phenotypeorthologous --chroms "$chrom" \
       --plugin-cache "$PLUGIN_CACHE" --workers "$WORKERS" --bgzf --force) \

--- a/tests/data/plugin_gff/demo.gff3
+++ b/tests/data/plugin_gff/demo.gff3
@@ -1,0 +1,3 @@
+##gff-version 3
+1	test	gene	600000	605000	.	-	.	ID=gene:ENSG00000225880;gene_id=ENSG00000225880;Rat_gene_id=ENSRNOG00000000001;Rat_Orthologous_phenotype= leading space|two, comma;Mouse_gene_id=ENSMUSG00000000001;Mouse_Orthologous_phenotype=abnormal coat/hair pigmentation|hyperactivity
+1	test	gene	604360	604360	.	+	.	ID=gene:ENSG00000293331;gene_id=ENSG00000293331;Rat_gene_id=ENSRNOG00000000002;Rat_Orthologous_phenotype=rat only

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -197,6 +197,122 @@ def text_plugin_cache(metadata_cache_dir, tmp_path_factory):
     return str(plugin_root)
 
 
+@pytest.fixture(scope="module")
+def interval_plugin_cache(metadata_cache_dir, tmp_path_factory):
+    """An interval (gene-span) plugin built from tests/data/plugin_gff/demo.gff3.
+
+    Row 1 spans 600000-605000 for ENSG00000225880 (covers the golden variants
+    at 604358 and 604360 but not 611317); row 2 is the one-base span 604360 for
+    ENSG00000293331 with no mouse attributes.
+    """
+    from tests.test_build_plugin_cache import _GFF_MANIFEST, _init_full_repo
+
+    import vepyr
+
+    root = tmp_path_factory.mktemp("interval_plugin")
+    repo = _init_full_repo(root, manifest=_GFF_MANIFEST)
+    plugin_root = root / "pc"
+    built = vepyr.build_plugin_cache(
+        "demo",
+        "v0.1.0",
+        source_path=str(TESTS_DIR / "data" / "plugin_gff" / "demo.gff3"),
+        cache_dir=metadata_cache_dir,
+        plugin_cache_root=str(plugin_root),
+        plugins_repo=str(repo),
+        chroms=["1"],
+    )
+    # Interval shards carry no tier information: every row is cold.
+    assert built == [("chr1", 2, 0, 2)]
+    return str(plugin_root)
+
+
+def _plugin_tails(vcf_path, n_fields):
+    """{(pos, gene): plugin tail} for every CSQ entry, tail = last n_fields tokens."""
+    out = {}
+    for line in Path(vcf_path).read_text().splitlines():
+        if line.startswith("#"):
+            continue
+        cols = line.split("\t")
+        pos = int(cols[1])
+        csq = next(
+            (f[len("CSQ=") :] for f in cols[7].split(";") if f.startswith("CSQ=")),
+            None,
+        )
+        if csq is None:
+            continue
+        for entry in csq.split(","):
+            tokens = entry.split("|")
+            gene = tokens[1]  # fields="core": Allele|Gene|Feature|Feature_type|...
+            out[(pos, gene)] = "|".join(tokens[-n_fields:])
+    return out
+
+
+class TestIntervalPlugin:
+    """lookup = "interval": span overlap + {Gene}, first row in file order, VEP escaping."""
+
+    def test_gene_span_gates_and_values_escape_like_vep(
+        self, interval_plugin_cache, metadata_cache_dir, tmp_path
+    ):
+        import vepyr
+
+        output = tmp_path / "interval.vcf"
+        vepyr.annotate(
+            INPUT_VCF,
+            metadata_cache_dir,
+            fields="core",
+            plugin_cache_root=interval_plugin_cache,
+            plugins=["demo"],
+            output_vcf=str(output),
+            show_progress=False,
+        )
+        header = next(
+            line
+            for line in output.read_text().splitlines()
+            if line.startswith("##INFO=<ID=CSQ")
+        )
+        assert header.rstrip('">').endswith(
+            "Demo_Mouse_geneid|Demo_Mouse_phenotype|Demo_Rat_geneid|Demo_Rat_phenotype"
+        ), "alphabetical field order"
+        tails = _plugin_tails(output, 4)
+        # Inside the LINC00115 span: all four fields; VEP escaping of the
+        # leading space, the comma, the pipe and the whitespace runs.
+        assert tails[(604358, "ENSG00000225880")] == (
+            "ENSMUSG00000000001|abnormal_coat/hair_pigmentation&hyperactivity"
+            "|ENSRNOG00000000001|_leading_space&two&_comma"
+        )
+        # Same variant, the other gene: its one-base span starts at 604360 -> miss.
+        assert tails[(604358, "ENSG00000293331")] == "|||"
+        # Boundary: span [604360, 604360] overlaps the variant at 604360; no
+        # mouse attributes -> empty.
+        assert tails[(604360, "ENSG00000293331")] == "||ENSRNOG00000000002|rat_only"
+        # Gene id matches but the variant lies outside the span (VEP's flank
+        # rule) -> miss.
+        assert tails[(611317, "ENSG00000225880")] == "|||"
+
+    def test_lazyframe_columns_are_per_transcript_lists(
+        self, interval_plugin_cache, metadata_cache_dir
+    ):
+        import polars as pl
+
+        import vepyr
+
+        lf = vepyr.annotate(
+            INPUT_VCF,
+            metadata_cache_dir,
+            plugin_cache_root=interval_plugin_cache,
+            plugins=["demo"],
+            show_progress=False,
+        )
+        df = lf.select(
+            "start", "Gene", "Demo_Rat_geneid", "Demo_Rat_phenotype"
+        ).collect()
+        assert df.schema["Demo_Rat_geneid"] == pl.List(pl.String)
+        row = df.filter(pl.col("start") == 604358).row(0, named=True)
+        genes, rat = row["Gene"], row["Demo_Rat_geneid"]
+        assert rat[genes.index("ENSG00000225880")] == "ENSRNOG00000000001"
+        assert rat[genes.index("ENSG00000293331")] is None
+
+
 class TestCsqValueEscaping:
     """vepyr#93 -- a whitespace RUN in a CSQ value collapses to ONE underscore.
 

--- a/tests/test_build_plugin_cache.py
+++ b/tests/test_build_plugin_cache.py
@@ -40,6 +40,48 @@ _UTF8_MANIFEST = _FULL_MANIFEST.replace(
     "CAST(score AS FLOAT) AS demo_score", "score AS demo_score"
 ).replace('type = "Float32"', 'type = "Utf8"')
 
+# A gene-span GFF source with an interval lookup keyed by {Gene}. Mirrors
+# plugins/phenotypeorthologous in vepyr-plugins, at fixture scale.
+_GFF_MANIFEST = '''\
+plugin_name = "demo"
+coordinate_system = "1-based"
+lookup = "interval"
+field_order = "alphabetical"
+ingest_sql = """
+SELECT chrom, start, "end", gene_id,
+       "Mouse_gene_id" AS mouse_gene_id, "Mouse_Orthologous_phenotype" AS mouse_phenotype,
+       "Rat_gene_id" AS rat_gene_id, "Rat_Orthologous_phenotype" AS rat_phenotype
+FROM plugin_demo_src
+"""
+
+[[source]]
+provider = "gff"
+path = "placeholder.gff3"
+  [source.gff]
+  attributes = ["gene_id", "Mouse_gene_id", "Mouse_Orthologous_phenotype", "Rat_gene_id", "Rat_Orthologous_phenotype"]
+
+[[match_column]]
+column = "gene_id"
+template = "{Gene}"
+
+[[value_columns]]
+column = "mouse_gene_id"
+csq_field = "Demo_Mouse_geneid"
+type = "Utf8"
+[[value_columns]]
+column = "mouse_phenotype"
+csq_field = "Demo_Mouse_phenotype"
+type = "Utf8"
+[[value_columns]]
+column = "rat_gene_id"
+csq_field = "Demo_Rat_geneid"
+type = "Utf8"
+[[value_columns]]
+column = "rat_phenotype"
+csq_field = "Demo_Rat_phenotype"
+type = "Utf8"
+'''
+
 # A manifest whose sole [[source]] carries a part -- the shape a {part: path}
 # mapping addresses.
 _PARTED_MANIFEST = _FULL_MANIFEST.replace(

--- a/tests/test_comparison_cli.py
+++ b/tests/test_comparison_cli.py
@@ -353,6 +353,27 @@ def test_main_forwards_the_sole_contig_to_profile_resolution(monkeypatch):
     assert seen["chrom"] == "chr22"
 
 
+@pytest.mark.parametrize("profile", ["merged_plugins", "merged_phenotypeorthologous"])
+def test_plugin_profiles_pass_the_single_requested_contig(monkeypatch, profile):
+    seen = {}
+
+    def fake_resolve(*args, **kwargs):
+        seen.update(kwargs)
+        raise profiles.ProfileUnavailable("stop here")
+
+    monkeypatch.setattr(profiles, "resolve", fake_resolve)
+    rc = cli.main(["--release", "116", "--profile", profile, "--chroms", "22"])
+    assert rc == 2
+    assert seen["chrom"] == "chr22"
+
+
+def test_phenotypeorthologous_profile_is_a_cli_choice(capsys):
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(["--release", "116", "--profile", "no_such_profile"])
+    assert excinfo.value.code == 2
+    assert "merged_phenotypeorthologous" in capsys.readouterr().err
+
+
 def test_main_passes_no_contig_when_several_are_requested(monkeypatch):
     seen = {}
 

--- a/tests/test_comparison_profiles.py
+++ b/tests/test_comparison_profiles.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 from comparison import profiles
 
@@ -218,8 +220,9 @@ def test_phenotypeorthologous_profile_attaches_only_that_plugin(tmp_path, monkey
 
     resolved = profiles.resolve("merged_phenotypeorthologous", "116", chrom=22)
     assert resolved.annotate_kwargs["plugins"] == ["phenotypeorthologous"]
-    assert resolved.vep_vcf.endswith("HG002_chr22_phenotypeorthologous_vep116.vcf.gz")
-    assert "/plugins/" in resolved.vep_vcf
+    ref = Path(resolved.vep_vcf)
+    assert ref.name == "HG002_chr22_phenotypeorthologous_vep116.vcf.gz"
+    assert ref.parent.name == "plugins"
 
 
 def test_plugin_profile_fails_when_the_plugin_cache_is_missing(tmp_path, monkeypatch):

--- a/tests/test_comparison_profiles.py
+++ b/tests/test_comparison_profiles.py
@@ -185,11 +185,11 @@ def test_default_input_returns_the_preferred_path_when_neither_exists(
     assert profiles.default_input("ref.fa") == str(tmp_path / "input" / "ref.fa")
 
 
-def _write_plugin_reference(tmp_path, chrom=22):
-    """Create the per-contig plugin reference generate_vep_plugin_references.sh writes."""
+def _write_plugin_reference(tmp_path, chrom=22, profile="merged_plugins"):
+    """Create the per-contig plugin reference the reference generators write."""
     ref_dir = tmp_path / "output" / "116" / "plugins"
     ref_dir.mkdir(parents=True, exist_ok=True)
-    name = profiles.PROFILES["merged_plugins"].vep_per_contig.format(chrom=chrom)
+    name = profiles.PROFILES[profile].vep_per_contig.format(chrom=chrom)
     (ref_dir / f"{name}.vcf.gz").write_text("")
     return ref_dir / f"{name}.vcf.gz"
 
@@ -207,6 +207,19 @@ def test_plugin_profile_resolves_and_injects_the_plugin_cache_root(
 
     assert resolved.plugin_cache_root == str(plugin_cache)
     assert resolved.annotate_kwargs["plugin_cache_root"] == str(plugin_cache)
+
+
+def test_phenotypeorthologous_profile_attaches_only_that_plugin(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_VEPYR_DIR", str(tmp_path))
+    (tmp_path / "cache" / "116_GRCh38_merged").mkdir(parents=True)
+    plugin_cache = tmp_path / "cache" / "plugin_cache_116"
+    plugin_cache.mkdir(parents=True)
+    _write_plugin_reference(tmp_path, chrom=22, profile="merged_phenotypeorthologous")
+
+    resolved = profiles.resolve("merged_phenotypeorthologous", "116", chrom=22)
+    assert resolved.annotate_kwargs["plugins"] == ["phenotypeorthologous"]
+    assert resolved.vep_vcf.endswith("HG002_chr22_phenotypeorthologous_vep116.vcf.gz")
+    assert "/plugins/" in resolved.vep_vcf
 
 
 def test_plugin_profile_fails_when_the_plugin_cache_is_missing(tmp_path, monkeypatch):

--- a/tests/test_verify_parity_gate.py
+++ b/tests/test_verify_parity_gate.py
@@ -361,10 +361,11 @@ def test_gate_rejects_format_only_counts_for_unexpected_fields(tmp_path):
         _validate(value, tmp_path)
 
 
-def test_gate_refuses_plugin_profiles():
+@pytest.mark.parametrize("profile", ["merged_plugins", "merged_phenotypeorthologous"])
+def test_gate_refuses_plugin_profiles(profile):
     """Plugin profiles are comparison scenarios; the gate pins the core contract."""
     with pytest.raises(gate.GateError, match="plugins"):
-        gate.expected_csq_fields("merged_plugins")
+        gate.expected_csq_fields(profile)
 
 
 def test_gate_refuses_the_plugin_base_profile_too():


### PR DESCRIPTION
Ports Ensembl VEP's `PhenotypeOrthologous` plugin through a new GFF source provider and an interval lookup kind in the engine, and adds the oracle and comparison tooling to prove it.

- Pins the engine at the head of biodatageeks/datafusion-bio-functions#247 (stacked on #246: `provider = "gff"`, `lookup = "interval"`); re-pin to the master squash SHA after those merge.
- Catalog manifest: biodatageeks/vepyr-plugins#17, to be tagged `v0.2.0`.
- `merged_phenotypeorthologous` comparison profile in `run_comparison.py`; `build_vep_phenotypeorthologous_reference.sh` (VEP 116.0, merged cache, `--everything`, BGZF written by VEP, source and plugin code pinned by digest), the resumable `generate_vep_phenotypeorthologous_references.sh`, and `run_phenotypeorthologous_comparison.sh` (build shard → compare → strict md5 gate).
- Synthetic gene-span fixture test: span gating (matching gene id outside its span stays empty), alphabetical field order, VEP escaping (leading space, comma, pipe, whitespace runs) on both the VCF and LazyFrame paths.
- Docs: plugins.md (`lookup`, `[source.gff]`, interval shard schema, sixth plugin row), downloads.md, testing-vep.md, dataframes.md, architecture.md, README, e2e README.

Spec: `docs/superpowers/specs/2026-09-11-gff-plugin-source-and-phenotypeorthologous-design.md`; plans under `docs/superpowers/plans/2026-09-11-*`.

**Parity (VEP 116.0, merged cache, normalized HG002):**
- chr22 PhenotypeOrthologous: 90/90 shared CSQ fields at 100% (the four `PhenotypeOrthologous_*` fields: 1,242,828 entries each, 0 mismatches); strict body md5 `d757312dc87aabcc2d19c6db52ab25fb` concordant over 50,861 records, header identical apart from the `bcftools_normCommand` path; `--workers 1` == `--workers 4` byte-identical. Re-run green on the final pin 5386bfd.
- Whole sample, chr1–22 (4,096,123 records): one whole-input VEP 116.0 reference (`--merged --everything --fork 8 --compress_output bgzip`, only PhenotypeOrthologous loaded), compared with `run_comparison.py --profile merged_phenotypeorthologous --chroms all --comparison-mode md5 --md5-mode strict` against the 22 shards built from the catalog branch: **PASS, 22/22 contigs strictly concordant** (2026-09-12).

**Regression (vepyr-fix runbook, baseline on 4b0bd00 vs final on 5386bfd):**
- Strict md5, `merged` profile, all 22 contigs (4,096,123 records): PASS before and after.
- Five-plugin `merged_plugins` chr22: body md5 `8c6ae1e17452776316ab3ee48def0ebf` before and after (124/124 fields).
- Performance: baseline w8 78.3 s / 9.25 GB RSS, w1 310.7 s / 4.0 GB RSS; the final sweep runs once the host is quiet (a VEP reference job is currently using it) and will be posted here.

**Engine PRs:** #246 and #247 are green (Claude LGTM, Codex clean, CI pass). Review-loop fixes: `[source.gff].attributes` rejects duplicates and names that shadow the fixed GFF columns; interval probes are skipped for structural ALTs (symbolic, `*`, breakends) because Ensembl never hands a StructuralVariationFeature to a plugin; the start-primary shard sort is documented as tabix iteration order.

**Cache published:** `biodatageeks/vepyr_116_GRCh38_plugin_phenotypeorthologous`, dataset tag `v0.2.0`, built from vepyr-plugins `v0.2.0` (7736bbe) with strict source verification; 25 contigs (chr1–22, X, MT; chrY listed with 0 rows), 16,404 rows, every shard byte-identical to the build that passed the whole-genome gate. Commit 08b9b2f.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ybip12LHW1qoorZjs3TwYT