### PR TITLE
docs: add bioconda badges and conda install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 [![Platforms](https://img.shields.io/badge/platforms-linux%20%7C%20macOS%20%7C%20Windows-lightgrey)](https://pypi.org/project/vepyr/#files)
 ![GitHub License](https://img.shields.io/github/license/biodatageeks/vepyr)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/vepyr)
+[![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](https://anaconda.org/bioconda/vepyr)
+[![Bioconda](https://img.shields.io/conda/vn/bioconda/vepyr?label=bioconda)](https://anaconda.org/bioconda/vepyr)
+[![Bioconda - Downloads](https://img.shields.io/conda/dn/bioconda/vepyr?label=bioconda%20downloads)](https://anaconda.org/bioconda/vepyr)
+[![Bioconda - Platforms](https://img.shields.io/conda/pn/bioconda/vepyr?label=bioconda%20platforms)](https://anaconda.org/bioconda/vepyr)
 ![GitHub commit activity](https://img.shields.io/github/commit-activity/m/biodatageeks/vepyr)
 
 ![CI](https://github.com/biodatageeks/vepyr/actions/workflows/ci.yml/badge.svg?branch=master)
@@ -42,7 +46,14 @@ results as a `polars.LazyFrame` or a VCF with `CSQ` in the `INFO` column.
 pip install vepyr
 ```
 
-This installs both the Python package and a `vepyr` executable:
+or from [bioconda](https://anaconda.org/bioconda/vepyr)
+(linux-64, osx-64, osx-arm64):
+
+```bash
+conda install -c conda-forge -c bioconda vepyr
+```
+
+Either installs both the Python package and a `vepyr` executable:
 
 ```bash
 vepyr annotate \

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -5,8 +5,9 @@ covers the configuration validated against Ensembl VEP — `--everything` with a
 reference FASTA — plus the options a workflow engine needs. Everything else,
 including the Polars `LazyFrame` path, stays on the [Python API](api.md).
 
-`pip install vepyr` installs a `vepyr` executable alongside the library; no
-separate package is needed. `python -m vepyr` runs the same entry point when
+`pip install vepyr` (or `conda install -c conda-forge -c bioconda vepyr`)
+installs a `vepyr` executable alongside the library; no separate package is
+needed. `python -m vepyr` runs the same entry point when
 the scripts directory is not on `PATH`.
 
 ```bash

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -11,12 +11,20 @@ pip install vepyr
 This installs the Python package and a `vepyr` executable — see
 [Command line](cli.md).
 
-### From conda
+### From bioconda
 
-!!! note "In progress"
+[![install with bioconda](https://img.shields.io/badge/install%20with-bioconda-brightgreen.svg?style=flat)](https://anaconda.org/bioconda/vepyr)
+[![Bioconda](https://img.shields.io/conda/vn/bioconda/vepyr?label=bioconda)](https://anaconda.org/bioconda/vepyr)
+[![Bioconda - Platforms](https://img.shields.io/conda/pn/bioconda/vepyr?label=bioconda%20platforms)](https://anaconda.org/bioconda/vepyr)
 
-    A conda package is being prepared for [bioconda](https://bioconda.github.io/).
-    It is not published yet — use PyPI or a source build until it lands.
+```bash
+conda install -c conda-forge -c bioconda vepyr
+```
+
+The package is built for linux-64, osx-64 and osx-arm64 and ships the same
+`vepyr` executable. A new release reaches bioconda after its recipe update is
+merged, so it can trail PyPI by a few days — check the badge above for the
+current version.
 
 ### From source (for development)
 


### PR DESCRIPTION
vepyr is now on [bioconda](https://anaconda.org/bioconda/vepyr). This adds the bioconda badges and the conda install command, following the polars-bio README.

## Changes
- **README.md**: four badges (install with bioconda, version, downloads, platforms), plus `conda install -c conda-forge -c bioconda vepyr` in the Install section.
- **docs/quickstart.md**: the "From conda — not published yet" note is replaced by a "From bioconda" section with badges, the install command and supported platforms.
- **docs/cli.md**: the note about the `vepyr` executable now mentions the conda install.

## Notes
- Bioconda has only 0.6.0 so far; PyPI is at 0.7.0. The docs don't give a version number, and the version badge updates on its own.
- Builds exist for linux-64, osx-64 and osx-arm64 only (no linux-aarch64).
- `bioconda.github.io/recipes/vepyr/README.html` returns 404 even though the recipe is merged, so the badges link to `anaconda.org/bioconda/vepyr`. They can switch to the recipe page once it appears.
- All badge images and links were checked with curl. The MkDocs site was not built locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYgUmcbf5uU7p6cxg6jV3c