### PR TITLE
docs: variation-lookup figure and the script that measures it

### DIFF
--- a/docs/diagrams/variation-lookup-measure.py
+++ b/docs/diagrams/variation-lookup-measure.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Measure every quantity that appears in ``variation-lookup.py``'s MEASURED table.
+
+The figure claims that clustering the variation shard by tier, rather than by
+position alone, makes the lookup's locate read touch far less data. This script
+is where that claim comes from. It replays one real annotation buffer against a
+real shard twice: once in the order the shard actually ships, and once against a
+position-only counterfactual built from the same rows and the same page sizes.
+
+Nothing here is estimated. Run it, then paste the printed values into MEASURED.
+
+Inputs
+------
+--shard      one per-chromosome variation Parquet file from a built cache
+--pages      CSV of the position column's page boundaries, see below
+--vcf        a bgzipped, tabix-indexed VCF to draw the probe buffer from
+--chrom      contig name as it appears in the VCF
+--buffer     records in the buffer (5000 matches the engine's lookup slice)
+
+Producing --pages
+-----------------
+pyarrow does not expose the Parquet offset index, so the page boundaries come
+from a short Rust program built against the same ``parquet`` crate the engine
+uses. Drop this into ``datafusion/bio-function-vep/examples/`` in a checkout of
+biodatageeks/datafusion-bio-functions and run
+``cargo run --example dump_page_index --features parquet-cache -- <shard> <out.csv>``::
+
+    use parquet::file::reader::{FileReader, SerializedFileReader};
+    use parquet::file::serialized_reader::ReadOptionsBuilder;
+    use std::fs::File;
+    use std::io::{BufWriter, Write};
+
+    fn main() {
+        let path = std::env::args().nth(1).unwrap();
+        let out = std::env::args().nth(2).unwrap();
+        let reader = SerializedFileReader::new_with_options(
+            File::open(&path).unwrap(),
+            ReadOptionsBuilder::new().with_page_index().build(),
+        ).unwrap();
+        let md = reader.metadata();
+        let leaf = md.file_metadata().schema_descr().columns().iter()
+            .position(|c| c.name() == "start").unwrap();
+        let oi = md.offset_index().unwrap();
+        let mut w = BufWriter::new(File::create(out).unwrap());
+        writeln!(w, "first_row,end_row").unwrap();
+        let mut global = 0i64;
+        for rg in 0..md.num_row_groups() {
+            let locs = oi[rg][leaf].page_locations();
+            let rg_rows = md.row_group(rg).num_rows();
+            for p in 0..locs.len() {
+                let end = if p + 1 < locs.len() { locs[p + 1].first_row_index } else { rg_rows };
+                writeln!(w, "{},{}", global + locs[p].first_row_index, global + end).unwrap();
+            }
+            global += rg_rows;
+        }
+    }
+
+Method
+------
+A probe hits a page when the page holds a cached row whose ``start`` equals the
+probe position. The locate read decodes every row of every page it hits, so the
+cost reported here is the summed row span of those pages, not the match count.
+The counterfactual keeps the same rows and the same page row-counts and only
+changes the order, so the two columns differ by clustering alone.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+
+import numpy as np
+import pyarrow.parquet as pq
+
+
+def probe_positions(vcf: str, chrom: str, buffer_size: int) -> np.ndarray:
+    """The first `buffer_size` records of `chrom`, as sorted unique positions."""
+    out = subprocess.run(
+        ["bcftools", "query", "-r", chrom, "-f", "%POS\n", vcf],
+        capture_output=True,
+        text=True,
+    )
+    if out.returncode != 0:
+        sys.exit(f"bcftools failed: {out.stderr.strip()[:200]}")
+    pos = np.fromiter((int(x) for x in out.stdout.split()), dtype=np.int64)
+    if pos.size == 0:
+        sys.exit(f"no records for {chrom} in {vcf}")
+    return np.unique(pos[:buffer_size])
+
+
+def matching_rows(order: np.ndarray, probes: np.ndarray) -> np.ndarray:
+    """Row indices, in `order`'s layout, whose start is one of `probes`."""
+    idx = np.argsort(order, kind="stable")
+    vals = order[idx]
+    lo = np.searchsorted(vals, probes, "left")
+    hi = np.searchsorted(vals, probes, "right")
+    hits = [idx[a:b] for a, b in zip(lo, hi) if b > a]
+    return np.concatenate(hits) if hits else np.empty(0, dtype=np.int64)
+
+
+def layout_cost(rows, first_row, end_row):
+    """Pages the locate read opens, and the rows it decodes doing so."""
+    pages = np.unique(np.searchsorted(end_row, rows, "right"))
+    decoded = int((end_row[pages] - first_row[pages]).sum())
+    return len(pages), decoded
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("--shard", required=True)
+    ap.add_argument("--pages", required=True)
+    ap.add_argument("--vcf", required=True)
+    ap.add_argument("--chrom", default="chr22")
+    ap.add_argument("--buffer", type=int, default=5000)
+    args = ap.parse_args()
+
+    table = pq.read_table(args.shard, columns=["start", "tier"])
+    start = table.column("start").to_numpy(zero_copy_only=False).astype(np.int64)
+    tier = table.column("tier").to_numpy(zero_copy_only=False).astype(np.int8)
+
+    pages = np.loadtxt(args.pages, delimiter=",", skiprows=1, dtype=np.int64)
+    first_row, end_row = pages[:, 0], pages[:, 1]
+
+    probes = probe_positions(args.vcf, args.chrom, args.buffer)
+    rows = matching_rows(start, probes)
+    tier0_rows = int((tier == 0).sum())
+
+    shipped_pages, shipped_decoded = layout_cost(rows, first_row, end_row)
+    counter_pages, counter_decoded = layout_cost(
+        matching_rows(np.sort(start), probes), first_row, end_row
+    )
+
+    page_of = np.searchsorted(end_row, rows, "right")
+    t0_pages = np.unique(page_of[rows < tier0_rows])
+    t1_pages = np.unique(page_of[rows >= tier0_rows])
+    t0_rows = int((rows < tier0_rows).sum())
+    t1_rows = int((rows >= tier0_rows).sum())
+
+    print(f"shard             {args.shard}")
+    print(f"  rows            {len(start):,}")
+    print(f"  position pages  {len(pages):,}")
+    print(f"  tier 0 rows     {tier0_rows:,}  ({100 * tier0_rows / len(start):.1f}%)")
+    print(f"buffer            first {args.buffer:,} {args.chrom} records of {args.vcf}")
+    print(f"  probes          {len(probes):,}")
+    print(f"  matching rows   {len(rows):,}")
+    print()
+    print(
+        f"{'row layout':26} {'pages read':>11} {'rows scanned':>13} {'matches per page':>17}"
+    )
+    for label, p, d in (
+        ("sorted by position only", counter_pages, counter_decoded),
+        ("as shipped, tier 0 first", shipped_pages, shipped_decoded),
+    ):
+        print(f"{label:26} {p:11,} {d:13,} {len(rows) / p:17.1f}")
+    print(
+        f"\nratios: {counter_pages / shipped_pages:.1f}x fewer pages, "
+        f"{counter_decoded / shipped_decoded:.1f}x fewer rows scanned"
+    )
+    print()
+    print(
+        f"  tier 0: {len(t0_pages):4} pages, {t0_rows:,} rows -> {t0_rows / len(t0_pages):.1f} per page"
+    )
+    print(
+        f"  tier 1: {len(t1_pages):4} pages, {t1_rows:,} rows -> {t1_rows / max(len(t1_pages), 1):.1f} per page"
+    )
+    print(f"  common share of matches: {100 * t0_rows / len(rows):.0f}%")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/diagrams/variation-lookup.py
+++ b/docs/diagrams/variation-lookup.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+"""Generate the variation-lookup figure (docs/diagrams/variation-lookup.svg).
+
+Every quantity in MEASURED below comes from `variation-lookup-measure.py`, run against
+the chr22 shard of the GRCh38 merged cache for Ensembl VEP 116 and the HG002 benchmark
+VCF. Re-run that script and update MEASURED whenever the cache is rebuilt; nothing here
+is estimated. The cell strips in panel B are schematic and are labelled as such.
+
+Usage:  python docs/diagrams/variation-lookup.py
+Then:   rsvg-convert -f pdf -o variation-lookup.pdf docs/diagrams/variation-lookup.svg
+"""
+
+import pathlib
+
+# ---- measured on the GRCh38 merged cache for Ensembl VEP 116, chr22 shard,
+# ---- probed with the first 5,000 records of the HG002 chr22 benchmark VCF.
+MEASURED = dict(
+    shard_rows=15_148_238,
+    pages=15_381,
+    tier0_rows=821_809,
+    tier0_pct=5.4,
+    probes=5_000,
+    matched=6_178,
+    tiered_pages=220,
+    untiered_pages=920,
+    tiered_per_page=28.1,
+    untiered_per_page=6.7,
+    t0_pages=83,
+    t0_rows=5_946,
+    t0_per_page=71.6,
+    t1_pages=137,
+    t1_rows=232,
+    t1_per_page=1.7,
+    common_share=96,
+    tiered_decoded=207_732,
+    untiered_decoded=928_028,
+    decoded_ratio=4.5,
+)
+
+INK, MUTED, RULE = "#111111", "#555555", "#B0B0B0"
+BLUE, BLUEFILL = "#0072B2", "#D6E6F5"
+ORANGE, ORANGEFILL = "#D55E00", "#F7D9C4"
+GREY = "#BFBFBF"
+
+W = 1000
+o = []
+
+
+def t(x, y, s, fill=INK, size=None, bold=False, anchor=None):
+    a = f' font-size="{size}"' if size else ""
+    b = ' font-weight="bold"' if bold else ""
+    an = f' text-anchor="{anchor}"' if anchor else ""
+    o.append(f'  <text x="{x}" y="{y}"{a}{b}{an} fill="{fill}">{s}</text>')
+
+
+def rect(x, y, w, h, fill="#FFFFFF", stroke=INK, sw=1.2, extra=""):
+    o.append(
+        f'  <rect x="{x}" y="{y}" width="{w}" height="{h}" fill="{fill}" stroke="{stroke}" stroke-width="{sw}"{extra}/>'
+    )
+
+
+def line(x1, y1, x2, y2, stroke=RULE, sw=1, dash=None):
+    d = f' stroke-dasharray="{dash}"' if dash else ""
+    o.append(
+        f'  <line x1="{x1}" y1="{y1}" x2="{x2}" y2="{y2}" stroke="{stroke}" stroke-width="{sw}"{d}/>'
+    )
+
+
+def arrow(d, stroke=INK, sw=1.2, marker="arr"):
+    o.append(
+        f'  <path d="{d}" stroke="{stroke}" stroke-width="{sw}" fill="none" marker-end="url(#{marker})"/>'
+    )
+
+
+# ---------------------------------------------------------------- Panel A
+t(20, 34, "A", size=13, bold=True)
+t(36, 34, "Input buffer", size=12, bold=True)
+t(20, 50, "≤ 5,000 chr22 records, position-ordered", MUTED)
+rect(20, 58, 210, 118)
+t(30, 76, "position", MUTED)
+t(140, 76, "ref &gt; alt", MUTED)
+line(30, 82, 220, 82)
+for i, (p, a) in enumerate(
+    [
+        ("16,050,075", "A &gt; G"),
+        ("16,050,115", "G &gt; A"),
+        ("16,050,213", "C &gt; T"),
+        ("16,050,300", "CT &gt; C"),
+    ]
+):
+    t(30, 98 + 16 * i, p)
+    t(140, 98 + 16 * i, a)
+t(30, 166, "⋮")
+arrow("M125 176 V200")
+t(134, 186, "one or more probe", MUTED)
+t(134, 200, "positions per record", MUTED)
+rect(20, 202, 210, 46, BLUEFILL, BLUE, 1.4)
+t(30, 221, "probe positions", bold=True)
+o.append(
+    '  <text x="30" y="238">p<tspan font-size="8" baseline-shift="sub">1</tspan> &lt; '
+    'p<tspan font-size="8" baseline-shift="sub">2</tspan> &lt; … &lt; '
+    'p<tspan font-size="8" baseline-shift="sub">k</tspan>, unique</text>'
+)
+
+# ---------------------------------------------------------------- Panel B
+t(270, 34, "B", size=13, bold=True)
+t(286, 34, "Why the shard is clustered by tier", size=12, bold=True)
+t(
+    270,
+    50,
+    "the chr22 shard, one Parquet file: each cell below is one cached variant, each block of 12 cells one data page",
+    MUTED,
+)
+
+X0, CW, NCELL, PAGE = 270, 6.75, 96, 12
+
+
+def strip(y, common_idx, rare_probe_idx):
+    """Draw one layout. common_idx: cells holding a probed common variant."""
+    hit_pages = sorted({i // PAGE for i in list(common_idx) + list(rare_probe_idx)})
+    for pg in hit_pages:  # read-page tint behind the cells
+        rect(X0 + pg * PAGE * CW, y - 4, PAGE * CW, 22, BLUEFILL, BLUE, 1.4)
+    for i in range(NCELL):
+        x = X0 + i * CW
+        if i in common_idx:
+            fill, stroke = ORANGE, ORANGE
+        elif i in rare_probe_idx:
+            fill, stroke = "#FFFFFF", ORANGE
+        else:
+            fill, stroke = GREY, GREY
+        o.append(
+            f'  <rect x="{x:.2f}" y="{y}" width="{CW - 0.6:.2f}" height="14" fill="{fill}" stroke="{stroke}" stroke-width="0.5"/>'
+        )
+    for pg in range(1, NCELL // PAGE):  # page boundaries
+        line(X0 + pg * PAGE * CW, y - 4, X0 + pg * PAGE * CW, y + 18, INK, 1)
+    return hit_pages
+
+
+# counterfactual: common variants sprinkled through the file
+scattered = [7, 23, 41, 58, 77, 90]
+rare_scattered = [66]
+t(270, 72, "sorted by position only", bold=True)
+t(410, 72, "(counterfactual)", MUTED)
+hp1 = strip(78, scattered, rare_scattered)
+t(918, 72, "schematic", MUTED, anchor="end")
+
+# as shipped: the same common variants packed into tier 0
+packed = [0, 1, 2, 3, 4, 5]
+rare_packed = [66]
+t(270, 118, "as shipped: tier 0 first, then position", bold=True)
+hp2 = strip(124, packed, rare_packed)
+line(X0 + 6 * CW, 116, X0 + 6 * CW, 148, INK, 1.4, "3 3")
+t(
+    X0 + 6 * CW + 4,
+    158,
+    "tier seam: tier 0 is 5.4% of the rows, so it ends inside the first page",
+    MUTED,
+)
+t(918, 118, "schematic", MUTED, anchor="end")
+
+# key
+ky = 176
+o.append(
+    f'  <rect x="270" y="{ky - 8}" width="10" height="10" fill="{ORANGE}" stroke="{ORANGE}" stroke-width="0.5"/>'
+)
+t(286, ky, "probed, common (allele frequency ≥ 1%)")
+o.append(
+    f'  <rect x="500" y="{ky - 8}" width="10" height="10" fill="#FFFFFF" stroke="{ORANGE}" stroke-width="1"/>'
+)
+t(516, ky, "probed, rare")
+o.append(
+    f'  <rect x="590" y="{ky - 8}" width="10" height="10" fill="{GREY}" stroke="{GREY}" stroke-width="0.5"/>'
+)
+t(606, ky, "not probed")
+o.append(
+    f'  <rect x="676" y="{ky - 8}" width="10" height="10" fill="{BLUEFILL}" stroke="{BLUE}" stroke-width="1"/>'
+)
+t(692, ky, "page that must be read")
+
+M = MEASURED
+rect(270, 182, 648, 76, "#FFFFFF", INK, 1.2)
+t(280, 199, "measured", bold=True)
+t(
+    340,
+    199,
+    f"one real 5,000-record chr22 buffer, {M['matched']:,} matches: the locate read of C, over the position column",
+    MUTED,
+)
+t(280, 217, "row layout", MUTED)
+t(545, 217, f"pages read of {M['pages']:,}", MUTED)
+t(690, 217, "position rows scanned", MUTED)
+t(908, 217, "matches per page", MUTED, anchor="end")
+t(280, 233, "sorted by position only")
+t(545, 233, f"{M['untiered_pages']:,}")
+t(690, 233, f"{M['untiered_decoded']:,}")
+t(908, 233, f"{M['untiered_per_page']}", anchor="end")
+t(280, 249, "as shipped, tier 0 first")
+t(545, 249, f"{M['tiered_pages']:,}", BLUE)
+t(690, 249, f"{M['tiered_decoded']:,}", BLUE)
+t(908, 249, f"{M['tiered_per_page']}", BLUE, anchor="end")
+
+rect(270, 262, 648, 44, ORANGEFILL, ORANGE, 1.4)
+t(280, 280, f"{M['common_share']}% of the matches are common", bold=True)
+t(
+    520,
+    280,
+    f"{M['t0_pages']} tier-0 pages carry {M['t0_rows']:,} of them, {M['t0_per_page']} rows per page",
+)
+t(280, 296, f"the rare {100 - M['common_share']}% still scatter")
+t(
+    520,
+    296,
+    f"{M['t1_pages']} tier-1 pages carry {M['t1_rows']} rows, {M['t1_per_page']} rows per page",
+)
+
+# page directory + candidate pages
+arrow("M230 225 H250 V344 H268", BLUE, 1.4, "arr-b")
+rect(270, 318, 300, 54)
+t(280, 336, "page directory", bold=True)
+t(280, 352, "from the file footer, built once per chromosome", MUTED)
+t(280, 366, "and shared by every worker on that contig", MUTED)
+arrow("M570 345 H608")
+rect(610, 318, 308, 54, BLUEFILL, BLUE, 1.4)
+t(620, 336, "candidate pages", bold=True)
+t(620, 352, "binary search per probe position within each tier run;", MUTED)
+t(620, 366, "adjacent pages merge into row ranges (select / skip)", MUTED)
+
+# writer properties
+rect(270, 384, 648, 192)
+t(280, 402, "how the shard is written", bold=True)
+t(520, 402, "→ what it buys at lookup", MUTED)
+line(280, 408, 908, 408)
+rows = [
+    (
+        "rows clustered by tier,",
+        "then sorted by position",
+        "page min / max ascend within a run, so a probe is found by",
+        "binary search; the directory keeps one run per tier",
+    ),
+    (
+        "tier 0 = any position where",
+        "max(MAF, AF, gnomADg, gnomADe) ≥ 1%,",
+        "the measured block above: for the same probes, 4.2× fewer pages",
+        "and 4.5× fewer position rows decoded to locate the 6,178 matches",
+    ),
+    (
+        "plus its ± 1 bp neighbours; 5.4% of rows",
+        None,
+        "frequency is the only criterion, and it is decided per position:",
+        "every allele at a common position joins tier 0, however rare",
+    ),
+    (
+        "pages of 1,024 rows (the default),",
+        "~2.4 KiB compressed; page statistics on",
+        "footer column + offset indexes give each page's position",
+        "range and first row, so skipping is decided from metadata",
+    ),
+    (
+        "no dictionary encoding; zstd(3)",
+        None,
+        "a selected page decodes alone; with a dictionary, reading one row",
+        "first decodes its column chunk's dictionary, built over 10⁶ rows",
+    ),
+]
+y = 426
+for l1, l2, r1, r2 in rows:
+    t(280, y, l1)
+    if l2:
+        t(280, y + 14, l2)
+    t(520, y, r1, BLUE)
+    t(520, y + 14, r2, BLUE)
+    y += 36
+
+line(20, 598, 980, 598, "#DDDDDD")
+
+# ---------------------------------------------------------------- Panel C
+t(20, 624, "C", size=13, bold=True)
+t(36, 624, "Two reads of the shard: locate, then take", size=12, bold=True)
+rect(20, 634, 450, 194, "#FFFFFF", BLUE, 1.4)
+t(30, 653, "Locate · one column, many rows", bold=True)
+t(30, 668, "this is the scan counted in panel B", BLUE)
+t(30, 683, "the position column alone, every row in the candidate page ranges", MUTED)
+t(30, 697, "nearby page byte ranges are coalesced into single reads", MUTED)
+t(30, 715, "file row", MUTED)
+t(110, 715, "position", MUTED)
+line(30, 721, 250, 721)
+tbl = [
+    ("612 352", "16,050,001", False),
+    ("612 353", "16,050,075", True),
+    ("612 354", "16,050,075", True),
+    ("612 355", "16,050,082", False),
+    ("612 356", "16,050,213", True),
+    ("612 357", "16,050,213", True),
+]
+for i2, (fr, pos, hit) in enumerate(tbl):
+    yy = 735 + 14 * i2
+    t(30, yy, fr)
+    t(110, yy, pos)
+    if hit:
+        o.append(f'  <circle cx="200" cy="{yy - 4}" r="3.5" fill="{BLUE}"/>')
+t(30, 818, "⋮")
+arrow("M270 727 V812", BLUE, 1.6, "arr-b")
+t(282, 743, "monotonic cursor", BLUE, bold=True)
+t(282, 759, "advances one file row per")
+t(282, 773, "streamed value, never backwards")
+t(282, 795, "● position is in the probe set")
+t(282, 809, "→ its file row is recorded")
+arrow("M470 721 H508")
+rect(510, 684, 90, 112, BLUEFILL, BLUE, 1.4)
+t(520, 703, "row offsets", bold=True)
+for i2, v in enumerate(["612 353", "612 354", "612 356", "612 357"]):
+    t(520, 724 + 15 * i2, v)
+t(520, 787, "⋮ ascending", MUTED)
+arrow("M600 721 H638")
+rect(640, 634, 310, 194, "#FFFFFF", BLUE, 1.4)
+t(650, 653, "Take · many columns, few rows", bold=True)
+t(650, 668, "the subset of columns the run needs, only the matched rows", MUTED)
+t(650, 692, "position", MUTED)
+t(740, 692, "alleles", MUTED)
+t(800, 692, "identifier", MUTED)
+t(890, 692, "…", MUTED)
+line(650, 698, 940, 698)
+for i2, (pp, aa, rr) in enumerate(
+    [
+        ("16,050,075", "A/G", "rs587697622"),
+        ("16,050,075", "A/T", "rs…"),
+        ("16,050,213", "C/A", "rs…"),
+        ("16,050,213", "C/T", "rs…"),
+    ]
+):
+    yy = 716 + 16 * i2
+    t(650, yy, pp)
+    t(740, yy, aa)
+    t(800, yy, rr)
+t(650, 782, "⋮")
+t(650, 804, "the only rows that leave the shard", BLUE, bold=True)
+
+line(20, 848, 980, 848, "#DDDDDD")
+
+# ---------------------------------------------------------------- Panel D
+t(20, 864, "D", size=13, bold=True)
+t(36, 864, "Join back to the buffer", size=12, bold=True)
+rect(20, 874, 210, 104)
+t(30, 893, "input buffer", bold=True)
+for i2, (pp, aa) in enumerate(
+    [
+        ("16,050,075", "A &gt; G"),
+        ("16,050,115", "G &gt; A"),
+        ("16,050,213", "C &gt; T"),
+        ("16,050,300", "CT &gt; C"),
+    ]
+):
+    t(30, 913 + 16 * i2, pp)
+    t(140, 913 + 16 * i2, aa)
+arrow("M230 926 H268")
+rect(270, 874, 300, 104)
+t(280, 893, "allele matching per record", bold=True)
+t(280, 913, "rows at its probe positions are accepted when")
+t(280, 929, "• the record is not flagged as failed")
+t(280, 945, "• the record interval overlaps the variant")
+t(280, 961, "• the alleles match exactly (first match wins)")
+arrow("M570 926 H608")
+rect(610, 874, 340, 104, BLUEFILL, BLUE, 1.4)
+t(620, 893, "buffer + cache columns · one row in, one row out", bold=True)
+for i2, (aa, rr) in enumerate(
+    [
+        ("A &gt; G", "rs587697622 and its cache columns"),
+        ("G &gt; A", "no record at this position → null"),
+        ("C &gt; T", "C/A rejected, C/T matched"),
+        ("CT &gt; C", "matched at its shifted probe position"),
+    ]
+):
+    t(620, 913 + 16 * i2, aa)
+    t(700, 913 + 16 * i2, rr)
+arrow("M420 978 V1000", "#E69F00", 1.6, "arr-o")
+rect(270, 1002, 680, 44, "#FBEEDC", "#E69F00", 1.4)
+o.append(
+    '  <text x="280" y="1021"><tspan font-weight="bold">co-located variants</tspan> at the same positions are collected '
+    "separately for the transcript annotation stage:</text>"
+)
+t(280, 1037, "existing identifiers, allele frequencies, clinical significance")
+
+H = 1066
+
+ARIA = (
+    "Four panels. A: one lookup slice of up to 5,000 position-ordered VCF records is reduced to a sorted unique set of probe positions. "
+    "B: why the shard is clustered by tier. Two schematic strips of cells show the same probe set against two layouts: sorted by position alone "
+    "the probed common variants are sprinkled through the file, while clustering tier 0 first packs them together. A measured block gives the "
+    "real figures for one 5,000-record chromosome 22 buffer against this shard: 920 pages read and 928,028 rows decoded without tiering, against "
+    "220 pages and 207,732 rows with it, for the same 6,178 matches. A table lists how the shard is written and what each choice buys at lookup. "
+    "C: two reads that differ in both axes, one column across many rows to locate the offsets, then many columns across few rows to take the "
+    "payload. D: those rows are joined back to the buffer by allele matching, giving one output row per input record, with co-located variants "
+    "collected separately for the transcript annotation stage."
+)
+
+HDR = 26
+H += HDR
+head = (
+    f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {W} {H}" width="{W}" height="{H}" '
+    f'font-family="Helvetica, Arial, sans-serif" font-size="11" fill="{INK}" role="img" aria-label="{ARIA}">\n'
+    "  <defs>\n"
+    f'    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0L10 5L0 10z" fill="#333333"/></marker>\n'
+    f'    <marker id="arr-b" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0L10 5L0 10z" fill="{BLUE}"/></marker>\n'
+    '    <marker id="arr-o" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0L10 5L0 10z" fill="#E69F00"/></marker>\n'
+    "  </defs>\n"
+    f'  <rect x="0" y="0" width="{W}" height="{H}" fill="#FFFFFF"/>\n'
+)
+header = (
+    f'  <text x="20" y="18" font-size="11" fill="{MUTED}">'
+    'Worked example throughout: <tspan font-weight="bold" fill="#111111">chromosome 22</tspan>'
+    " of the GRCh38 merged cache for Ensembl VEP 116, probed with the HG002 benchmark VCF.</text>\n"
+)
+body = f'  <g transform="translate(0,{HDR})">\n' + "\n".join(o) + "\n  </g>\n"
+pathlib.Path(__file__).with_name("variation-lookup.svg").write_text(
+    head + header + body + "</svg>\n"
+)
+print("wrote", pathlib.Path(__file__).with_name("variation-lookup.svg"))

--- a/docs/diagrams/variation-lookup.svg
+++ b/docs/diagrams/variation-lookup.svg
@@ -1,0 +1,418 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1000 1092" width="1000" height="1092" font-family="Helvetica, Arial, sans-serif" font-size="11" fill="#111111" role="img" aria-label="Four panels. A: one lookup slice of up to 5,000 position-ordered VCF records is reduced to a sorted unique set of probe positions. B: why the shard is clustered by tier. Two schematic strips of cells show the same probe set against two layouts: sorted by position alone the probed common variants are sprinkled through the file, while clustering tier 0 first packs them together. A measured block gives the real figures for one 5,000-record chromosome 22 buffer against this shard: 920 pages read and 928,028 rows decoded without tiering, against 220 pages and 207,732 rows with it, for the same 6,178 matches. A table lists how the shard is written and what each choice buys at lookup. C: two reads that differ in both axes, one column across many rows to locate the offsets, then many columns across few rows to take the payload. D: those rows are joined back to the buffer by allele matching, giving one output row per input record, with co-located variants collected separately for the transcript annotation stage.">
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0L10 5L0 10z" fill="#333333"/></marker>
+    <marker id="arr-b" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0L10 5L0 10z" fill="#0072B2"/></marker>
+    <marker id="arr-o" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0L10 5L0 10z" fill="#E69F00"/></marker>
+  </defs>
+  <rect x="0" y="0" width="1000" height="1092" fill="#FFFFFF"/>
+  <text x="20" y="18" font-size="11" fill="#555555">Worked example throughout: <tspan font-weight="bold" fill="#111111">chromosome 22</tspan> of the GRCh38 merged cache for Ensembl VEP 116, probed with the HG002 benchmark VCF.</text>
+  <g transform="translate(0,26)">
+  <text x="20" y="34" font-size="13" font-weight="bold" fill="#111111">A</text>
+  <text x="36" y="34" font-size="12" font-weight="bold" fill="#111111">Input buffer</text>
+  <text x="20" y="50" fill="#555555">≤ 5,000 chr22 records, position-ordered</text>
+  <rect x="20" y="58" width="210" height="118" fill="#FFFFFF" stroke="#111111" stroke-width="1.2"/>
+  <text x="30" y="76" fill="#555555">position</text>
+  <text x="140" y="76" fill="#555555">ref &gt; alt</text>
+  <line x1="30" y1="82" x2="220" y2="82" stroke="#B0B0B0" stroke-width="1"/>
+  <text x="30" y="98" fill="#111111">16,050,075</text>
+  <text x="140" y="98" fill="#111111">A &gt; G</text>
+  <text x="30" y="114" fill="#111111">16,050,115</text>
+  <text x="140" y="114" fill="#111111">G &gt; A</text>
+  <text x="30" y="130" fill="#111111">16,050,213</text>
+  <text x="140" y="130" fill="#111111">C &gt; T</text>
+  <text x="30" y="146" fill="#111111">16,050,300</text>
+  <text x="140" y="146" fill="#111111">CT &gt; C</text>
+  <text x="30" y="166" fill="#111111">⋮</text>
+  <path d="M125 176 V200" stroke="#111111" stroke-width="1.2" fill="none" marker-end="url(#arr)"/>
+  <text x="134" y="186" fill="#555555">one or more probe</text>
+  <text x="134" y="200" fill="#555555">positions per record</text>
+  <rect x="20" y="202" width="210" height="46" fill="#D6E6F5" stroke="#0072B2" stroke-width="1.4"/>
+  <text x="30" y="221" font-weight="bold" fill="#111111">probe positions</text>
+  <text x="30" y="238">p<tspan font-size="8" baseline-shift="sub">1</tspan> &lt; p<tspan font-size="8" baseline-shift="sub">2</tspan> &lt; … &lt; p<tspan font-size="8" baseline-shift="sub">k</tspan>, unique</text>
+  <text x="270" y="34" font-size="13" font-weight="bold" fill="#111111">B</text>
+  <text x="286" y="34" font-size="12" font-weight="bold" fill="#111111">Why the shard is clustered by tier</text>
+  <text x="270" y="50" fill="#555555">the chr22 shard, one Parquet file: each cell below is one cached variant, each block of 12 cells one data page</text>
+  <text x="270" y="72" font-weight="bold" fill="#111111">sorted by position only</text>
+  <text x="410" y="72" fill="#555555">(counterfactual)</text>
+  <rect x="270.0" y="74" width="81.0" height="22" fill="#D6E6F5" stroke="#0072B2" stroke-width="1.4"/>
+  <rect x="351.0" y="74" width="81.0" height="22" fill="#D6E6F5" stroke="#0072B2" stroke-width="1.4"/>
+  <rect x="513.0" y="74" width="81.0" height="22" fill="#D6E6F5" stroke="#0072B2" stroke-width="1.4"/>
+  <rect x="594.0" y="74" width="81.0" height="22" fill="#D6E6F5" stroke="#0072B2" stroke-width="1.4"/>
+  <rect x="675.0" y="74" width="81.0" height="22" fill="#D6E6F5" stroke="#0072B2" stroke-width="1.4"/>
+  <rect x="756.0" y="74" width="81.0" height="22" fill="#D6E6F5" stroke="#0072B2" stroke-width="1.4"/>
+  <rect x="837.0" y="74" width="81.0" height="22" fill="#D6E6F5" stroke="#0072B2" stroke-width="1.4"/>
+  <rect x="270.00" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="276.75" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="283.50" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="290.25" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="297.00" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="303.75" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="310.50" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="317.25" y="78" width="6.15" height="14" fill="#D55E00" stroke="#D55E00" stroke-width="0.5"/>
+  <rect x="324.00" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="330.75" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="337.50" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="344.25" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="351.00" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="357.75" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="364.50" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="371.25" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="378.00" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="384.75" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="391.50" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="398.25" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="405.00" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="411.75" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="418.50" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="425.25" y="78" width="6.15" height="14" fill="#D55E00" stroke="#D55E00" stroke-width="0.5"/>
+  <rect x="432.00" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="438.75" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="445.50" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="452.25" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="459.00" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="465.75" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="472.50" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="479.25" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="486.00" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="492.75" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="499.50" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="506.25" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="513.00" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="519.75" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="526.50" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="533.25" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="540.00" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="546.75" y="78" width="6.15" height="14" fill="#D55E00" stroke="#D55E00" stroke-width="0.5"/>
+  <rect x="553.50" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="560.25" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="567.00" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="573.75" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="580.50" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="587.25" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="594.00" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="600.75" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="607.50" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="614.25" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="621.00" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="627.75" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="634.50" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="641.25" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="648.00" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="654.75" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="661.50" y="78" width="6.15" height="14" fill="#D55E00" stroke="#D55E00" stroke-width="0.5"/>
+  <rect x="668.25" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="675.00" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="681.75" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="688.50" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="695.25" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="702.00" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="708.75" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="715.50" y="78" width="6.15" height="14" fill="#FFFFFF" stroke="#D55E00" stroke-width="0.5"/>
+  <rect x="722.25" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="729.00" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="735.75" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="742.50" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="749.25" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="756.00" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="762.75" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="769.50" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="776.25" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="783.00" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="789.75" y="78" width="6.15" height="14" fill="#D55E00" stroke="#D55E00" stroke-width="0.5"/>
+  <rect x="796.50" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="803.25" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="810.00" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="816.75" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="823.50" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="830.25" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="837.00" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="843.75" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="850.50" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="857.25" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="864.00" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="870.75" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="877.50" y="78" width="6.15" height="14" fill="#D55E00" stroke="#D55E00" stroke-width="0.5"/>
+  <rect x="884.25" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="891.00" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="897.75" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="904.50" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="911.25" y="78" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <line x1="351.0" y1="74" x2="351.0" y2="96" stroke="#111111" stroke-width="1"/>
+  <line x1="432.0" y1="74" x2="432.0" y2="96" stroke="#111111" stroke-width="1"/>
+  <line x1="513.0" y1="74" x2="513.0" y2="96" stroke="#111111" stroke-width="1"/>
+  <line x1="594.0" y1="74" x2="594.0" y2="96" stroke="#111111" stroke-width="1"/>
+  <line x1="675.0" y1="74" x2="675.0" y2="96" stroke="#111111" stroke-width="1"/>
+  <line x1="756.0" y1="74" x2="756.0" y2="96" stroke="#111111" stroke-width="1"/>
+  <line x1="837.0" y1="74" x2="837.0" y2="96" stroke="#111111" stroke-width="1"/>
+  <text x="918" y="72" text-anchor="end" fill="#555555">schematic</text>
+  <text x="270" y="118" font-weight="bold" fill="#111111">as shipped: tier 0 first, then position</text>
+  <rect x="270.0" y="120" width="81.0" height="22" fill="#D6E6F5" stroke="#0072B2" stroke-width="1.4"/>
+  <rect x="675.0" y="120" width="81.0" height="22" fill="#D6E6F5" stroke="#0072B2" stroke-width="1.4"/>
+  <rect x="270.00" y="124" width="6.15" height="14" fill="#D55E00" stroke="#D55E00" stroke-width="0.5"/>
+  <rect x="276.75" y="124" width="6.15" height="14" fill="#D55E00" stroke="#D55E00" stroke-width="0.5"/>
+  <rect x="283.50" y="124" width="6.15" height="14" fill="#D55E00" stroke="#D55E00" stroke-width="0.5"/>
+  <rect x="290.25" y="124" width="6.15" height="14" fill="#D55E00" stroke="#D55E00" stroke-width="0.5"/>
+  <rect x="297.00" y="124" width="6.15" height="14" fill="#D55E00" stroke="#D55E00" stroke-width="0.5"/>
+  <rect x="303.75" y="124" width="6.15" height="14" fill="#D55E00" stroke="#D55E00" stroke-width="0.5"/>
+  <rect x="310.50" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="317.25" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="324.00" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="330.75" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="337.50" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="344.25" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="351.00" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="357.75" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="364.50" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="371.25" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="378.00" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="384.75" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="391.50" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="398.25" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="405.00" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="411.75" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="418.50" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="425.25" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="432.00" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="438.75" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="445.50" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="452.25" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="459.00" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="465.75" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="472.50" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="479.25" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="486.00" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="492.75" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="499.50" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="506.25" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="513.00" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="519.75" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="526.50" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="533.25" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="540.00" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="546.75" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="553.50" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="560.25" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="567.00" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="573.75" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="580.50" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="587.25" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="594.00" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="600.75" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="607.50" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="614.25" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="621.00" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="627.75" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="634.50" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="641.25" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="648.00" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="654.75" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="661.50" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="668.25" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="675.00" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="681.75" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="688.50" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="695.25" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="702.00" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="708.75" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="715.50" y="124" width="6.15" height="14" fill="#FFFFFF" stroke="#D55E00" stroke-width="0.5"/>
+  <rect x="722.25" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="729.00" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="735.75" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="742.50" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="749.25" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="756.00" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="762.75" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="769.50" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="776.25" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="783.00" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="789.75" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="796.50" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="803.25" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="810.00" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="816.75" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="823.50" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="830.25" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="837.00" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="843.75" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="850.50" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="857.25" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="864.00" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="870.75" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="877.50" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="884.25" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="891.00" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="897.75" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="904.50" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <rect x="911.25" y="124" width="6.15" height="14" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <line x1="351.0" y1="120" x2="351.0" y2="142" stroke="#111111" stroke-width="1"/>
+  <line x1="432.0" y1="120" x2="432.0" y2="142" stroke="#111111" stroke-width="1"/>
+  <line x1="513.0" y1="120" x2="513.0" y2="142" stroke="#111111" stroke-width="1"/>
+  <line x1="594.0" y1="120" x2="594.0" y2="142" stroke="#111111" stroke-width="1"/>
+  <line x1="675.0" y1="120" x2="675.0" y2="142" stroke="#111111" stroke-width="1"/>
+  <line x1="756.0" y1="120" x2="756.0" y2="142" stroke="#111111" stroke-width="1"/>
+  <line x1="837.0" y1="120" x2="837.0" y2="142" stroke="#111111" stroke-width="1"/>
+  <line x1="310.5" y1="116" x2="310.5" y2="148" stroke="#111111" stroke-width="1.4" stroke-dasharray="3 3"/>
+  <text x="314.5" y="158" fill="#555555">tier seam: tier 0 is 5.4% of the rows, so it ends inside the first page</text>
+  <text x="918" y="118" text-anchor="end" fill="#555555">schematic</text>
+  <rect x="270" y="168" width="10" height="10" fill="#D55E00" stroke="#D55E00" stroke-width="0.5"/>
+  <text x="286" y="176" fill="#111111">probed, common (allele frequency ≥ 1%)</text>
+  <rect x="500" y="168" width="10" height="10" fill="#FFFFFF" stroke="#D55E00" stroke-width="1"/>
+  <text x="516" y="176" fill="#111111">probed, rare</text>
+  <rect x="590" y="168" width="10" height="10" fill="#BFBFBF" stroke="#BFBFBF" stroke-width="0.5"/>
+  <text x="606" y="176" fill="#111111">not probed</text>
+  <rect x="676" y="168" width="10" height="10" fill="#D6E6F5" stroke="#0072B2" stroke-width="1"/>
+  <text x="692" y="176" fill="#111111">page that must be read</text>
+  <rect x="270" y="182" width="648" height="76" fill="#FFFFFF" stroke="#111111" stroke-width="1.2"/>
+  <text x="280" y="199" font-weight="bold" fill="#111111">measured</text>
+  <text x="340" y="199" fill="#555555">one real 5,000-record chr22 buffer, 6,178 matches: the locate read of C, over the position column</text>
+  <text x="280" y="217" fill="#555555">row layout</text>
+  <text x="545" y="217" fill="#555555">pages read of 15,381</text>
+  <text x="690" y="217" fill="#555555">position rows scanned</text>
+  <text x="908" y="217" text-anchor="end" fill="#555555">matches per page</text>
+  <text x="280" y="233" fill="#111111">sorted by position only</text>
+  <text x="545" y="233" fill="#111111">920</text>
+  <text x="690" y="233" fill="#111111">928,028</text>
+  <text x="908" y="233" text-anchor="end" fill="#111111">6.7</text>
+  <text x="280" y="249" fill="#111111">as shipped, tier 0 first</text>
+  <text x="545" y="249" fill="#0072B2">220</text>
+  <text x="690" y="249" fill="#0072B2">207,732</text>
+  <text x="908" y="249" text-anchor="end" fill="#0072B2">28.1</text>
+  <rect x="270" y="262" width="648" height="44" fill="#F7D9C4" stroke="#D55E00" stroke-width="1.4"/>
+  <text x="280" y="280" font-weight="bold" fill="#111111">96% of the matches are common</text>
+  <text x="520" y="280" fill="#111111">83 tier-0 pages carry 5,946 of them, 71.6 rows per page</text>
+  <text x="280" y="296" fill="#111111">the rare 4% still scatter</text>
+  <text x="520" y="296" fill="#111111">137 tier-1 pages carry 232 rows, 1.7 rows per page</text>
+  <path d="M230 225 H250 V344 H268" stroke="#0072B2" stroke-width="1.4" fill="none" marker-end="url(#arr-b)"/>
+  <rect x="270" y="318" width="300" height="54" fill="#FFFFFF" stroke="#111111" stroke-width="1.2"/>
+  <text x="280" y="336" font-weight="bold" fill="#111111">page directory</text>
+  <text x="280" y="352" fill="#555555">from the file footer, built once per chromosome</text>
+  <text x="280" y="366" fill="#555555">and shared by every worker on that contig</text>
+  <path d="M570 345 H608" stroke="#111111" stroke-width="1.2" fill="none" marker-end="url(#arr)"/>
+  <rect x="610" y="318" width="308" height="54" fill="#D6E6F5" stroke="#0072B2" stroke-width="1.4"/>
+  <text x="620" y="336" font-weight="bold" fill="#111111">candidate pages</text>
+  <text x="620" y="352" fill="#555555">binary search per probe position within each tier run;</text>
+  <text x="620" y="366" fill="#555555">adjacent pages merge into row ranges (select / skip)</text>
+  <rect x="270" y="384" width="648" height="192" fill="#FFFFFF" stroke="#111111" stroke-width="1.2"/>
+  <text x="280" y="402" font-weight="bold" fill="#111111">how the shard is written</text>
+  <text x="520" y="402" fill="#555555">→ what it buys at lookup</text>
+  <line x1="280" y1="408" x2="908" y2="408" stroke="#B0B0B0" stroke-width="1"/>
+  <text x="280" y="426" fill="#111111">rows clustered by tier,</text>
+  <text x="280" y="440" fill="#111111">then sorted by position</text>
+  <text x="520" y="426" fill="#0072B2">page min / max ascend within a run, so a probe is found by</text>
+  <text x="520" y="440" fill="#0072B2">binary search; the directory keeps one run per tier</text>
+  <text x="280" y="462" fill="#111111">tier 0 = any position where</text>
+  <text x="280" y="476" fill="#111111">max(MAF, AF, gnomADg, gnomADe) ≥ 1%,</text>
+  <text x="520" y="462" fill="#0072B2">the measured block above: for the same probes, 4.2× fewer pages</text>
+  <text x="520" y="476" fill="#0072B2">and 4.5× fewer position rows decoded to locate the 6,178 matches</text>
+  <text x="280" y="498" fill="#111111">plus its ± 1 bp neighbours; 5.4% of rows</text>
+  <text x="520" y="498" fill="#0072B2">frequency is the only criterion, and it is decided per position:</text>
+  <text x="520" y="512" fill="#0072B2">every allele at a common position joins tier 0, however rare</text>
+  <text x="280" y="534" fill="#111111">pages of 1,024 rows (the default),</text>
+  <text x="280" y="548" fill="#111111">~2.4 KiB compressed; page statistics on</text>
+  <text x="520" y="534" fill="#0072B2">footer column + offset indexes give each page's position</text>
+  <text x="520" y="548" fill="#0072B2">range and first row, so skipping is decided from metadata</text>
+  <text x="280" y="570" fill="#111111">no dictionary encoding; zstd(3)</text>
+  <text x="520" y="570" fill="#0072B2">a selected page decodes alone; with a dictionary, reading one row</text>
+  <text x="520" y="584" fill="#0072B2">first decodes its column chunk's dictionary, built over 10⁶ rows</text>
+  <line x1="20" y1="598" x2="980" y2="598" stroke="#DDDDDD" stroke-width="1"/>
+  <text x="20" y="624" font-size="13" font-weight="bold" fill="#111111">C</text>
+  <text x="36" y="624" font-size="12" font-weight="bold" fill="#111111">Two reads of the shard: locate, then take</text>
+  <rect x="20" y="634" width="450" height="194" fill="#FFFFFF" stroke="#0072B2" stroke-width="1.4"/>
+  <text x="30" y="653" font-weight="bold" fill="#111111">Locate · one column, many rows</text>
+  <text x="30" y="668" fill="#0072B2">this is the scan counted in panel B</text>
+  <text x="30" y="683" fill="#555555">the position column alone, every row in the candidate page ranges</text>
+  <text x="30" y="697" fill="#555555">nearby page byte ranges are coalesced into single reads</text>
+  <text x="30" y="715" fill="#555555">file row</text>
+  <text x="110" y="715" fill="#555555">position</text>
+  <line x1="30" y1="721" x2="250" y2="721" stroke="#B0B0B0" stroke-width="1"/>
+  <text x="30" y="735" fill="#111111">612 352</text>
+  <text x="110" y="735" fill="#111111">16,050,001</text>
+  <text x="30" y="749" fill="#111111">612 353</text>
+  <text x="110" y="749" fill="#111111">16,050,075</text>
+  <circle cx="200" cy="745" r="3.5" fill="#0072B2"/>
+  <text x="30" y="763" fill="#111111">612 354</text>
+  <text x="110" y="763" fill="#111111">16,050,075</text>
+  <circle cx="200" cy="759" r="3.5" fill="#0072B2"/>
+  <text x="30" y="777" fill="#111111">612 355</text>
+  <text x="110" y="777" fill="#111111">16,050,082</text>
+  <text x="30" y="791" fill="#111111">612 356</text>
+  <text x="110" y="791" fill="#111111">16,050,213</text>
+  <circle cx="200" cy="787" r="3.5" fill="#0072B2"/>
+  <text x="30" y="805" fill="#111111">612 357</text>
+  <text x="110" y="805" fill="#111111">16,050,213</text>
+  <circle cx="200" cy="801" r="3.5" fill="#0072B2"/>
+  <text x="30" y="818" fill="#111111">⋮</text>
+  <path d="M270 727 V812" stroke="#0072B2" stroke-width="1.6" fill="none" marker-end="url(#arr-b)"/>
+  <text x="282" y="743" font-weight="bold" fill="#0072B2">monotonic cursor</text>
+  <text x="282" y="759" fill="#111111">advances one file row per</text>
+  <text x="282" y="773" fill="#111111">streamed value, never backwards</text>
+  <text x="282" y="795" fill="#111111">● position is in the probe set</text>
+  <text x="282" y="809" fill="#111111">→ its file row is recorded</text>
+  <path d="M470 721 H508" stroke="#111111" stroke-width="1.2" fill="none" marker-end="url(#arr)"/>
+  <rect x="510" y="684" width="90" height="112" fill="#D6E6F5" stroke="#0072B2" stroke-width="1.4"/>
+  <text x="520" y="703" font-weight="bold" fill="#111111">row offsets</text>
+  <text x="520" y="724" fill="#111111">612 353</text>
+  <text x="520" y="739" fill="#111111">612 354</text>
+  <text x="520" y="754" fill="#111111">612 356</text>
+  <text x="520" y="769" fill="#111111">612 357</text>
+  <text x="520" y="787" fill="#555555">⋮ ascending</text>
+  <path d="M600 721 H638" stroke="#111111" stroke-width="1.2" fill="none" marker-end="url(#arr)"/>
+  <rect x="640" y="634" width="310" height="194" fill="#FFFFFF" stroke="#0072B2" stroke-width="1.4"/>
+  <text x="650" y="653" font-weight="bold" fill="#111111">Take · many columns, few rows</text>
+  <text x="650" y="668" fill="#555555">the subset of columns the run needs, only the matched rows</text>
+  <text x="650" y="692" fill="#555555">position</text>
+  <text x="740" y="692" fill="#555555">alleles</text>
+  <text x="800" y="692" fill="#555555">identifier</text>
+  <text x="890" y="692" fill="#555555">…</text>
+  <line x1="650" y1="698" x2="940" y2="698" stroke="#B0B0B0" stroke-width="1"/>
+  <text x="650" y="716" fill="#111111">16,050,075</text>
+  <text x="740" y="716" fill="#111111">A/G</text>
+  <text x="800" y="716" fill="#111111">rs587697622</text>
+  <text x="650" y="732" fill="#111111">16,050,075</text>
+  <text x="740" y="732" fill="#111111">A/T</text>
+  <text x="800" y="732" fill="#111111">rs…</text>
+  <text x="650" y="748" fill="#111111">16,050,213</text>
+  <text x="740" y="748" fill="#111111">C/A</text>
+  <text x="800" y="748" fill="#111111">rs…</text>
+  <text x="650" y="764" fill="#111111">16,050,213</text>
+  <text x="740" y="764" fill="#111111">C/T</text>
+  <text x="800" y="764" fill="#111111">rs…</text>
+  <text x="650" y="782" fill="#111111">⋮</text>
+  <text x="650" y="804" font-weight="bold" fill="#0072B2">the only rows that leave the shard</text>
+  <line x1="20" y1="848" x2="980" y2="848" stroke="#DDDDDD" stroke-width="1"/>
+  <text x="20" y="864" font-size="13" font-weight="bold" fill="#111111">D</text>
+  <text x="36" y="864" font-size="12" font-weight="bold" fill="#111111">Join back to the buffer</text>
+  <rect x="20" y="874" width="210" height="104" fill="#FFFFFF" stroke="#111111" stroke-width="1.2"/>
+  <text x="30" y="893" font-weight="bold" fill="#111111">input buffer</text>
+  <text x="30" y="913" fill="#111111">16,050,075</text>
+  <text x="140" y="913" fill="#111111">A &gt; G</text>
+  <text x="30" y="929" fill="#111111">16,050,115</text>
+  <text x="140" y="929" fill="#111111">G &gt; A</text>
+  <text x="30" y="945" fill="#111111">16,050,213</text>
+  <text x="140" y="945" fill="#111111">C &gt; T</text>
+  <text x="30" y="961" fill="#111111">16,050,300</text>
+  <text x="140" y="961" fill="#111111">CT &gt; C</text>
+  <path d="M230 926 H268" stroke="#111111" stroke-width="1.2" fill="none" marker-end="url(#arr)"/>
+  <rect x="270" y="874" width="300" height="104" fill="#FFFFFF" stroke="#111111" stroke-width="1.2"/>
+  <text x="280" y="893" font-weight="bold" fill="#111111">allele matching per record</text>
+  <text x="280" y="913" fill="#111111">rows at its probe positions are accepted when</text>
+  <text x="280" y="929" fill="#111111">• the record is not flagged as failed</text>
+  <text x="280" y="945" fill="#111111">• the record interval overlaps the variant</text>
+  <text x="280" y="961" fill="#111111">• the alleles match exactly (first match wins)</text>
+  <path d="M570 926 H608" stroke="#111111" stroke-width="1.2" fill="none" marker-end="url(#arr)"/>
+  <rect x="610" y="874" width="340" height="104" fill="#D6E6F5" stroke="#0072B2" stroke-width="1.4"/>
+  <text x="620" y="893" font-weight="bold" fill="#111111">buffer + cache columns · one row in, one row out</text>
+  <text x="620" y="913" fill="#111111">A &gt; G</text>
+  <text x="700" y="913" fill="#111111">rs587697622 and its cache columns</text>
+  <text x="620" y="929" fill="#111111">G &gt; A</text>
+  <text x="700" y="929" fill="#111111">no record at this position → null</text>
+  <text x="620" y="945" fill="#111111">C &gt; T</text>
+  <text x="700" y="945" fill="#111111">C/A rejected, C/T matched</text>
+  <text x="620" y="961" fill="#111111">CT &gt; C</text>
+  <text x="700" y="961" fill="#111111">matched at its shifted probe position</text>
+  <path d="M420 978 V1000" stroke="#E69F00" stroke-width="1.6" fill="none" marker-end="url(#arr-o)"/>
+  <rect x="270" y="1002" width="680" height="44" fill="#FBEEDC" stroke="#E69F00" stroke-width="1.4"/>
+  <text x="280" y="1021"><tspan font-weight="bold">co-located variants</tspan> at the same positions are collected separately for the transcript annotation stage:</text>
+  <text x="280" y="1037" fill="#111111">existing identifiers, allele frequencies, clinical significance</text>
+  </g>
+</svg>


### PR DESCRIPTION
## What

A manuscript figure for the variation-lookup path, and the two scripts that produce it. The scripts are the point: every quantity on the figure can be re-derived rather than taken on trust.

`docs/diagrams/` already pairs a source with its rendered SVG, so these sit alongside the existing mermaid diagrams.

| File | Role |
|---|---|
| `variation-lookup.py` | draws the figure; all quantities in one `MEASURED` dict at the top |
| `variation-lookup-measure.py` | produces those quantities from a real cache and a real VCF |
| `variation-lookup.svg` | the rendered figure |

## The figure

Four panels: an input buffer reduced to probe positions; why the shard is clustered by tier; the two reads that resolve the probes; and the join back to the buffer.

The cell strips in panel B are schematic and are labelled as such on the figure. Everything else, including the tier threshold, the page geometry and the whole measured block, is real.

## What the measurement does

It replays one real 5,000-record chr22 buffer against a real shard twice, once in the shipped `(tier, position)` order and once against a position-only counterfactual built from the same rows and the same page row-counts, so the two differ by clustering alone. It reports what the locate read costs: the pages it opens and the rows it decodes.

For the chr22 shard of the GRCh38 merged cache for Ensembl VEP 116, probed with the HG002 benchmark VCF, matching 6,178 cached rows:

| Row layout | Pages read of 15,381 | Position rows scanned | Matches per page |
|---|---|---|---|
| Sorted by position only | 920 | 928,028 | 6.7 |
| As shipped, tier 0 first | 220 | 207,732 | 28.1 |

The split behind that average: 96% of the matches are common variants served by 83 tier-0 pages at 71.6 rows each, while the rare 4% still scatter over 137 tier-1 pages at 1.7 rows each.

## Reproducing

```
python docs/diagrams/variation-lookup.py            # redraw from MEASURED
python docs/diagrams/variation-lookup-measure.py \
    --shard  $DATA_VEPYR_DIR/cache/116_GRCh38_merged/variation/chr22.parquet \
    --pages  chr22_pages.csv \
    --vcf    $DATA_VEPYR_DIR/HG002_GRCh38_1_22_v4.2.1_benchmark.vcf.gz
```

pyarrow cannot read the Parquet offset index, so the page boundaries come from a short Rust program built against the same `parquet` crate the engine uses. It is carried verbatim in the measure script's docstring rather than left as an undocumented step.

## Scope

Docs only. No library code, no tests, no pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0112cyTLXZanqcnAkVxQiZwy
