### PR TITLE
ci: build and test Linux aarch64 wheels on native arm runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,11 +103,37 @@ jobs:
           uv sync --python ${{ matrix.python-version }}
           uv run pytest -v
 
+  # Linux arm64 on a native GitHub arm runner, not cross-compiled, so the
+  # same host that builds the wheel also runs the suite. One interpreter for
+  # the same abi3 reasoning as the Windows job above.
+  linux-arm64-tests:
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12"]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: astral-sh/setup-uv@v5
+      - name: Install VCF command-line tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bcftools tabix
+      - name: Build and test
+        run: |
+          uv python install ${{ matrix.python-version }}
+          uv sync --python ${{ matrix.python-version }}
+          uv run pytest -v
+
   linux:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.target == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     strategy:
       matrix:
-        target: [x86_64]
+        target: [x86_64, aarch64]
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -110,12 +110,12 @@ jobs:
 
   linux:
     needs: prepare
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.target == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     permissions:
       contents: read
     strategy:
       matrix:
-        target: [x86_64]
+        target: [x86_64, aarch64]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/bioconda-recipe/meta.yaml
+++ b/bioconda-recipe/meta.yaml
@@ -72,8 +72,9 @@ about:
   dev_url: https://github.com/biodatageeks/vepyr
 
 extra:
-  # Matches the Unix platforms exercised by the upstream 0.6.0 wheel builds.
+  # Matches the Unix platforms exercised by the upstream wheel builds.
   additional-platforms:
+    - linux-aarch64
     - osx-arm64
   recipe-maintainers:
     - mwiewior

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -65,7 +65,7 @@ uv run mkdocs build
 uv run maturin build --release
 ```
 
-Wheels are produced for Linux (x86_64), macOS (x86_64, aarch64), and Windows (x64).
+Wheels are produced for Linux (x86_64, aarch64), macOS (x86_64, aarch64), and Windows (x64).
 
 ## Smoke test
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ vepyr is a Python library backed by a native Rust engine that provides:
 | Cache types | `ensembl`, `merged`, `refseq` |
 | Ensembl releases | 115+ |
 | Python | 3.10 — 3.14 |
-| Platforms | Linux (x86_64), macOS (x86_64, aarch64), Windows (x64) |
+| Platforms | Linux (x86_64, aarch64), macOS (x86_64, aarch64), Windows (x64) |
 
 ## Quick example
 

--- a/notebooks/annotate.ipynb
+++ b/notebooks/annotate.ipynb
@@ -384,6 +384,7 @@
    "cell_type": "code",
    "metadata": {},
    "source": [
+    "# polars-bio is not a vepyr dependency; install it for this cell: pip install polars-bio\n",
     "import polars_bio as pb\n",
     "import os\n",
     "\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ vepyr = "vepyr.cli:main"
 docs = ["vepyr[docs]"]
 dev = [
     "pytest>=8.0",
-    "polars-bio>=0.26.0",
     "pre-commit>=4.5.1",
     # parquet-rs writer used by the golden-cache fixtures (tests/cache_metadata.py,
     # tests/data/golden/prepare.py) so shards keep an arrow-rs-readable page index.

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -709,7 +709,7 @@ class TestAnnotate:
                 v == "missense_variant" for v in df["most_severe_consequence"].to_list()
             )
 
-    def test_sink_vcf(self, metadata_cache_dir):
+    def test_collect_to_tsv(self, metadata_cache_dir):
         """Collected annotations should write out as a tab-separated file."""
         import vepyr
 
@@ -720,7 +720,7 @@ class TestAnnotate:
             reference_fasta=REFERENCE_FASTA,
         )
 
-        with tempfile.NamedTemporaryFile(suffix=".vcf", delete=False) as f:
+        with tempfile.NamedTemporaryFile(suffix=".tsv", delete=False) as f:
             out_path = f.name
 
         try:

--- a/tests/test_annotate.py
+++ b/tests/test_annotate.py
@@ -710,7 +710,7 @@ class TestAnnotate:
             )
 
     def test_sink_vcf(self, metadata_cache_dir):
-        """Writing to VCF via polars-bio sink_vcf should work."""
+        """Collected annotations should write out as a tab-separated file."""
         import vepyr
 
         lf = vepyr.annotate(
@@ -719,11 +719,6 @@ class TestAnnotate:
             everything=True,
             reference_fasta=REFERENCE_FASTA,
         )
-
-        try:
-            import polars_bio  # noqa: F401
-        except ImportError:
-            pytest.skip("polars-bio not installed")
 
         with tempfile.NamedTemporaryFile(suffix=".vcf", delete=False) as f:
             out_path = f.name

--- a/uv.lock
+++ b/uv.lock
@@ -2300,36 +2300,6 @@ wheels = [
 ]
 
 [[package]]
-name = "polars-bio"
-version = "0.26.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "datafusion" },
-    { name = "polars" },
-    { name = "polars-config-meta" },
-    { name = "pyarrow" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/98/26/3cb8f9776d317626f65c34516c3dfe8b2743e67d4e5a627e5581eafd129c/polars_bio-0.26.0.tar.gz", hash = "sha256:50d3e5fcac48c300047bf75574dfff6490e9861325bdd0249b466668fde2ec72", size = 39943877, upload-time = "2026-03-07T19:04:25.07Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/54/9156ee8e191c9753637c1ea75c131f50414bb8bb9af89e7c2a73a646fbff/polars_bio-0.26.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:811a0e98224ccb1070f69455a99d53e84e3c645535ae8dd918f8ceca9411cfff", size = 66728892, upload-time = "2026-03-07T19:04:10.348Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/60/664d3fe30027e2b092c325489bcbe28525ab28237b3890c3d9d0c6bd0834/polars_bio-0.26.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:95aa932281d3de5be08962736d49ad6a3755f0e3a80ea5efaaf95a006bfc682d", size = 63492004, upload-time = "2026-03-07T19:04:05.297Z" },
-    { url = "https://files.pythonhosted.org/packages/db/00/dd17135efc55b21f4f28ac86d0ac2b40601adda474b9611063f3f1ba8529/polars_bio-0.26.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:92dd12a05a52775db355ddc058e36774cbd7cab227073f205e568dc1e783e698", size = 71883448, upload-time = "2026-03-07T19:04:15.308Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/91/7800317f7d124aec89ec85f930f02e7619d6a846450309260c54b8c5ebb4/polars_bio-0.26.0-cp39-abi3-win_amd64.whl", hash = "sha256:8ffb7bb624727482d873e94fa4c64283439a84c44c81d4bd2e18cfef5bba70d1", size = 63140964, upload-time = "2026-03-07T19:04:30.066Z" },
-    { url = "https://files.pythonhosted.org/packages/48/6e/9d767f3f8e52afb9fe6e68067261aef03dcefe319fb22607f56055ece35b/polars_bio-0.26.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2148d0057f7ebd84aba40af0bfcd1c07c75055df443c82f4045dd4b5ebb2b2e4", size = 71862099, upload-time = "2026-03-07T19:04:20.811Z" },
-]
-
-[[package]]
-name = "polars-config-meta"
-version = "0.3.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6b/c2/794a7e877e2e598c9a3cdc321d63e1d65d59595997880edf2577831ee6fc/polars_config_meta-0.3.2.tar.gz", hash = "sha256:b1fa809357776c751a57212f155bfbefd9bf02faead5ec59d0d5d4cd4fcf52e1", size = 16730, upload-time = "2026-01-05T12:50:04.783Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/e1/fed85aa50b0ad75d4b3cae94962148b4f03338b240a74afdc8400c73203f/polars_config_meta-0.3.2-py3-none-any.whl", hash = "sha256:efd6e7df6410b10695f1ee23d1ffc0d5292320aea6a273345f6849ae34d9d14e", size = 13057, upload-time = "2026-01-05T12:50:03.68Z" },
-]
-
-[[package]]
 name = "polars-runtime-32"
 version = "1.39.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3330,7 +3300,7 @@ wheels = [
 
 [[package]]
 name = "vepyr"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "polars" },
@@ -3358,7 +3328,6 @@ dev = [
     { name = "jupyterlab" },
     { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "matplotlib", version = "3.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "polars-bio" },
     { name = "pre-commit" },
     { name = "pytest" },
 ]
@@ -3387,7 +3356,6 @@ dev = [
     { name = "ipywidgets", specifier = ">=8.1.8" },
     { name = "jupyterlab", specifier = ">=4.6.3" },
     { name = "matplotlib", specifier = ">=3.8" },
-    { name = "polars-bio", specifier = ">=0.26.0" },
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "pytest", specifier = ">=8.0" },
 ]


### PR DESCRIPTION
## Summary

Adds Linux arm64 (aarch64) support.

- **Wheels:** `aarch64` added to the manylinux matrix in `ci.yml` and `publish_to_pypi.yml`. Built natively on `ubuntu-24.04-arm` runners, not cross-compiled. `publish` already collects every `wheels-*` artifact, so it is unchanged.
- **Tests:** new `linux-arm64-tests` job runs the pytest suite on `ubuntu-24.04-arm` with Python 3.12 (one interpreter, since the wheel is abi3, same reasoning as the Windows job).
- **bioconda:** `linux-aarch64` added to `additional-platforms`.
- **Docs:** platform lists in `docs/index.md` and `docs/developers.md`.

- **Dev dependencies:** `polars-bio` removed from the `dev` group. Nothing in the suite called it (`test_sink_vcf` only imported it to skip when it was missing), and it has no Linux aarch64 wheel, so `uv sync` on the arm64 job would have compiled it from source. The notebook cell that reads the golden VCF with it now notes the separate install.

No Rust changes. The one arch-specific dependency on the annotation path is `coitrees` 0.4, which selects its NEON interval tree at compile time on aarch64 (NEON is a default target feature there); the macOS arm64 wheel already ships that path, and `linux-arm64-tests` exercises it end to end. vepyr's own `cargo test` has no arch-specific code and does not reach it.

## Motivation

A Seqera Wave build of `pip install vepyr==0.7.0` for `linux/arm64` fails: PyPI has no aarch64 wheel, pip falls back to the sdist, and the image has no C toolchain (`error: linker cc not found`). Build: https://wave.seqera.io/view/builds/bd-f73652bf66f6062f_1

## Test plan

- [ ] `linux (aarch64)` wheel job builds a `manylinux_*_aarch64` abi3 wheel
- [ ] `linux-arm64-tests` passes (LFS fixtures, bcftools/tabix via apt, golden outputs)
- [ ] After release: rerun the Wave build for `linux/arm64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JD5mVRErcEzPWfHZtQxWhK

