### PR TITLE
chore(bioconda): 0.7.0 recipe with a single abi3 build

### DIFF
--- a/bioconda-recipe/meta.yaml
+++ b/bioconda-recipe/meta.yaml
@@ -14,8 +14,8 @@ build:
   # vepyr is built with pyo3's abi3-py310 feature: one build serves every
   # Python >= 3.10, instead of one ~15 min Rust compile per Python version
   # (four of them overran the one-hour linux-aarch64 CircleCI job).
-  python_version_independent: true  # [py == 310]
-  skip: true  # [py != 310]
+  python_version_independent: true
+  skip: true  # [not is_python_min]
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
 
@@ -33,12 +33,12 @@ requirements:
     - git
     - cross-python_{{ target_platform }}  # [build_platform != target_platform]
   host:
-    - python 3.10.*
-    - python-abi3  # [py == 310]
+    - python {{ python_min }}
+    - python-abi3
     - pip
     - maturin >=1.0,<2.0
   run:
-    - python >=3.10
+    - python >={{ python_min }}
     - pyarrow >=18.0
     - polars >=1.37.1
     - tqdm >=4.60

--- a/bioconda-recipe/meta.yaml
+++ b/bioconda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "vepyr" %}
-{% set version = "0.6.0" %}
+{% set version = "0.7.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,15 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 1afe1824512e211f084e298fc86fa964e9516bcc87086ea02dde4a045237d538
+  sha256: 8da7b34b27e9c81ff83018f18d14aa264c839e81099e38c70408203811217f54
 
 build:
   number: 0
-  skip: true  # [py < 310]
+  # vepyr is built with pyo3's abi3-py310 feature: one build serves every
+  # Python >= 3.10, instead of one ~15 min Rust compile per Python version
+  # (four of them overran the one-hour linux-aarch64 CircleCI job).
+  python_version_independent: true  # [py == 310]
+  skip: true  # [py != 310]
   run_exports:
     - {{ pin_subpackage(name, max_pin="x.x") }}
 
@@ -29,11 +33,12 @@ requirements:
     - git
     - cross-python_{{ target_platform }}  # [build_platform != target_platform]
   host:
-    - python
+    - python 3.10.*
+    - python-abi3  # [py == 310]
     - pip
     - maturin >=1.0,<2.0
   run:
-    - python
+    - python >=3.10
     - pyarrow >=18.0
     - polars >=1.37.1
     - tqdm >=4.60
@@ -72,7 +77,7 @@ about:
   dev_url: https://github.com/biodatageeks/vepyr
 
 extra:
-  # Matches the Unix platforms exercised by the upstream wheel builds.
+  # Matches the Unix platforms exercised by the upstream 0.7.0 wheel builds.
   additional-platforms:
     - linux-aarch64
     - osx-arm64


### PR DESCRIPTION
## Summary

Syncs `bioconda-recipe/` with [bioconda-recipes#69191](https://github.com/bioconda/bioconda-recipes/pull/69191), which ships vepyr 0.7.0 and adds `linux-aarch64`:

- **Version:** 0.7.0, with the PyPI sdist sha256 (the local copy was still at 0.6.0).
- **One abi3 build instead of one per Python version**, using the conda-forge abi3 pattern:
  ```yaml
  build:
    python_version_independent: true
    skip: true  # [not is_python_min]
  requirements:
    host:
      - python {{ python_min }}
      - python-abi3
    run:
      - python >={{ python_min }}
  ```

## Why

On #69191, `build and test (ARM)` hit CircleCI's one-hour limit (`arm-large`, 4 CPUs). Each Python variant is a full ~14.5 min Rust compile, about 17.5 min with tests. py310, py311 and py312 built and passed, then the job was killed as py313 started. vepyr is built with pyo3's `abi3-py310`, so one build serves every Python >= 3.10.

The first version of this change (`py == 310` selectors with a `python 3.10.*` host pin) built **nothing**. With the host pinned, conda-build stopped treating python as a used variant, so the recipe collapsed to one arbitrary python variant. bioconda-utils (`trim_skip`) dropped it whenever that variant wasn't 3.10, and CI logged `Nothing to be done for recipe recipes/vepyr` on linux-64 and linux-aarch64 while still going green. `is_python_min` is zipped with `python` in conda-forge's pinning, so selecting on it keeps the variants enumerated.

## Test plan

- [x] Rendered with bioconda-utils v4.4.1's exact variant config (conda-forge-pinning 2026.01.07 plus bioconda's `conda_build_config.yaml`) and `trim_skip`: exactly one build on linux-64 and linux-aarch64, python 3.10, `python_version_independent: true`, host `python 3.10` + `python-abi3`, run `python >=3.10`. The earlier `py == 310` recipe rendered zero builds under the same config.
- [x] The same recipe is pushed to bioconda-recipes#69191 (76c4249)
- [ ] bioconda-recipes#69191 CI actually builds and tests vepyr (log shows `BUILD START: ['vepyr-0.7.0-py310…']`, not `Nothing to be done`), including the ARM job

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKg8s8NKnvTk8nymNNg5y1
